### PR TITLE
Fix deepcopy of Primitive

### DIFF
--- a/src/document/json/primitive.ts
+++ b/src/document/json/primitive.ts
@@ -98,7 +98,9 @@ export class JSONPrimitive extends JSONElement {
   }
 
   public deepcopy(): JSONPrimitive {
-    return this;
+    const primitive = JSONPrimitive.of(this.value, this.getCreatedAt());
+    primitive.setUpdatedAt(this.getUpdatedAt());
+    return primitive;
   }
 
   public getType(): PrimitiveType {

--- a/test/document/document_test.ts
+++ b/test/document/document_test.ts
@@ -260,4 +260,22 @@ describe('Document', function () {
       assert.equal(idx + 1, root['list'].getElementByIndex(idx).getValue());
     }
   });
+
+  it('can rollback, primitive deepcopy', function () {
+    const doc = Document.create('test-col', 'test-doc');
+
+    doc.update(root => {
+      root['k1'] = {};
+      root['k1']['k1.1'] = 1
+      root['k1']['k1.2'] = 2
+    });
+    assert.equal('{"k1":{"k1.1":1,"k1.2":2}}', doc.toSortedJSON());
+    assert.throws(() => {
+      doc.update(root => {
+        delete root['k1']['k1.1'];
+        throw Error('dummy error');
+      }, 'dummy error');
+    })
+    assert.equal('{"k1":{"k1.1":1,"k1.2":2}}', doc.toSortedJSON());
+  });
 });


### PR DESCRIPTION
#### What does this PR do?
Properties change when deleting an instance of Primitive.
It seems that it cannot be considered as immutable.
So deepcopy should not return a instance with the same memory address.

#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?

https://github.com/yorkie-team/yorkie/issues/66

### Checklist
- [x] Added relevant tests
- [x] Didn't break anything
