### PR TITLE
Update for publish to npm

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,6 +95,9 @@ public/
 # DynamoDB Local files
 .dynamodb/
 
+# Publish
+build/
+
 ### Vim ###
 # Swap
 [._]*.s[a-v][a-z]

--- a/package.json
+++ b/package.json
@@ -2,15 +2,21 @@
   "name": "yorkie-js-sdk",
   "version": "0.0.10",
   "description": "Yorkie JS SDK",
-  "main": "./src/yorkie.ts",
+  "main": "build/yorkie.js",
+  "types": "build/yorkie.d.ts",
+  "files": [
+    "build"
+  ],
   "scripts": {
     "build:proto": "protoc --js_out=import_style=commonjs:. --grpc-web_out=import_style=commonjs+dts,mode=grpcwebtext:. ./src/api/yorkie.proto",
+    "build:publish": "tsc",
     "build": "webpack --config webpack.config.js",
     "start": "webpack-dev-server --watch --config webpack.dev.config.js",
     "test": "karma start karma.conf.js --single-run",
     "test:local": "karma start karma.conf.js --single-run --testRPCAddr=http://localhost:8080",
     "test:watch": "karma start karma.conf.js",
-    "lint": "eslint . --fix --ext .ts"
+    "lint": "eslint . --fix --ext .ts",
+    "prepare": "npm run build:publish"
   },
   "repository": {
     "type": "git",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,16 @@
   "compilerOptions": {
     "sourceMap": true,
     "target": "esnext",
+    "module": "commonjs",
+    "outDir": "build",
+    "declaration": true,
+    "esModuleInterop": true,
     "removeComments": false,
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "allowJs": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "src/**/*.d.ts"],
   "typeRoots": ["node_modules/@types"]
 }


### PR DESCRIPTION
#### What does this PR do?
Modify the compilation setting for distributing typescript as a library.
And this PR adds a script to be compiled before deployment.

#### How should this be manually tested?
You can try installing and using the library.
`npm install git+https://github.com/dc7303/yorkie-js-sdk.git\#feature\/publish-for-ts`

#### Any background context you want to provide?


#### What are the relevant tickets?

Fixes #95

### Checklist
- [ ] Added relevant tests
- [x] Didn't break anything
