### PR TITLE
Add test code for handling network error

### DIFF
--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -39,7 +39,7 @@ export enum DocEventType {
   RemoteChange = 'remote-change',
 }
 
-interface DocEvent {
+export interface DocEvent {
   name: DocEventType;
   value: any;
 }

--- a/test/yorkie_test.ts
+++ b/test/yorkie_test.ts
@@ -15,9 +15,10 @@
  */
 
 import { assert } from 'chai';
+import { EventEmitter } from 'events';
 import * as sinon from 'sinon';
-import { Client } from '../src/core/client';
-import { Document } from '../src/document/document';
+import { Client, ClientEvent, ClientEventType } from '../src/core/client';
+import { Document, DocEvent, DocEventType } from '../src/document/document';
 import yorkie from '../src/yorkie';
 
 const testRPCAddr = 'https://yorkie.dev/api';
@@ -429,5 +430,84 @@ describe('Yorkie', function () {
       await c1.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
     }, this.test.title);
+  });
+
+  it('Can recover from temporary disconnect (realtime sync)', async function() {
+    const c1 = yorkie.createClient(testRPCAddr);
+    const c2 = yorkie.createClient(testRPCAddr);
+    await c1.activate();
+    await c2.activate();
+
+    const docKey = `${this.test.title}-${new Date().getTime()}`;
+    const d1 = yorkie.createDocument(testCollection, docKey);
+    const d2 = yorkie.createDocument(testCollection, docKey);
+
+    await c1.attach(d1);
+    await c2.attach(d2);
+
+    const listener1 = new EventEmitter();
+    const listener2 = new EventEmitter();
+    const createSpy = (emitter: EventEmitter) => {
+      return (event: ClientEvent | DocEvent) => emitter.emit(event.name);
+    };
+    const spy1 = createSpy(listener1);
+    const spy2 = createSpy(listener2);
+    const waitFor = (eventName: string, listener: EventEmitter) => {
+      return new Promise(resolve => listener.on(eventName, resolve));
+    };
+
+    const unsub1 = {
+      client: c1.subscribe(spy1),
+      doc: d1.subscribe(spy1),
+    };
+    const unsub2 = {
+      client: c2.subscribe(spy2),
+      doc: d2.subscribe(spy2),
+    };
+
+    // Normal Condition
+    d2.update((root) => {
+      root['k1'] = 'undefined';
+    });
+
+    await waitFor(DocEventType.LocalChange, listener2);  // d2 should be able to update
+    await waitFor(DocEventType.RemoteChange, listener1); // d1 should be able to receive d2's update
+    assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+
+    // Simulate network error
+    const xhr = sinon.useFakeXMLHttpRequest();
+    xhr.onCreate = (req) => {
+      req.respond(400, {
+        'Content-Type': 'application/grpc-web-text+proto',
+      }, null);
+    };
+
+    d2.update((root) => {
+      root['k1'] = 'v1';
+    });
+
+    await waitFor(DocEventType.LocalChange, listener2);  // d2 should be able to update
+    await waitFor(ClientEventType.SyncFailed, listener2); // c2 should fail to sync
+    c1.sync();
+    await waitFor(ClientEventType.SyncFailed, listener1); // c1 should also fail to sync
+    assert.equal(d1.toSortedJSON(), '{"k1":"undefined"}');
+    assert.equal(d2.toSortedJSON(), '{"k1":"v1"}');
+
+    // Back to normal condition
+    xhr.restore();
+
+    await waitFor(DocEventType.RemoteChange, listener1); // d1 should be able to receive d2's update
+    assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+
+    unsub1.client();
+    unsub2.client();
+    unsub1.doc();
+    unsub2.doc();
+
+    await c1.detach(d1);
+    await c2.detach(d2);
+
+    await c1.deactivate();
+    await c2.deactivate();
   });
 });


### PR DESCRIPTION
#### What does this PR do?
Test code for #48 

#### How should this be manually tested?
`npm test`

#### Any background context you want to provide?
In both of these tests I check three things:
1. Check if remote changes can be synced automatically under normal conditions (this is already tested, but is included in order to be self-contained)
2. Simulate network error by making XHR intentionally fail. Then make sure that sync errors.
3. Let XHR be processed normally again and check that documents sync seamlessly.

There are two tests which test basically the same thing, but using different modes. One tests the above three points by manually syncing the clients, while the other uses realtime syncing and makes the test event driven.

### Checklist
- [x] Added relevant tests
- [x] Didn't break anything
