### PR TITLE
Prevent bursting sync requests when the network is unavailable

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -32,8 +32,8 @@
       textLogHolder.innerText = doc.getRootObject().content.getAnnotatedString();
     }
 
-    function displayPeers(peers) {
-      peersHolder.innerText = JSON.stringify(peers);
+    function displayPeers(peers, clientID) {
+      peersHolder.innerHTML = JSON.stringify(peers).replace(clientID, `<b>${clientID}</b>`);
     }
 
     // https://github.com/codemirror/CodeMirror/pull/5619
@@ -110,7 +110,7 @@
 
         client.subscribe((event) => {
           if (event.name === 'documents-watching-peer-changed') {
-            displayPeers(event.value[doc.getKey().toIDString()]);
+            displayPeers(event.value[doc.getKey().toIDString()], client.getID());
           }
         });
 

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -315,7 +315,9 @@ export class Client implements Observable<ClientEvent> {
       }
 
       Promise.all(promises).then(() => {
-        setTimeout(doLoop, this.syncLoopDuration);
+        const syncLoopDuration = this.remoteChangeEventStream ?
+          this.syncLoopDuration : this.reconnectStreamDelay;
+        setTimeout(doLoop, syncLoopDuration);
       }).catch((err) => {
         logger.error(`[SL] c:"${this.getKey()}" sync failed: ${err.message}`);
       });


### PR DESCRIPTION
#### What does this PR do?

Prevent bursting sync requests when the network is unavailable

#### How should this be manually tested?

1. Quit the frontend server with a keyboard interrupt (Ctrl + C)
2. Modifying contents in the CodeMirror example

#### What are the relevant tickets?

Address #48

### Checklist
- [ ] Added relevant tests
- [x] Didn't break anything