### PR TITLE
Support Long type for yorkie SDK

### DIFF
--- a/src/document/json/primitive.ts
+++ b/src/document/json/primitive.ts
@@ -58,6 +58,8 @@ export class JSONPrimitive extends JSONElement {
         return bytes[0] | bytes[1] << 8 | bytes[2] << 16 | bytes[3] << 24;
       case PrimitiveType.String:
         return new TextDecoder("utf-8").decode(bytes);
+      case PrimitiveType.Long:
+        return Long.fromBytesLE(Array.from(bytes));
       default:
         throw new YorkieError(Code.Unimplemented, `unimplemented type: ${primitiveType}`);
     }
@@ -136,6 +138,11 @@ export class JSONPrimitive extends JSONElement {
       }
       case PrimitiveType.String: {
         return new TextEncoder().encode(this.value as string);
+      }
+      case PrimitiveType.Long: {
+        const longVal = this.value as Long;
+        const longToBytes = longVal.toBytesLE();
+        return Uint8Array.from(longToBytes);
       }
       default:
         throw new YorkieError(Code.Unimplemented, `unimplemented type: ${this.valueType}`);

--- a/test/yorkie_test.ts
+++ b/test/yorkie_test.ts
@@ -162,7 +162,7 @@ describe('Yorkie', function() {
       d1.update((root) => {
         root['k1'] = true;
         root['k2'] = 2147483647;
-        // root['k3'] = yorkie.Long.fromString('9223372036854775807');
+        root['k3'] = yorkie.Long.fromString('9223372036854775807');
         // root['k4'] = 1.79;
         root['k5'] = '4';
         // root['k6'] = new Uint8Array([65,66]);


### PR DESCRIPTION
#### What does this PR do?
Support Long type for yorkie-js-sdk

#### How should this be manually tested?

I tested by running `npm run test`. But I'm not sure this approach is right.🤔

#### Any background context you want to provide?
After referring these two references ([r1](https://github.com/yorkie-team/yorkie/blob/master/pkg/document/json/primitive.go#L42-L66), [r2](https://github.com/yorkie-team/yorkie/blob/master/pkg/document/json/primitive.go#L42-L66)) as @hackerwins mentioned to me, I tried to figure out how can I solve it. I found out [long](https://www.npmjs.com/package/long) is used in yorki-js-sdk, so I use the library's supported method and utility. I'm not sure I did it correctly, so please feel free to feedback about my code :)

#### What are the relevant tickets?

Address #1

### Checklist
- [x] Added relevant tests
- [ ] Didn't break anything 
