### PR TITLE
Support double type for yorkie-js-sdk

### DIFF
--- a/src/document/json/primitive.ts
+++ b/src/document/json/primitive.ts
@@ -56,6 +56,13 @@ export class JSONPrimitive extends JSONElement {
         return bytes[0] ? true : false;
       case PrimitiveType.Integer:
         return bytes[0] | bytes[1] << 8 | bytes[2] << 16 | bytes[3] << 24;
+      case PrimitiveType.Double: {
+        const view = new DataView(bytes.buffer);
+        bytes.forEach(function (b, i) {
+          view.setUint8(i, b);
+        });
+        return view.getFloat64(0, true);
+      }
       case PrimitiveType.String:
         return new TextDecoder("utf-8").decode(bytes);
       case PrimitiveType.Long:
@@ -139,6 +146,13 @@ export class JSONPrimitive extends JSONElement {
           (intVal >> 16) & 0xff,
           (intVal >> 24) & 0xff
         ]);
+      }
+      case PrimitiveType.Double: {
+        const doubleVal = this.value as number;
+        const uint8Array = new Uint8Array(8);
+        const view = new DataView(uint8Array.buffer);
+        view.setFloat64(0, doubleVal, true);
+        return uint8Array;
       }
       case PrimitiveType.String: {
         return new TextEncoder().encode(this.value as string);

--- a/test/yorkie_test.ts
+++ b/test/yorkie_test.ts
@@ -163,7 +163,7 @@ describe('Yorkie', function() {
         root['k1'] = true;
         root['k2'] = 2147483647;
         root['k3'] = yorkie.Long.fromString('9223372036854775807');
-        // root['k4'] = 1.79;
+        root['k4'] = 1.79;
         root['k5'] = '4';
         root['k6'] = new Uint8Array([65,66]);
         root['k7'] = new Date();


### PR DESCRIPTION
#### What does this PR do?

Support double type for yorkie-js-sdk

#### How should this be manually tested?

npm run test

#### Any background context you want to provide?

I refer to this [answer](https://stackoverflow.com/questions/40970739/how-to-convert-two-16bit-integer-high-word-low-word-into-32bit-float/40970862#40970862) to deal with double type.🤔

#### What are the relevant tickets?

Address #1

### Checklist
- [x] Added relevant tests
- [x] Didn't break anything
