### PR TITLE
Fix a bug that attributes were lost when splitting RichText nodes

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -118,8 +118,10 @@ export class Client implements Observable<ClientEvent> {
     this.metadata = opts.metadata ? opts.metadata : {};
     this.status = ClientStatus.Deactivated;
     this.attachmentMap = new Map();
-    this.syncLoopDuration = opts.syncLoopDuration || DefaultClientOptions.syncLoopDuration;
-    this.reconnectStreamDelay = opts.reconnectStreamDelay || DefaultClientOptions.reconnectStreamDelay;
+    this.syncLoopDuration =
+      opts.syncLoopDuration || DefaultClientOptions.syncLoopDuration;
+    this.reconnectStreamDelay =
+      opts.reconnectStreamDelay || DefaultClientOptions.reconnectStreamDelay;
 
     this.rpcClient = new RPCClient(rpcAddr, null, null);
     this.eventStream = createObservable<ClientEvent>((observer) => {

--- a/src/document/json/object.ts
+++ b/src/document/json/object.ts
@@ -20,7 +20,7 @@ import { JSONContainer, JSONElement } from './element';
 import { RHTPQMap } from './rht_pq_map';
 import { PlainText } from './plain_text';
 import { RichText } from './rich_text';
-import { CounterType, Counter } from './counter';
+import { CounterType } from './counter';
 import { CounterProxy } from '../proxy/counter_proxy';
 
 /**
@@ -52,11 +52,13 @@ export class JSONObject extends JSONContainer {
   public purge(value: JSONElement): void {
     this.memberNodes.purge(value);
   }
+
   /**
    * Don't use createCounter directly. Be sure to use it through a proxy.
    * The reason for setting the CounterProxy type as the return value
    * is to provide the CounterProxy interface to the user.
    */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   public createCounter(key: string, value: CounterType): CounterProxy {
     logger.fatal(`unsupported: this method should be called by proxy: ${key}`);
     return null;

--- a/src/document/json/rht.ts
+++ b/src/document/json/rht.ts
@@ -84,7 +84,7 @@ export class RHT {
 
   public deepcopy(): RHT {
     const rht = new RHT();
-    for (const [key, node] of this.nodeMapByKey) {
+    for (const [, node] of this.nodeMapByKey) {
       rht.set(node.getKey(), node.getValue(), node.getUpdatedAt());
     }
     return rht;

--- a/src/document/json/rht.ts
+++ b/src/document/json/rht.ts
@@ -82,6 +82,14 @@ export class RHT {
     return this.nodeMapByKey.get(key).getValue();
   }
 
+  public deepcopy(): RHT {
+    const rht = new RHT();
+    for (const [key, node] of this.nodeMapByKey) {
+      rht.set(node.getKey(), node.getValue(), node.getUpdatedAt());
+    }
+    return rht;
+  }
+
   public toJSON(): string {
     const items = [];
     for (const [key, node] of this.nodeMapByKey) {

--- a/src/document/json/rich_text.ts
+++ b/src/document/json/rich_text.ts
@@ -49,7 +49,11 @@ export class RichTextValue {
   }
 
   public substring(indexStart: number, indexEnd: number): RichTextValue {
-    return new RichTextValue(this.content.substring(indexStart, indexEnd));
+    const value = new RichTextValue(
+      this.content.substring(indexStart, indexEnd),
+    );
+    value.attributes = this.attributes.deepcopy();
+    return value;
   }
 
   public setAttr(key: string, value: string, updatedAt: TimeTicket): void {

--- a/src/document/json/rich_text.ts
+++ b/src/document/json/rich_text.ts
@@ -107,6 +107,7 @@ export class RichText extends JSONElement {
     fromIdx: number,
     toIdx: number,
     content: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     attributes?: { [key: string]: string },
   ): RichText {
     logger.fatal(

--- a/src/document/json/root.ts
+++ b/src/document/json/root.ts
@@ -143,6 +143,7 @@ export class JSONRoot {
   private _garbageCollect(element: JSONElement): number {
     let count = 0;
 
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const callback = (elem: JSONElement, parent: JSONContainer): boolean => {
       this.deregisterElement(elem);
       count++;

--- a/test/document/json/rht_test.ts
+++ b/test/document/json/rht_test.ts
@@ -74,12 +74,11 @@ describe('RHT', function () {
     };
 
     const rht = RHT.create();
-    for (const dataKey of Object.keys(testData)) {
-      rht.set(dataKey, testData[dataKey], InitialTimeTicket);
+    for (const [key, value] of Object.entries(testData)) {
+      rht.set(key, value, InitialTimeTicket);
     }
 
     const jsonStr = rht.toJSON();
-
     const jsonObj = JSON.parse(jsonStr);
     assert.equal(jsonObj.testKey1, testData.testKey1);
     assert.equal(jsonObj.testKey2, testData.testKey2);
@@ -94,12 +93,11 @@ describe('RHT', function () {
     };
 
     const rht = RHT.create();
-    for (const dataKey of Object.keys(testData)) {
-      rht.set(dataKey, testData[dataKey], InitialTimeTicket);
+    for (const [key, value] of Object.entries(testData)) {
+      rht.set(key, value, InitialTimeTicket);
     }
 
     const jsonObj = rht.toObject();
-
     assert.equal(jsonObj.testKey1, testData.testKey1);
     assert.equal(jsonObj.testKey2, testData.testKey2);
     assert.equal(jsonObj.testKey3, testData.testKey3);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What does this PR do?

When splitting nodes in RichText, the logic to copy the original attributes to the new node is missing.
I also fixed some ESLint warnings that occurred.

- JS SDK: https://github.com/yorkie-team/yorkie-js-sdk/pull/136/files#diff-26660d373ad8f77f4021da7988d9aa7a1a276c75e44115439d2dd7bb91171c58R52
- Yorkie: https://github.com/yorkie-team/yorkie/blob/main/pkg/document/json/rich_text.go#L83

#### How should this be manually tested?


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #135

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
