### PR TITLE
Fix: Modify to build in Typescript strict mode

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,5 +9,7 @@ module.exports = {
   ],
   rules: {
     'prettier/prettier': 'error',
+    '@typescript-eslint/no-non-null-assertion': 'off',
+    '@typescript-eslint/no-explicit-any': 'off',
   },
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "yorkie-js-sdk",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -147,6 +147,11 @@
         "@types/minimatch": "*",
         "@types/node": "*"
       }
+    },
+    "@types/google-protobuf": {
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.7.4.tgz",
+      "integrity": "sha512-6PjMFKl13cgB4kRdYtvyjKl8VVa0PXS2IdVxHhQ8GEKbxBkyJtSbaIeK1eZGjDKN7dvUh4vkOvU9FMwYNv4GQQ=="
     },
     "@types/json-schema": {
       "version": "7.0.6",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "webpack-dev-server": "^3.11.0"
   },
   "dependencies": {
+    "@types/google-protobuf": "^3.7.4",
     "@types/long": "^4.0.1",
     "google-protobuf": "^3.14.0",
     "grpc-web": "^1.2.1",

--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -15,7 +15,7 @@
  */
 
 import Long from 'long';
-
+import * as jspb from 'google-protobuf';
 import { Code, YorkieError } from '../util/error';
 import { InitialTimeTicket, TimeTicket } from '../document/time/ticket';
 import { Operation } from '../document/operation/operation';
@@ -68,9 +68,11 @@ import {
 import { IncreaseOperation } from '../document/operation/increase_operation';
 import { CounterType, Counter } from '../document/json/counter';
 
-function fromMetadataMap(pbMetadataMap): { [key: string]: string } {
-  const metadata = {};
-  pbMetadataMap.forEach((value, key) => {
+function fromMetadataMap(
+  pbMetadataMap: jspb.Map<string, string>,
+): { [key: string]: string } {
+  const metadata: { [key: string]: string } = {};
+  pbMetadataMap.forEach((value: string, key: string) => {
     metadata[key] = value;
   });
   return metadata;

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -20,6 +20,9 @@ import {
   Observable,
   createObservable,
   Unsubscribe,
+  ErrorFn,
+  CompleteFn,
+  NextFn,
 } from '../util/observable';
 import { ActorID } from './time/actor_id';
 import { DocumentKey } from './key/document_key';
@@ -120,8 +123,16 @@ export class Document implements Observable<DocEvent> {
     }
   }
 
-  public subscribe(nextOrObserver, error?, complete?): Unsubscribe {
-    return this.eventStream.subscribe(nextOrObserver, error, complete);
+  public subscribe(
+    nextOrObserver: Observer<DocEvent> | NextFn<DocEvent>,
+    error?: ErrorFn,
+    complete?: CompleteFn,
+  ): Unsubscribe {
+    return this.eventStream.subscribe(
+      nextOrObserver as NextFn<DocEvent>,
+      error,
+      complete,
+    );
   }
 
   /**

--- a/src/document/json/rich_text.ts
+++ b/src/document/json/rich_text.ts
@@ -48,7 +48,7 @@ export class RichTextValue {
     return this.content.length;
   }
 
-  public substring(indexStart, indexEnd: number): RichTextValue {
+  public substring(indexStart: number, indexEnd: number): RichTextValue {
     return new RichTextValue(this.content.substring(indexStart, indexEnd));
   }
 

--- a/src/document/operation/edit_operation.ts
+++ b/src/document/operation/edit_operation.ts
@@ -24,7 +24,7 @@ import { Operation } from './operation';
 export class EditOperation extends Operation {
   private fromPos: RGATreeSplitNodePos;
   private toPos: RGATreeSplitNodePos;
-  private maxCreatedAtMapByActor;
+  private maxCreatedAtMapByActor: Map<string, TimeTicket>;
   private content: string;
 
   constructor(

--- a/src/util/comparator.ts
+++ b/src/util/comparator.ts
@@ -16,7 +16,7 @@
 
 export type Comparator<K> = (keyA: K, keyB: K) => number;
 
-export const DefaultComparator = (a, b): number => {
+export const DefaultComparator = (a: unknown, b: unknown): number => {
   if (a === b) {
     return 0;
   } else if (a < b) {

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -268,7 +268,7 @@ export class SplayTree<V> {
   }
 
   public getAnnotatedString(): string {
-    const metaString = [];
+    const metaString: Array<SplayNode<V>> = [];
     this.traverseInorder(this.root, metaString);
     return metaString
       .map(

--- a/test/api/converter_test.ts
+++ b/test/api/converter_test.ts
@@ -17,12 +17,13 @@
 import { assert } from 'chai';
 import { Document } from '../../src/document/document';
 import { converter } from '../../src/api/converter';
+import { Indexable } from '../helper/helper';
 
 describe('Converter', function () {
   it('should encode/decode bytes', function () {
     const doc = Document.create('test-col', 'test-doc');
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['k1'] = {
         'k1.1': true,
         'k1.2': 2147483647,

--- a/test/document/document_test.ts
+++ b/test/document/document_test.ts
@@ -19,6 +19,7 @@ import { Document } from '../../src/document/document';
 import { InitialCheckpoint } from '../../src/document/checkpoint/checkpoint';
 import { MaxTimeTicket } from '../../src/document/time/ticket';
 import { JSONArray } from '../../src/document/json/array';
+import { Indexable } from '../helper/helper';
 
 describe('Document', function () {
   it('should apply updates of string', function () {
@@ -28,7 +29,7 @@ describe('Document', function () {
     assert.isTrue(doc1.getCheckpoint().equals(InitialCheckpoint));
     assert.isFalse(doc1.hasLocalChanges());
 
-    doc1.update((root) => {
+    doc1.update((root: Indexable) => {
       root['k1'] = 'v1';
       root['k2'] = 'v2';
       assert.equal('v1', root['k1']);
@@ -43,18 +44,18 @@ describe('Document', function () {
     const doc = Document.create('test-col', 'test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['k1'] = { 'k1-1': 'v1' };
       root['k1']['k1-2'] = 'v2';
     }, 'set {"k1-1":"v1","k1-2":"v2":}');
     assert.equal('{"k1":{"k1-1":"v1","k1-2":"v2"}}', doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['k1']['k1-2'] = 'v3';
     }, 'set {"k1-2":"v3"}');
     assert.equal('{"k1":{"k1-1":"v1","k1-2":"v3"}}', doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['k2'] = ['1', '2'];
       root['k2'].push('3');
     }, 'set ["1","2","3"]');
@@ -64,7 +65,7 @@ describe('Document', function () {
     );
 
     assert.throws(() => {
-      doc.update((root) => {
+      doc.update((root: Indexable) => {
         root['k2'].push('4');
         throw new Error('dummy error');
       }, 'push "4"');
@@ -74,7 +75,7 @@ describe('Document', function () {
       doc.toSortedJSON(),
     );
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['k2'].push('4');
     }, 'push "4"');
     assert.equal(
@@ -82,7 +83,7 @@ describe('Document', function () {
       doc.toSortedJSON(),
     );
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['k2'].push({ 'k2-5': 'v4' });
     }, 'push "{k2-5: 4}"');
     assert.equal(
@@ -95,7 +96,7 @@ describe('Document', function () {
     const doc = Document.create('test-col', 'test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['k1'] = { 'k1-1': 'v1', 'k1-2': 'v2' };
       root['k2'] = ['1', '2', '3'];
     }, 'set {"k1":{"k1-1":"v1","k1-2":"v2"},"k2":["1","2","3"]}');
@@ -104,7 +105,7 @@ describe('Document', function () {
       doc.toSortedJSON(),
     );
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       delete root['k1']['k1-1'];
       root['k1']['k1-3'] = 'v4';
 
@@ -124,13 +125,13 @@ describe('Document', function () {
     //           ------ ins links ----
     //           |            |      |
     // [init] - [A] - [12] - {BC} - [D]
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       const text = root.createText('k1');
       text.edit(0, 0, 'ABCD');
       text.edit(1, 3, '12');
     }, 'set {"k1":"A12D"}');
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       assert.equal(
         '[0:00:0:0 ][1:00:2:0 A][1:00:3:0 12]{1:00:2:1 BC}[1:00:2:3 D]',
         root['k1'].getAnnotatedString(),
@@ -162,13 +163,13 @@ describe('Document', function () {
     //           -- ins links ---
     //           |              |
     // [init] - [ABC] - [\n] - [D]
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       const text = root.createRichText('k1');
       text.edit(0, 0, 'ABCD');
       text.edit(3, 3, '\n');
     }, 'set {"k1":"ABC\nD"}');
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       assert.equal(
         '[0:00:0:0 ][1:00:2:0 ABC][1:00:3:0 \n][1:00:2:3 D][1:00:1:0 \n]',
         root['k1'].getAnnotatedString(),
@@ -185,7 +186,7 @@ describe('Document', function () {
     const doc = Document.create('test-col', 'test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       const text = root.createText('k1');
       text.edit(0, 0, 'ㅎ');
       text.edit(0, 1, '하');
@@ -202,8 +203,8 @@ describe('Document', function () {
     const doc = Document.create('test-col', 'test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
-    let toDelete;
-    doc.update((root) => {
+    let toDelete: any;
+    doc.update((root: Indexable) => {
       root['list'] = [];
       assert.equal(1, root['list'].push(4));
       assert.equal(2, root['list'].push(3));
@@ -214,12 +215,12 @@ describe('Document', function () {
 
     assert.equal('{"list":[4,3,2,1]}', doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['list'].deleteByID(toDelete.getID());
     }, 'delete 2');
     assert.equal('{"list":[4,3,1]}', doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       assert.equal(4, root['list'].push(2));
     }, 'push 2');
     assert.equal('{"list":[4,3,1,2]}', doc.toSortedJSON());
@@ -229,8 +230,8 @@ describe('Document', function () {
     const doc = Document.create('test-col', 'test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
-    let prev;
-    doc.update((root) => {
+    let prev: any;
+    doc.update((root: Indexable) => {
       root['list'] = [];
       root['list'].push(1);
       root['list'].push(2);
@@ -240,23 +241,23 @@ describe('Document', function () {
 
     assert.equal('{"list":[1,2,4]}', doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['list'].insertAfter(prev.getID(), 3);
     }, 'insert 3');
     assert.equal('{"list":[1,2,3,4]}', doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       delete root['list'][1];
     }, 'remove 2');
     assert.equal('{"list":[1,3,4]}', doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       prev = root['list'].getElementByIndex(0);
       root['list'].insertAfter(prev.getID(), 2);
     }, 'insert 2');
     assert.equal('{"list":[1,2,3,4]}', doc.toSortedJSON());
 
-    const root = doc.getRootObject();
+    const root: Indexable = doc.getRootObject();
     for (let idx = 0; idx < root['list'].length; idx++) {
       assert.equal(idx + 1, root['list'][idx]);
       assert.equal(idx + 1, root['list'].getElementByIndex(idx).getValue());
@@ -267,14 +268,14 @@ describe('Document', function () {
     const doc = Document.create('test-col', 'test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['1'] = 1;
       root['2'] = [1, 2, 3];
       root['3'] = 3;
     }, 'set 1, 2, 3');
     assert.equal('{"1":1,"2":[1,2,3],"3":3}', doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       delete root['2'];
     }, 'deletes 2');
     assert.equal('{"1":1,"3":3}', doc.toSortedJSON());
@@ -286,11 +287,11 @@ describe('Document', function () {
   it('garbage collection test2', function () {
     const size = 10000;
     const doc = Document.create('test-col', 'test-doc');
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['1'] = [...Array(size).keys()];
     }, 'sets big array');
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       delete root['1'];
     }, 'deletes the array');
 
@@ -301,12 +302,12 @@ describe('Document', function () {
     const doc = Document.create('test-col', 'test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['list'] = [1, 2, 3];
     }, 'set 1, 2, 3');
     assert.equal('{"list":[1,2,3]}', doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       delete root['list'][1];
     }, 'deletes 2');
     assert.equal('{"list":[1,3]}', doc.toSortedJSON());
@@ -329,18 +330,18 @@ describe('Document', function () {
     const doc = Document.create('test-col', 'test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['list'] = [0, 1, 2];
     }, 'set {"list":[0,1,2]}');
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       const next = root['list'].getElementByIndex(0);
       const item = root['list'].getElementByIndex(2);
       root['list'].moveBefore(next.getID(), item.getID());
       assert.equal('{"list":[2,0,1]}', root.toJSON());
     });
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       const next = root['list'].getElementByIndex(0);
       const item = root['list'].getElementByIndex(2);
       root['list'].moveBefore(next.getID(), item.getID());
@@ -351,14 +352,14 @@ describe('Document', function () {
   it('can rollback, primitive deepcopy', function () {
     const doc = Document.create('test-col', 'test-doc');
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['k1'] = {};
       root['k1']['k1.1'] = 1;
       root['k1']['k1.2'] = 2;
     });
     assert.equal('{"k1":{"k1.1":1,"k1.2":2}}', doc.toSortedJSON());
     assert.throws(() => {
-      doc.update((root) => {
+      doc.update((root: Indexable) => {
         delete root['k1']['k1.1'];
         throw Error('dummy error');
       }, 'dummy error');
@@ -369,7 +370,7 @@ describe('Document', function () {
   it('can be increased by Counter type', function () {
     const doc = Document.create('test-col', 'test-doc');
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['k1'] = {};
       root['k1'].createCounter('age', 1);
       root['k1'].createCounter('length', 10.5);
@@ -379,7 +380,7 @@ describe('Document', function () {
     });
     assert.equal(`{"k1":{"age":6,"length":14}}`, doc.toSortedJSON());
 
-    doc.update((root) => {
+    doc.update((root: Indexable) => {
       root['k1']['age'].increase(1.5).increase(1);
       root['k1']['length'].increase(3.5).increase(1);
     });
@@ -387,7 +388,7 @@ describe('Document', function () {
 
     // error test
     assert.Throw(() => {
-      doc.update((root) => {
+      doc.update((root: Indexable) => {
         root['k1']['age'].increase(true);
       });
     }, 'Unsupported type of value: boolean');

--- a/test/document/json/rht_test.ts
+++ b/test/document/json/rht_test.ts
@@ -17,6 +17,7 @@
 import { assert } from 'chai';
 import { RHT } from '../../../src/document/json/rht';
 import { InitialTimeTicket } from '../../../src/document/time/ticket';
+import { Indexable } from '../../helper/helper';
 
 describe('RHT', function () {
   it('should set and get a value', function () {
@@ -66,7 +67,7 @@ describe('RHT', function () {
   });
 
   it('should handle toJSON', function () {
-    const testData = {
+    const testData: Indexable = {
       testKey1: 'testValue1',
       testKey2: 'testValue2',
       testKey3: 'testValue3',
@@ -86,7 +87,7 @@ describe('RHT', function () {
   });
 
   it('should handle toObject', function () {
-    const testData = {
+    const testData: Indexable = {
       testKey1: 'testValue1',
       testKey2: 'testValue2',
       testKey3: 'testValue3',

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -21,3 +21,7 @@ export function range(from: number, to: number): Array<number> {
   }
   return list;
 }
+
+export type Indexable = {
+  [index: string]: any;
+};

--- a/test/yorkie_test.ts
+++ b/test/yorkie_test.ts
@@ -25,6 +25,7 @@ import {
 } from '../src/core/client';
 import { Document, DocEvent, DocEventType } from '../src/document/document';
 import yorkie from '../src/yorkie';
+import { Indexable } from './helper/helper';
 
 const __karma__ = (global as any).__karma__;
 const testRPCAddr = __karma__.config.testRPCAddr || 'http://localhost:8080';
@@ -106,7 +107,7 @@ describe('Yorkie', function () {
     await client2.activate();
 
     await client1.attach(doc1, true);
-    doc1.update((root) => {
+    doc1.update((root: Indexable) => {
       root['k1'] = { 'k1-1': 'v1' };
       root['k2'] = ['1', '2'];
     }, 'set v1, v2');
@@ -136,14 +137,14 @@ describe('Yorkie', function () {
 
       assert.equal(0, spy.callCount);
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['k1'] = 'v1';
       });
       await c1.sync();
       await c2.sync();
       assert.equal(1, spy.callCount);
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['k2'] = 'v2';
       });
       await c1.sync();
@@ -152,7 +153,7 @@ describe('Yorkie', function () {
 
       unsub();
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['k3'] = 'v3';
       });
       await c1.sync();
@@ -180,7 +181,7 @@ describe('Yorkie', function () {
     const unsub1 = d1.subscribe(spy1);
     const unsub2 = d2.subscribe(spy2);
 
-    d2.update((root) => {
+    d2.update((root: Indexable) => {
       root['k1'] = 'v1';
     });
 
@@ -199,7 +200,7 @@ describe('Yorkie', function () {
 
   it('Can handle primitive types', async function () {
     await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['k1'] = true;
         root['k2'] = 2147483647;
         root['k3'] = yorkie.Long.fromString('9223372036854775807');
@@ -217,10 +218,10 @@ describe('Yorkie', function () {
 
   it('Can handle concurrent set/delete operations', async function () {
     await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['k1'] = 'v1';
       });
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         root['k1'] = 'v2';
       });
       await c1.sync();
@@ -228,17 +229,17 @@ describe('Yorkie', function () {
       await c1.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['k2'] = {};
       });
       await c1.sync();
       await c2.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['k2'] = 'v2';
       });
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         root['k2']['k2.1'] = { 'k2.1.1': 'v3' };
       });
       await c1.sync();
@@ -246,10 +247,10 @@ describe('Yorkie', function () {
       await c1.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['k3'] = 'v4';
       });
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         root['k4'] = 'v5';
       });
       await c1.sync();
@@ -257,10 +258,10 @@ describe('Yorkie', function () {
       await c1.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         delete root['k3'];
       });
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         root['k3'] = 'v6';
       });
       await c1.sync();
@@ -272,17 +273,17 @@ describe('Yorkie', function () {
 
   it('Can handle concurrent add operations', async function () {
     await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['k1'] = ['1'];
       });
       await c1.sync();
       await c2.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['k1'].push('2');
       });
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         root['k1'].push('3');
       });
       await c1.sync();
@@ -294,8 +295,8 @@ describe('Yorkie', function () {
 
   it('Can handle concurrent insertAfter operations', async function () {
     await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
-      let prev;
-      d1.update((root) => {
+      let prev: any;
+      d1.update((root: Indexable) => {
         root['k1'] = [1, 2, 3, 4];
         prev = root['k1'].getElementByIndex(1);
       });
@@ -303,11 +304,11 @@ describe('Yorkie', function () {
       await c2.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['k1'].deleteByID(prev.getID());
         assert.equal('{"k1":[1,3,4]}', root.toJSON());
       });
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         root['k1'].insertAfter(prev.getID(), 2);
         assert.equal('{"k1":[1,2,2,3,4]}', root.toJSON());
       });
@@ -317,12 +318,12 @@ describe('Yorkie', function () {
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
       assert.equal('{"k1":[1,2,3,4]}', d1.toJSON());
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         const prev = root['k1'].getElementByIndex(1);
         root['k1'].insertAfter(prev.getID(), '2.1');
         assert.equal('{"k1":[1,2,"2.1",3,4]}', root.toJSON());
       });
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         const prev = root['k1'].getElementByIndex(1);
         root['k1'].insertAfter(prev.getID(), '2.2');
         assert.equal('{"k1":[1,2,"2.2",3,4]}', root.toJSON());
@@ -336,7 +337,7 @@ describe('Yorkie', function () {
 
   it('Can handle concurrent moveBefore operations', async function () {
     await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['k1'] = [0, 1, 2];
         assert.equal('{"k1":[0,1,2]}', root.toJSON());
       });
@@ -344,28 +345,28 @@ describe('Yorkie', function () {
       await c2.sync();
       assert.equal(d1.toJSON(), d2.toJSON());
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         const next = root['k1'].getElementByIndex(0);
         const item = root['k1'].getElementByIndex(2);
         root['k1'].moveBefore(next.getID(), item.getID());
         assert.equal('{"k1":[2,0,1]}', root.toJSON());
       });
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         const next = root['k1'].getElementByIndex(0);
         const item = root['k1'].getElementByIndex(2);
         root['k1'].moveBefore(next.getID(), item.getID());
         assert.equal('{"k1":[1,2,0]}', root.toJSON());
       });
 
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         const next = root['k1'].getElementByIndex(1);
         const item = root['k1'].getElementByIndex(2);
         root['k1'].moveBefore(next.getID(), item.getID());
         assert.equal('{"k1":[0,2,1]}', root.toJSON());
       });
 
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         const next = root['k1'].getElementByIndex(1);
         const item = root['k1'].getElementByIndex(2);
         root['k1'].moveBefore(next.getID(), item.getID());
@@ -380,7 +381,7 @@ describe('Yorkie', function () {
 
   it('should handle edit operations', async function () {
     await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root.createText('k1');
         root['k1'].edit(0, 0, 'ABCD');
       }, 'set new text by c1');
@@ -389,7 +390,7 @@ describe('Yorkie', function () {
       assert.equal(d1.toSortedJSON(), `{"k1":"ABCD"}`);
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root.createText('k1');
         root['k1'].edit(0, 0, '1234');
       }, 'edit 0,0 1234 by c1');
@@ -403,7 +404,7 @@ describe('Yorkie', function () {
 
   it('should handle concurrent edit operations', async function () {
     await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root.createText('k1');
       }, 'set new text by c1');
       await c1.sync();
@@ -411,11 +412,11 @@ describe('Yorkie', function () {
       assert.equal(d1.toSortedJSON(), `{"k1":""}`);
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['k1'].edit(0, 0, 'ABCD');
       }, 'edit 0,0 ABCD by c1');
       assert.equal(d1.toSortedJSON(), `{"k1":"ABCD"}`);
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         root['k1'].edit(0, 0, '1234');
       }, 'edit 0,0 1234 by c2');
       assert.equal(d2.toSortedJSON(), `{"k1":"1234"}`);
@@ -424,10 +425,10 @@ describe('Yorkie', function () {
       await c1.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['k1'].edit(2, 3, 'XX');
       }, 'edit 2,3 XX by c1');
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         root['k1'].edit(2, 3, 'YY');
       }, 'edit 2,3 YY by c1');
       await c1.sync();
@@ -435,10 +436,10 @@ describe('Yorkie', function () {
       await c1.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['k1'].edit(4, 5, 'ZZ');
       }, 'edit 4,5 ZZ by c1');
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         root['k1'].edit(2, 3, 'TT');
       }, 'edit 2,3 TT by c1');
 
@@ -453,18 +454,18 @@ describe('Yorkie', function () {
     await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
       // 01. Updates 700 changes over snapshot threshold.
       for (let idx = 0; idx < 700; idx++) {
-        d1.update((root) => {
+        d1.update((root: Indexable) => {
           root[`${idx}`] = idx;
         });
       }
       await c1.sync();
 
       // 02. Makes local changes then pull a snapshot from the agent.
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         root['key'] = 'value';
       });
       await c2.sync();
-      assert.equal(d2.getRootObject()['key'], 'value');
+      assert.equal(d2.getRootObject() as Indexable['key'], 'value');
 
       await c1.sync();
       await c2.sync();
@@ -487,7 +488,7 @@ describe('Yorkie', function () {
     await client1.attach(doc1);
     await client2.attach(doc2);
 
-    doc1.update((root) => {
+    doc1.update((root: Indexable) => {
       root['1'] = 1;
       root['2'] = [1, 2, 3];
       root['3'] = 3;
@@ -502,7 +503,7 @@ describe('Yorkie', function () {
     // (1, 0) -> (1, 1): syncedseqs:(0, 0)
     await client2.sync();
 
-    doc2.update((root) => {
+    doc2.update((root: Indexable) => {
       delete root['2'];
     }, 'removes 2');
     assert.equal(0, doc1.getGarbageLen());
@@ -554,7 +555,7 @@ describe('Yorkie', function () {
     await client1.attach(doc1);
     await client2.attach(doc2);
 
-    doc1.update((root) => {
+    doc1.update((root: Indexable) => {
       root['1'] = 1;
       root['2'] = [1, 2, 3];
       root['3'] = 3;
@@ -569,7 +570,7 @@ describe('Yorkie', function () {
     // (1, 0) -> (1, 1): syncedseqs:(0, 0)
     await client2.sync();
 
-    doc1.update((root) => {
+    doc1.update((root: Indexable) => {
       delete root['2'];
     }, 'removes 2');
     assert.equal(4, doc1.getGarbageLen());
@@ -600,10 +601,10 @@ describe('Yorkie', function () {
 
   it('Can handle increase operation', async function () {
     await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root.createCounter('age', 0);
       });
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['age'].increase(1).increase(2);
         root.createCounter('length', 10);
       });
@@ -616,7 +617,7 @@ describe('Yorkie', function () {
 
   it('Can handle concurrent increase operation', async function () {
     await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root.createCounter('age', 0);
         root.createCounter('width', 0);
         root.createCounter('height', 0);
@@ -625,11 +626,11 @@ describe('Yorkie', function () {
       await c2.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
-      d1.update((root) => {
+      d1.update((root: Indexable) => {
         root['age'].increase(1).increase(2);
         root['width'].increase(10);
       });
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         root['age'].increase(3.14).increase(2);
         root.createCounter('width', 2.5);
       });
@@ -644,7 +645,7 @@ describe('Yorkie', function () {
   it('Can recover from temporary disconnect (manual sync)', async function () {
     await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
       // Normal Condition
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         root['k1'] = 'undefined';
       });
 
@@ -664,7 +665,7 @@ describe('Yorkie', function () {
         );
       };
 
-      d2.update((root) => {
+      d2.update((root: Indexable) => {
         root['k1'] = 'v1';
       });
 
@@ -723,7 +724,7 @@ describe('Yorkie', function () {
     };
 
     // Normal Condition
-    d2.update((root) => {
+    d2.update((root: Indexable) => {
       root['k1'] = 'undefined';
     });
 
@@ -743,7 +744,7 @@ describe('Yorkie', function () {
       );
     };
 
-    d2.update((root) => {
+    d2.update((root: Indexable) => {
       root['k1'] = 'v1';
     });
 

--- a/test/yorkie_test.ts
+++ b/test/yorkie_test.ts
@@ -465,7 +465,7 @@ describe('Yorkie', function () {
         root['key'] = 'value';
       });
       await c2.sync();
-      assert.equal(d2.getRootObject() as Indexable['key'], 'value');
+      assert.equal((d2.getRootObject() as Indexable)['key'], 'value');
 
       await c1.sync();
       await c2.sync();

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,9 @@
     "removeComments": false,
     "allowSyntheticDefaultImports": true,
     "declaration": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "strict": true,
+    "strictNullChecks": false,
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"],


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

#### What does this PR do?
Modify to build in Typescript strict mode

1. change to Typescript strict mode
2. ignore null, undefine rule => [link](https://github.com/yorkie-team/yorkie-js-sdk/compare/master...mojosoeun:fix/strict-mode?expand=1#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0R10)
As we discussed the 'undefined' and null rules at the weekly meeting,  I temporarily changed the rule of `strictNullChecks`
3. declare types where there is no type
4. allow `any` type => [link](https://github.com/yorkie-team/yorkie-js-sdk/compare/master...mojosoeun:fix/strict-mode?expand=1#diff-e2954b558f2aa82baff0e30964490d12942e0e251c1aa56c3294de6ec67b7cf5R13)
5. allow non-null assertions using the `!` postfix operator => [link](https://github.com/yorkie-team/yorkie-js-sdk/compare/master...mojosoeun:fix/strict-mode?expand=1#diff-e2954b558f2aa82baff0e30964490d12942e0e251c1aa56c3294de6ec67b7cf5R12)

After I created this PR, I realized I had to split commits depending on the feature. I'll make sure to do it next time! 🙏
#### How should this be manually tested?


#### Any background context you want to provide?
When we update `Document` in the test file like below, we got tserror `error: Index signature of object type implicitly has an 'any' type.`
```javascript
doc.update((root <=== this part) => {
 root['k1'] = { 'k1-1': 'v1' };
 root['k1'] = { 'k1-1': 'v1' };
 root['k1']['k1-2'] = 'v2';
 root['k1']['k1-2'] = 'v2';
}, 'set {"k1-1":"v1","k1-2":"v2":}');
```
To solve this error, there are two options.
1. modify `noImplicitAny` to `false` in the tsconfig.json
2. use index signature

In my view, because this error occurs in the test code, I choose option 2 and declare the signature(`Indexable`) in the helper [file](https://github.com/yorkie-team/yorkie-js-sdk/compare/master...mojosoeun:fix/strict-mode?expand=1#diff-3b09053a321111ac0dff86f6582fb46ffbf089956224ed8665ed856a4ccd8ad2R24-R27). But If we have other good alternatives, feel free to comment on this PR!

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/yorkie-js-sdk/issues/94

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
