### PR TITLE
Add testRPCAddr parameter

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -18,7 +18,8 @@ module.exports = function(config) {
     client: {
       mocha: {
         timeout: 6000
-      }
+      },
+      testRPCAddr: config.testRPCAddr,
     },
 
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "webpack --config webpack.dev.config.js",
     "start": "webpack-dev-server --watch --config webpack.dev.config.js",
     "test": "karma start karma.conf.js --single-run",
+    "test:local": "karma start karma.conf.js --single-run --testRPCAddr=http://localhost:8080",
     "test:watch": "karma start karma.conf.js",
     "lint": "eslint . --fix --ext .ts"
   },

--- a/test/yorkie_test.ts
+++ b/test/yorkie_test.ts
@@ -20,8 +20,8 @@ import { Client } from '../src/core/client';
 import { Document } from '../src/document/document';
 import yorkie from '../src/yorkie';
 
-const testRPCAddr = 'https://yorkie.dev/api';
-// const testRPCAddr = 'http://localhost:8080';
+const __karma__ = (global as any).__karma__;
+const testRPCAddr = __karma__.config.testRPCAddr || 'https://yorkie.dev/api';
 const testCollection = 'test-col';
 
 async function withTwoClientsAndDocuments(


### PR DESCRIPTION
#### What does this PR do?

Support testRPCAddr parameter for test code

#### How should this be manually tested?

`npm run test`
`npm run test:local`
`npm run test -- --testRPCAddr=http://localhost:8080`

#### Any background context you want to provide?

ref: https://stackoverflow.com/questions/38876237/karma-start-passing-parameters

#### What are the relevant tickets?

Fixes #

### Checklist
- [ ] Added relevant tests
- [x] Didn't break anything
