### PR TITLE
Fix missing integer generation in primitive

### DIFF
--- a/src/document/json/primitive.ts
+++ b/src/document/json/primitive.ts
@@ -110,7 +110,7 @@ export class JSONPrimitive extends JSONElement {
       case 'boolean':
         return PrimitiveType.Boolean;
       case 'number':
-        return PrimitiveType.Double;
+        return this.isInteger(value) ? PrimitiveType.Integer : PrimitiveType.Double;
       case 'string':
         return PrimitiveType.String;
       case 'object':

--- a/test/json/primitive_test.ts
+++ b/test/json/primitive_test.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2020 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { assert } from 'chai';
+import { JSONPrimitive, PrimitiveType } from '../../src/document/json/primitive';
+import { InitialTimeTicket } from '../../src/document/time/ticket';
+import Long from 'long';
+
+describe('Primitive', function () {
+  it('Can create numeric type', function () {
+    const integer = JSONPrimitive.of(10, InitialTimeTicket);
+    const double = JSONPrimitive.of(3.14, InitialTimeTicket);
+    const long = JSONPrimitive.of(Long.fromString('100'), InitialTimeTicket);
+
+    assert.equal(integer.getType(), PrimitiveType.Integer);
+    assert.equal(double.getType(), PrimitiveType.Double);
+    assert.equal(long.getType(), PrimitiveType.Long);
+  });
+});


### PR DESCRIPTION
#### What does this PR do?
Real numbers and integers in javascript are of type 'number'.
So, when creating 'Primitive', branch processing is needed to
distinguish whether the 'number' type is a real number or an integer.


#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?

Fixes #

### Checklist
- [x] Added relevant tests
- [x] Didn't break anything
