### PR TITLE
Remove non-deterministic random from test code

### DIFF
--- a/test/util/llrb_tree_test.ts
+++ b/test/util/llrb_tree_test.ts
@@ -15,40 +15,53 @@
  */
 
 import { assert } from 'chai';
-import { range, shuffle } from '../helper/helper';
 import { LLRBTree } from '../../src/util/llrb_tree';
+
+const arrays = [
+  [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+  [8, 5, 7, 9, 1, 3, 6, 0, 4, 2],
+  [7, 2, 0, 3, 1, 9, 8, 4, 6, 5],
+  [2, 0, 3, 5, 8, 6, 4, 1, 9, 7],
+  [8, 4, 7, 9, 2, 6, 0, 3, 1, 5],
+  [7, 1, 5, 2, 8, 6, 3, 4, 0, 9],
+  [9, 8, 7, 6, 5, 4, 3, 2, 1, 0],
+];
 
 describe('LLRBTree', function () {
   it('Can put/remove while keeping order', function () {
-    const tree = new LLRBTree<number, number>();
-    for (const idx of shuffle(range(0, 10))) {
-      tree.put(idx, idx);
+    for (const array of arrays) {
+      const tree = new LLRBTree<number, number>();
+      for (const idx of array) {
+        tree.put(idx, idx);
+      }
+
+      assert.deepEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], tree.values());
+
+      tree.remove(8);
+      assert.deepEqual([0, 1, 2, 3, 4, 5, 6, 7, 9], tree.values());
+
+      tree.remove(2);
+      assert.deepEqual([0, 1, 3, 4, 5, 6, 7, 9], tree.values());
+
+      tree.remove(5);
+      assert.deepEqual([0, 1, 3, 4, 6, 7, 9], tree.values());
     }
-
-    assert.deepEqual([0, 1, 2, 3, 4, 5, 6, 7, 8, 9], tree.values());
-
-    tree.remove(8);
-    assert.deepEqual([0, 1, 2, 3, 4, 5, 6, 7, 9], tree.values());
-
-    tree.remove(2);
-    assert.deepEqual([0, 1, 3, 4, 5, 6, 7, 9], tree.values());
-
-    tree.remove(5);
-    assert.deepEqual([0, 1, 3, 4, 6, 7, 9], tree.values());
   });
 
   it('Can floor entry', function () {
-    const tree = new LLRBTree<number, number>();
-    for (const idx of shuffle(range(0, 10))) {
-      tree.put(idx, idx);
+    for (const array of arrays) {
+      const tree = new LLRBTree<number, number>();
+      for (const idx of array) {
+        tree.put(idx, idx);
+      }
+
+      assert.equal(8, tree.floorEntry(8).value);
+
+      tree.remove(8);
+      assert.equal(7, tree.floorEntry(8).value);
+
+      tree.remove(7);
+      assert.equal(6, tree.floorEntry(8).value);
     }
-
-    assert.equal(8, tree.floorEntry(8).value);
-
-    tree.remove(8);
-    assert.equal(7, tree.floorEntry(8).value);
-
-    tree.remove(7);
-    assert.equal(6, tree.floorEntry(8).value);
   });
 });


### PR DESCRIPTION
#### What does this PR do?

Remove non-deterministic random from test code

#### How should this be manually tested?


#### Any background context you want to provide?

Since the test contains non-deterministic random, the test coverage
changes each time the test is executed in CI. There are times when it
is marked with an X, in order to avoid this situation, non-deterministic
random should be removed.

<img width="674" alt="Screen Shot 2020-11-27 at 15 13 59" src="https://user-images.githubusercontent.com/2059311/100417009-34f29080-30c3-11eb-8492-5043268e17fb.png">

#### What are the relevant tickets?

#107

### Checklist
- [x] Added relevant tests
- [x] Didn't break anything
