### PR TITLE
Cleanup typescript undefined

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,6 +15,7 @@ module.exports = {
     'prettier/prettier': 'error',
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/ban-ts-comment': 'off',
     'tsdoc/syntax': 'error',
     'object-shorthand': ['error', 'always'],
     'no-unreachable': 'error',

--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -114,7 +114,7 @@ function toChangeID(changeID: ChangeID): PbChangeID {
   return pbChangeID;
 }
 
-function toTimeTicket(ticket: TimeTicket): PbTimeTicket | undefined {
+function toTimeTicket(ticket?: TimeTicket): PbTimeTicket | undefined {
   if (!ticket) {
     return;
   }
@@ -122,7 +122,7 @@ function toTimeTicket(ticket: TimeTicket): PbTimeTicket | undefined {
   const pbTimeTicket = new PbTimeTicket();
   pbTimeTicket.setLamport(ticket.getLamportAsString());
   pbTimeTicket.setDelimiter(ticket.getDelimiter());
-  pbTimeTicket.setActorId(toUint8Array(ticket.getActorID()));
+  pbTimeTicket.setActorId(toUint8Array(ticket.getActorID()!));
   return pbTimeTicket;
 }
 
@@ -489,7 +489,7 @@ function toChangePack(pack: ChangePack): PbChangePack {
   pbChangePack.setDocumentKey(toDocumentKey(pack.getKey()));
   pbChangePack.setCheckpoint(toCheckpoint(pack.getCheckpoint()));
   pbChangePack.setChangesList(toChanges(pack.getChanges()));
-  pbChangePack.setSnapshot(pack.getSnapshot());
+  pbChangePack.setSnapshot(pack.getSnapshot()!);
   pbChangePack.setMinSyncedTicket(toTimeTicket(pack.getMinSyncedTicket()));
   return pbChangePack;
 }
@@ -515,7 +515,7 @@ function fromChangeID(pbChangeID: PbChangeID): ChangeID {
   );
 }
 
-function fromTimeTicket(pbTimeTicket: PbTimeTicket): TimeTicket | undefined {
+function fromTimeTicket(pbTimeTicket?: PbTimeTicket): TimeTicket | undefined {
   if (!pbTimeTicket) {
     return;
   }
@@ -570,18 +570,18 @@ function fromJSONElementSimple(
 ): JSONElement {
   switch (pbJSONElement.getType()) {
     case PbValueType.JSON_OBJECT:
-      return JSONObject.create(fromTimeTicket(pbJSONElement.getCreatedAt()!)!);
+      return JSONObject.create(fromTimeTicket(pbJSONElement.getCreatedAt())!);
     case PbValueType.JSON_ARRAY:
-      return JSONArray.create(fromTimeTicket(pbJSONElement.getCreatedAt()!)!);
+      return JSONArray.create(fromTimeTicket(pbJSONElement.getCreatedAt())!);
     case PbValueType.TEXT:
       return PlainText.create(
         RGATreeSplit.create(),
-        fromTimeTicket(pbJSONElement.getCreatedAt()!)!,
+        fromTimeTicket(pbJSONElement.getCreatedAt())!,
       );
     case PbValueType.RICH_TEXT:
       return RichText.create(
         RGATreeSplit.create(),
-        fromTimeTicket(pbJSONElement.getCreatedAt()!)!,
+        fromTimeTicket(pbJSONElement.getCreatedAt())!,
       );
     case PbValueType.BOOLEAN:
     case PbValueType.INTEGER:
@@ -595,7 +595,7 @@ function fromJSONElementSimple(
           fromValueType(pbJSONElement.getType()),
           pbJSONElement.getValue_asU8(),
         ),
-        fromTimeTicket(pbJSONElement.getCreatedAt()!)!,
+        fromTimeTicket(pbJSONElement.getCreatedAt())!,
       );
     case PbValueType.INTEGER_CNT:
     case PbValueType.DOUBLE_CNT:
@@ -605,7 +605,7 @@ function fromJSONElementSimple(
           fromCounterType(pbJSONElement.getType()),
           pbJSONElement.getValue_asU8(),
         ),
-        fromTimeTicket(pbJSONElement.getCreatedAt()!)!,
+        fromTimeTicket(pbJSONElement.getCreatedAt())!,
       );
   }
 
@@ -618,7 +618,7 @@ function fromJSONElementSimple(
 function fromTextNodePos(pbTextNodePos: PbTextNodePos): RGATreeSplitNodePos {
   return RGATreeSplitNodePos.of(
     RGATreeSplitNodeID.of(
-      fromTimeTicket(pbTextNodePos.getCreatedAt()!)!,
+      fromTimeTicket(pbTextNodePos.getCreatedAt())!,
       pbTextNodePos.getOffset(),
     ),
     pbTextNodePos.getRelativeOffset(),
@@ -627,7 +627,7 @@ function fromTextNodePos(pbTextNodePos: PbTextNodePos): RGATreeSplitNodePos {
 
 function fromTextNodeID(pbTextNodeID: PbTextNodeID): RGATreeSplitNodeID {
   return RGATreeSplitNodeID.of(
-    fromTimeTicket(pbTextNodeID.getCreatedAt()!)!,
+    fromTimeTicket(pbTextNodeID.getCreatedAt())!,
     pbTextNodeID.getOffset(),
   );
 }
@@ -637,7 +637,7 @@ function fromTextNode(pbTextNode: PbTextNode): RGATreeSplitNode<string> {
     fromTextNodeID(pbTextNode.getId()!),
     pbTextNode.getValue(),
   );
-  textNode.remove(fromTimeTicket(pbTextNode.getRemovedAt()!)!);
+  textNode.remove(fromTimeTicket(pbTextNode.getRemovedAt()));
   return textNode;
 }
 
@@ -648,7 +648,7 @@ function fromRichTextNode(
     fromTextNodeID(pbTextNode.getId()!),
     RichTextValue.create(pbTextNode.getValue()),
   );
-  textNode.remove(fromTimeTicket(pbTextNode.getRemovedAt()!)!);
+  textNode.remove(fromTimeTicket(pbTextNode.getRemovedAt()));
   return textNode;
 }
 
@@ -662,31 +662,31 @@ function fromOperations(pbOperations: PbOperation[]): Operation[] {
       operation = SetOperation.create(
         pbSetOperation!.getKey(),
         fromJSONElementSimple(pbSetOperation!.getValue()!),
-        fromTimeTicket(pbSetOperation!.getParentCreatedAt()!)!,
-        fromTimeTicket(pbSetOperation!.getExecutedAt()!)!,
+        fromTimeTicket(pbSetOperation!.getParentCreatedAt())!,
+        fromTimeTicket(pbSetOperation!.getExecutedAt())!,
       );
     } else if (pbOperation.hasAdd()) {
       const pbAddOperation = pbOperation.getAdd();
       operation = AddOperation.create(
-        fromTimeTicket(pbAddOperation!.getParentCreatedAt()!)!,
-        fromTimeTicket(pbAddOperation!.getPrevCreatedAt()!)!,
+        fromTimeTicket(pbAddOperation!.getParentCreatedAt())!,
+        fromTimeTicket(pbAddOperation!.getPrevCreatedAt())!,
         fromJSONElementSimple(pbAddOperation!.getValue()!),
-        fromTimeTicket(pbAddOperation!.getExecutedAt()!)!,
+        fromTimeTicket(pbAddOperation!.getExecutedAt())!,
       );
     } else if (pbOperation.hasMove()) {
       const pbMoveOperation = pbOperation.getMove();
       operation = MoveOperation.create(
-        fromTimeTicket(pbMoveOperation!.getParentCreatedAt()!)!,
-        fromTimeTicket(pbMoveOperation!.getPrevCreatedAt()!)!,
-        fromTimeTicket(pbMoveOperation!.getCreatedAt()!)!,
-        fromTimeTicket(pbMoveOperation!.getExecutedAt()!)!,
+        fromTimeTicket(pbMoveOperation!.getParentCreatedAt())!,
+        fromTimeTicket(pbMoveOperation!.getPrevCreatedAt())!,
+        fromTimeTicket(pbMoveOperation!.getCreatedAt())!,
+        fromTimeTicket(pbMoveOperation!.getExecutedAt())!,
       );
     } else if (pbOperation.hasRemove()) {
       const pbRemoveOperation = pbOperation.getRemove();
       operation = RemoveOperation.create(
-        fromTimeTicket(pbRemoveOperation!.getParentCreatedAt()!)!,
-        fromTimeTicket(pbRemoveOperation!.getCreatedAt()!)!,
-        fromTimeTicket(pbRemoveOperation!.getExecutedAt()!)!,
+        fromTimeTicket(pbRemoveOperation!.getParentCreatedAt())!,
+        fromTimeTicket(pbRemoveOperation!.getCreatedAt())!,
+        fromTimeTicket(pbRemoveOperation!.getExecutedAt())!,
       );
     } else if (pbOperation.hasEdit()) {
       const pbEditOperation = pbOperation.getEdit();
@@ -695,20 +695,20 @@ function fromOperations(pbOperations: PbOperation[]): Operation[] {
         createdAtMapByActor.set(key, fromTimeTicket(value));
       });
       operation = EditOperation.create(
-        fromTimeTicket(pbEditOperation!.getParentCreatedAt()!)!,
+        fromTimeTicket(pbEditOperation!.getParentCreatedAt())!,
         fromTextNodePos(pbEditOperation!.getFrom()!),
         fromTextNodePos(pbEditOperation!.getTo()!),
         createdAtMapByActor,
         pbEditOperation!.getContent(),
-        fromTimeTicket(pbEditOperation!.getExecutedAt()!)!,
+        fromTimeTicket(pbEditOperation!.getExecutedAt())!,
       );
     } else if (pbOperation.hasSelect()) {
       const pbSelectOperation = pbOperation.getSelect();
       operation = SelectOperation.create(
-        fromTimeTicket(pbSelectOperation!.getParentCreatedAt()!)!,
+        fromTimeTicket(pbSelectOperation!.getParentCreatedAt())!,
         fromTextNodePos(pbSelectOperation!.getFrom()!),
         fromTextNodePos(pbSelectOperation!.getTo()!),
-        fromTimeTicket(pbSelectOperation!.getExecutedAt()!)!,
+        fromTimeTicket(pbSelectOperation!.getExecutedAt())!,
       );
     } else if (pbOperation.hasRichEdit()) {
       const pbEditOperation = pbOperation.getRichEdit();
@@ -721,13 +721,13 @@ function fromOperations(pbOperations: PbOperation[]): Operation[] {
         attributes.set(key, value);
       });
       operation = RichEditOperation.create(
-        fromTimeTicket(pbEditOperation!.getParentCreatedAt()!)!,
+        fromTimeTicket(pbEditOperation!.getParentCreatedAt())!,
         fromTextNodePos(pbEditOperation!.getFrom()!),
         fromTextNodePos(pbEditOperation!.getTo()!),
         createdAtMapByActor,
         pbEditOperation!.getContent(),
         attributes,
-        fromTimeTicket(pbEditOperation!.getExecutedAt()!)!,
+        fromTimeTicket(pbEditOperation!.getExecutedAt())!,
       );
     } else if (pbOperation.hasStyle()) {
       const pbStyleOperation = pbOperation.getStyle();
@@ -736,18 +736,18 @@ function fromOperations(pbOperations: PbOperation[]): Operation[] {
         attributes.set(key, value);
       });
       operation = StyleOperation.create(
-        fromTimeTicket(pbStyleOperation!.getParentCreatedAt()!)!,
+        fromTimeTicket(pbStyleOperation!.getParentCreatedAt())!,
         fromTextNodePos(pbStyleOperation!.getFrom()!),
         fromTextNodePos(pbStyleOperation!.getTo()!),
         attributes,
-        fromTimeTicket(pbStyleOperation!.getExecutedAt()!)!,
+        fromTimeTicket(pbStyleOperation!.getExecutedAt())!,
       );
     } else if (pbOperation.hasIncrease()) {
       const pbIncreaseOperation = pbOperation.getIncrease();
       operation = IncreaseOperation.create(
-        fromTimeTicket(pbIncreaseOperation!.getParentCreatedAt()!)!,
+        fromTimeTicket(pbIncreaseOperation!.getParentCreatedAt())!,
         fromJSONElementSimple(pbIncreaseOperation!.getValue()!),
-        fromTimeTicket(pbIncreaseOperation!.getExecutedAt()!)!,
+        fromTimeTicket(pbIncreaseOperation!.getExecutedAt())!,
       );
     } else {
       throw new YorkieError(Code.Unimplemented, `unimplemented operation`);
@@ -788,7 +788,7 @@ function fromChangePack(pbPack: PbChangePack): ChangePack {
     fromCheckpoint(pbPack.getCheckpoint()!),
     fromChanges(pbPack.getChangesList()),
     pbPack.getSnapshot_asU8(),
-    fromTimeTicket(pbPack.getMinSyncedTicket()!),
+    fromTimeTicket(pbPack.getMinSyncedTicket()),
   );
 }
 
@@ -799,8 +799,8 @@ function fromJSONObject(pbObject: PbJSONElement.JSONObject): JSONObject {
     rht.set(pbRHTNode.getKey(), fromJSONElement(pbRHTNode.getElement()!));
   }
 
-  const obj = new JSONObject(fromTimeTicket(pbObject.getCreatedAt()!)!, rht);
-  obj.remove(fromTimeTicket(pbObject.getRemovedAt()!)!);
+  const obj = new JSONObject(fromTimeTicket(pbObject.getCreatedAt())!, rht);
+  obj.remove(fromTimeTicket(pbObject.getRemovedAt()));
   return obj;
 }
 
@@ -812,10 +812,10 @@ function fromJSONArray(pbArray: PbJSONElement.JSONArray): JSONArray {
   }
 
   const arr = new JSONArray(
-    fromTimeTicket(pbArray.getCreatedAt()!)!,
+    fromTimeTicket(pbArray.getCreatedAt())!,
     rgaTreeList,
   );
-  arr.remove(fromTimeTicket(pbArray.getRemovedAt()!)!);
+  arr.remove(fromTimeTicket(pbArray.getRemovedAt()));
   return arr;
 }
 
@@ -827,9 +827,9 @@ function fromJSONPrimitive(
       fromValueType(pbPrimitive.getType()),
       pbPrimitive.getValue_asU8(),
     ),
-    fromTimeTicket(pbPrimitive.getCreatedAt()!)!,
+    fromTimeTicket(pbPrimitive.getCreatedAt())!,
   );
-  primitive.remove(fromTimeTicket(pbPrimitive.getRemovedAt()!)!);
+  primitive.remove(fromTimeTicket(pbPrimitive.getRemovedAt()));
   return primitive;
 }
 
@@ -849,9 +849,9 @@ function fromJSONText(pbText: PbJSONElement.Text): PlainText {
 
   const text = PlainText.create(
     rgaTreeSplit,
-    fromTimeTicket(pbText.getCreatedAt()!)!,
+    fromTimeTicket(pbText.getCreatedAt())!,
   );
-  text.remove(fromTimeTicket(pbText.getRemovedAt()!)!);
+  text.remove(fromTimeTicket(pbText.getRemovedAt()));
   return text;
 }
 
@@ -871,9 +871,9 @@ function fromJSONRichText(pbText: PbJSONElement.RichText): RichText {
 
   const text = RichText.create(
     rgaTreeSplit,
-    fromTimeTicket(pbText.getCreatedAt()!)!,
+    fromTimeTicket(pbText.getCreatedAt())!,
   );
-  text.remove(fromTimeTicket(pbText.getRemovedAt()!)!);
+  text.remove(fromTimeTicket(pbText.getRemovedAt()));
   return text;
 }
 
@@ -883,9 +883,9 @@ function fromCounter(pbCounter: PbJSONElement.Counter): Counter {
       fromCounterType(pbCounter.getType()),
       pbCounter.getValue_asU8(),
     ),
-    fromTimeTicket(pbCounter.getCreatedAt()!)!,
+    fromTimeTicket(pbCounter.getCreatedAt())!,
   );
-  counter.remove(fromTimeTicket(pbCounter.getRemovedAt()!)!);
+  counter.remove(fromTimeTicket(pbCounter.getRemovedAt()));
   return counter;
 }
 
@@ -910,7 +910,7 @@ function fromJSONElement(pbJSONElement: PbJSONElement): JSONElement {
   }
 }
 
-function bytesToObject(bytes: Uint8Array): JSONObject {
+function bytesToObject(bytes?: Uint8Array): JSONObject {
   if (!bytes) {
     return JSONObject.create(InitialTimeTicket);
   }

--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -114,9 +114,9 @@ function toChangeID(changeID: ChangeID): PbChangeID {
   return pbChangeID;
 }
 
-function toTimeTicket(ticket: TimeTicket): PbTimeTicket {
+function toTimeTicket(ticket: TimeTicket): PbTimeTicket | undefined {
   if (!ticket) {
-    return null;
+    return;
   }
 
   const pbTimeTicket = new PbTimeTicket();
@@ -271,7 +271,7 @@ function toOperation(operation: Operation): PbOperation {
     pbEditOperation.setTo(toTextNodePos(editOperation.getToPos()));
     const pbCreatedAtMapByActor = pbEditOperation.getCreatedAtMapByActorMap();
     for (const [key, value] of editOperation.getMaxCreatedAtMapByActor()) {
-      pbCreatedAtMapByActor.set(key, toTimeTicket(value));
+      pbCreatedAtMapByActor.set(key, toTimeTicket(value)!);
     }
     pbEditOperation.setContent(editOperation.getContent());
     pbEditOperation.setExecutedAt(toTimeTicket(editOperation.getExecutedAt()));
@@ -298,7 +298,7 @@ function toOperation(operation: Operation): PbOperation {
     pbRichEditOperation.setTo(toTextNodePos(richEditOperation.getToPos()));
     const pbCreatedAtMapByActor = pbRichEditOperation.getCreatedAtMapByActorMap();
     for (const [key, value] of richEditOperation.getMaxCreatedAtMapByActor()) {
-      pbCreatedAtMapByActor.set(key, toTimeTicket(value));
+      pbCreatedAtMapByActor.set(key, toTimeTicket(value)!);
     }
     pbRichEditOperation.setContent(richEditOperation.getContent());
     const pbAttributes = pbRichEditOperation.getAttributesMap();
@@ -515,9 +515,9 @@ function fromChangeID(pbChangeID: PbChangeID): ChangeID {
   );
 }
 
-function fromTimeTicket(pbTimeTicket: PbTimeTicket): TimeTicket {
+function fromTimeTicket(pbTimeTicket: PbTimeTicket): TimeTicket | undefined {
   if (!pbTimeTicket) {
-    return null;
+    return;
   }
 
   return TimeTicket.of(
@@ -570,18 +570,18 @@ function fromJSONElementSimple(
 ): JSONElement {
   switch (pbJSONElement.getType()) {
     case PbValueType.JSON_OBJECT:
-      return JSONObject.create(fromTimeTicket(pbJSONElement.getCreatedAt()));
+      return JSONObject.create(fromTimeTicket(pbJSONElement.getCreatedAt()!)!);
     case PbValueType.JSON_ARRAY:
-      return JSONArray.create(fromTimeTicket(pbJSONElement.getCreatedAt()));
+      return JSONArray.create(fromTimeTicket(pbJSONElement.getCreatedAt()!)!);
     case PbValueType.TEXT:
       return PlainText.create(
         RGATreeSplit.create(),
-        fromTimeTicket(pbJSONElement.getCreatedAt()),
+        fromTimeTicket(pbJSONElement.getCreatedAt()!)!,
       );
     case PbValueType.RICH_TEXT:
       return RichText.create(
         RGATreeSplit.create(),
-        fromTimeTicket(pbJSONElement.getCreatedAt()),
+        fromTimeTicket(pbJSONElement.getCreatedAt()!)!,
       );
     case PbValueType.BOOLEAN:
     case PbValueType.INTEGER:
@@ -595,7 +595,7 @@ function fromJSONElementSimple(
           fromValueType(pbJSONElement.getType()),
           pbJSONElement.getValue_asU8(),
         ),
-        fromTimeTicket(pbJSONElement.getCreatedAt()),
+        fromTimeTicket(pbJSONElement.getCreatedAt()!)!,
       );
     case PbValueType.INTEGER_CNT:
     case PbValueType.DOUBLE_CNT:
@@ -605,7 +605,7 @@ function fromJSONElementSimple(
           fromCounterType(pbJSONElement.getType()),
           pbJSONElement.getValue_asU8(),
         ),
-        fromTimeTicket(pbJSONElement.getCreatedAt()),
+        fromTimeTicket(pbJSONElement.getCreatedAt()!)!,
       );
   }
 
@@ -618,7 +618,7 @@ function fromJSONElementSimple(
 function fromTextNodePos(pbTextNodePos: PbTextNodePos): RGATreeSplitNodePos {
   return RGATreeSplitNodePos.of(
     RGATreeSplitNodeID.of(
-      fromTimeTicket(pbTextNodePos.getCreatedAt()),
+      fromTimeTicket(pbTextNodePos.getCreatedAt()!)!,
       pbTextNodePos.getOffset(),
     ),
     pbTextNodePos.getRelativeOffset(),
@@ -627,17 +627,17 @@ function fromTextNodePos(pbTextNodePos: PbTextNodePos): RGATreeSplitNodePos {
 
 function fromTextNodeID(pbTextNodeID: PbTextNodeID): RGATreeSplitNodeID {
   return RGATreeSplitNodeID.of(
-    fromTimeTicket(pbTextNodeID.getCreatedAt()),
+    fromTimeTicket(pbTextNodeID.getCreatedAt()!)!,
     pbTextNodeID.getOffset(),
   );
 }
 
 function fromTextNode(pbTextNode: PbTextNode): RGATreeSplitNode<string> {
   const textNode = RGATreeSplitNode.create(
-    fromTextNodeID(pbTextNode.getId()),
+    fromTextNodeID(pbTextNode.getId()!),
     pbTextNode.getValue(),
   );
-  textNode.remove(fromTimeTicket(pbTextNode.getRemovedAt()));
+  textNode.remove(fromTimeTicket(pbTextNode.getRemovedAt()!)!);
   return textNode;
 }
 
@@ -645,10 +645,10 @@ function fromRichTextNode(
   pbTextNode: PbRichTextNode,
 ): RGATreeSplitNode<RichTextValue> {
   const textNode = RGATreeSplitNode.create(
-    fromTextNodeID(pbTextNode.getId()),
+    fromTextNodeID(pbTextNode.getId()!),
     RichTextValue.create(pbTextNode.getValue()),
   );
-  textNode.remove(fromTimeTicket(pbTextNode.getRemovedAt()));
+  textNode.remove(fromTimeTicket(pbTextNode.getRemovedAt()!)!);
   return textNode;
 }
 
@@ -660,94 +660,94 @@ function fromOperations(pbOperations: PbOperation[]): Operation[] {
     if (pbOperation.hasSet()) {
       const pbSetOperation = pbOperation.getSet();
       operation = SetOperation.create(
-        pbSetOperation.getKey(),
-        fromJSONElementSimple(pbSetOperation.getValue()),
-        fromTimeTicket(pbSetOperation.getParentCreatedAt()),
-        fromTimeTicket(pbSetOperation.getExecutedAt()),
+        pbSetOperation!.getKey(),
+        fromJSONElementSimple(pbSetOperation!.getValue()!),
+        fromTimeTicket(pbSetOperation!.getParentCreatedAt()!)!,
+        fromTimeTicket(pbSetOperation!.getExecutedAt()!)!,
       );
     } else if (pbOperation.hasAdd()) {
       const pbAddOperation = pbOperation.getAdd();
       operation = AddOperation.create(
-        fromTimeTicket(pbAddOperation.getParentCreatedAt()),
-        fromTimeTicket(pbAddOperation.getPrevCreatedAt()),
-        fromJSONElementSimple(pbAddOperation.getValue()),
-        fromTimeTicket(pbAddOperation.getExecutedAt()),
+        fromTimeTicket(pbAddOperation!.getParentCreatedAt()!)!,
+        fromTimeTicket(pbAddOperation!.getPrevCreatedAt()!)!,
+        fromJSONElementSimple(pbAddOperation!.getValue()!),
+        fromTimeTicket(pbAddOperation!.getExecutedAt()!)!,
       );
     } else if (pbOperation.hasMove()) {
       const pbMoveOperation = pbOperation.getMove();
       operation = MoveOperation.create(
-        fromTimeTicket(pbMoveOperation.getParentCreatedAt()),
-        fromTimeTicket(pbMoveOperation.getPrevCreatedAt()),
-        fromTimeTicket(pbMoveOperation.getCreatedAt()),
-        fromTimeTicket(pbMoveOperation.getExecutedAt()),
+        fromTimeTicket(pbMoveOperation!.getParentCreatedAt()!)!,
+        fromTimeTicket(pbMoveOperation!.getPrevCreatedAt()!)!,
+        fromTimeTicket(pbMoveOperation!.getCreatedAt()!)!,
+        fromTimeTicket(pbMoveOperation!.getExecutedAt()!)!,
       );
     } else if (pbOperation.hasRemove()) {
       const pbRemoveOperation = pbOperation.getRemove();
       operation = RemoveOperation.create(
-        fromTimeTicket(pbRemoveOperation.getParentCreatedAt()),
-        fromTimeTicket(pbRemoveOperation.getCreatedAt()),
-        fromTimeTicket(pbRemoveOperation.getExecutedAt()),
+        fromTimeTicket(pbRemoveOperation!.getParentCreatedAt()!)!,
+        fromTimeTicket(pbRemoveOperation!.getCreatedAt()!)!,
+        fromTimeTicket(pbRemoveOperation!.getExecutedAt()!)!,
       );
     } else if (pbOperation.hasEdit()) {
       const pbEditOperation = pbOperation.getEdit();
       const createdAtMapByActor = new Map();
-      pbEditOperation.getCreatedAtMapByActorMap().forEach((value, key) => {
+      pbEditOperation!.getCreatedAtMapByActorMap().forEach((value, key) => {
         createdAtMapByActor.set(key, fromTimeTicket(value));
       });
       operation = EditOperation.create(
-        fromTimeTicket(pbEditOperation.getParentCreatedAt()),
-        fromTextNodePos(pbEditOperation.getFrom()),
-        fromTextNodePos(pbEditOperation.getTo()),
+        fromTimeTicket(pbEditOperation!.getParentCreatedAt()!)!,
+        fromTextNodePos(pbEditOperation!.getFrom()!),
+        fromTextNodePos(pbEditOperation!.getTo()!),
         createdAtMapByActor,
-        pbEditOperation.getContent(),
-        fromTimeTicket(pbEditOperation.getExecutedAt()),
+        pbEditOperation!.getContent(),
+        fromTimeTicket(pbEditOperation!.getExecutedAt()!)!,
       );
     } else if (pbOperation.hasSelect()) {
       const pbSelectOperation = pbOperation.getSelect();
       operation = SelectOperation.create(
-        fromTimeTicket(pbSelectOperation.getParentCreatedAt()),
-        fromTextNodePos(pbSelectOperation.getFrom()),
-        fromTextNodePos(pbSelectOperation.getTo()),
-        fromTimeTicket(pbSelectOperation.getExecutedAt()),
+        fromTimeTicket(pbSelectOperation!.getParentCreatedAt()!)!,
+        fromTextNodePos(pbSelectOperation!.getFrom()!),
+        fromTextNodePos(pbSelectOperation!.getTo()!),
+        fromTimeTicket(pbSelectOperation!.getExecutedAt()!)!,
       );
     } else if (pbOperation.hasRichEdit()) {
       const pbEditOperation = pbOperation.getRichEdit();
       const createdAtMapByActor = new Map();
-      pbEditOperation.getCreatedAtMapByActorMap().forEach((value, key) => {
+      pbEditOperation!.getCreatedAtMapByActorMap().forEach((value, key) => {
         createdAtMapByActor.set(key, fromTimeTicket(value));
       });
       const attributes = new Map();
-      pbEditOperation.getAttributesMap().forEach((value, key) => {
+      pbEditOperation!.getAttributesMap().forEach((value, key) => {
         attributes.set(key, value);
       });
       operation = RichEditOperation.create(
-        fromTimeTicket(pbEditOperation.getParentCreatedAt()),
-        fromTextNodePos(pbEditOperation.getFrom()),
-        fromTextNodePos(pbEditOperation.getTo()),
+        fromTimeTicket(pbEditOperation!.getParentCreatedAt()!)!,
+        fromTextNodePos(pbEditOperation!.getFrom()!),
+        fromTextNodePos(pbEditOperation!.getTo()!),
         createdAtMapByActor,
-        pbEditOperation.getContent(),
+        pbEditOperation!.getContent(),
         attributes,
-        fromTimeTicket(pbEditOperation.getExecutedAt()),
+        fromTimeTicket(pbEditOperation!.getExecutedAt()!)!,
       );
     } else if (pbOperation.hasStyle()) {
       const pbStyleOperation = pbOperation.getStyle();
       const attributes = new Map();
-      pbStyleOperation.getAttributesMap().forEach((value, key) => {
+      pbStyleOperation!.getAttributesMap().forEach((value, key) => {
         attributes.set(key, value);
       });
       operation = StyleOperation.create(
-        fromTimeTicket(pbStyleOperation.getParentCreatedAt()),
-        fromTextNodePos(pbStyleOperation.getFrom()),
-        fromTextNodePos(pbStyleOperation.getTo()),
+        fromTimeTicket(pbStyleOperation!.getParentCreatedAt()!)!,
+        fromTextNodePos(pbStyleOperation!.getFrom()!),
+        fromTextNodePos(pbStyleOperation!.getTo()!),
         attributes,
-        fromTimeTicket(pbStyleOperation.getExecutedAt()),
+        fromTimeTicket(pbStyleOperation!.getExecutedAt()!)!,
       );
     } else if (pbOperation.hasIncrease()) {
       const pbIncreaseOperation = pbOperation.getIncrease();
       operation = IncreaseOperation.create(
-        fromTimeTicket(pbIncreaseOperation.getParentCreatedAt()),
-        fromJSONElementSimple(pbIncreaseOperation.getValue()),
-        fromTimeTicket(pbIncreaseOperation.getExecutedAt()),
+        fromTimeTicket(pbIncreaseOperation!.getParentCreatedAt()!)!,
+        fromJSONElementSimple(pbIncreaseOperation!.getValue()!),
+        fromTimeTicket(pbIncreaseOperation!.getExecutedAt()!)!,
       );
     } else {
       throw new YorkieError(Code.Unimplemented, `unimplemented operation`);
@@ -765,7 +765,7 @@ function fromChanges(pbChanges: PbChange[]): Change[] {
   for (const pbChange of pbChanges) {
     changes.push(
       Change.create(
-        fromChangeID(pbChange.getId()),
+        fromChangeID(pbChange.getId()!),
         pbChange.getMessage(),
         fromOperations(pbChange.getOperationsList()),
       ),
@@ -784,11 +784,11 @@ function fromCheckpoint(pbCheckpoint: PbCheckpoint): Checkpoint {
 
 function fromChangePack(pbPack: PbChangePack): ChangePack {
   return ChangePack.create(
-    fromDocumentKey(pbPack.getDocumentKey()),
-    fromCheckpoint(pbPack.getCheckpoint()),
+    fromDocumentKey(pbPack.getDocumentKey()!),
+    fromCheckpoint(pbPack.getCheckpoint()!),
     fromChanges(pbPack.getChangesList()),
     pbPack.getSnapshot_asU8(),
-    fromTimeTicket(pbPack.getMinSyncedTicket()),
+    fromTimeTicket(pbPack.getMinSyncedTicket()!),
   );
 }
 
@@ -796,11 +796,11 @@ function fromJSONObject(pbObject: PbJSONElement.JSONObject): JSONObject {
   const rht = new RHTPQMap();
   for (const pbRHTNode of pbObject.getNodesList()) {
     // eslint-disable-next-line
-    rht.set(pbRHTNode.getKey(), fromJSONElement(pbRHTNode.getElement()));
+    rht.set(pbRHTNode.getKey(), fromJSONElement(pbRHTNode.getElement()!));
   }
 
-  const obj = new JSONObject(fromTimeTicket(pbObject.getCreatedAt()), rht);
-  obj.remove(fromTimeTicket(pbObject.getRemovedAt()));
+  const obj = new JSONObject(fromTimeTicket(pbObject.getCreatedAt()!)!, rht);
+  obj.remove(fromTimeTicket(pbObject.getRemovedAt()!)!);
   return obj;
 }
 
@@ -808,14 +808,14 @@ function fromJSONArray(pbArray: PbJSONElement.JSONArray): JSONArray {
   const rgaTreeList = new RGATreeList();
   for (const pbRGANode of pbArray.getNodesList()) {
     // eslint-disable-next-line
-    rgaTreeList.insert(fromJSONElement(pbRGANode.getElement()));
+    rgaTreeList.insert(fromJSONElement(pbRGANode.getElement()!));
   }
 
   const arr = new JSONArray(
-    fromTimeTicket(pbArray.getCreatedAt()),
+    fromTimeTicket(pbArray.getCreatedAt()!)!,
     rgaTreeList,
   );
-  arr.remove(fromTimeTicket(pbArray.getRemovedAt()));
+  arr.remove(fromTimeTicket(pbArray.getRemovedAt()!)!);
   return arr;
 }
 
@@ -827,9 +827,9 @@ function fromJSONPrimitive(
       fromValueType(pbPrimitive.getType()),
       pbPrimitive.getValue_asU8(),
     ),
-    fromTimeTicket(pbPrimitive.getCreatedAt()),
+    fromTimeTicket(pbPrimitive.getCreatedAt()!)!,
   );
-  primitive.remove(fromTimeTicket(pbPrimitive.getRemovedAt()));
+  primitive.remove(fromTimeTicket(pbPrimitive.getRemovedAt()!)!);
   return primitive;
 }
 
@@ -841,7 +841,7 @@ function fromJSONText(pbText: PbJSONElement.Text): PlainText {
     const current = rgaTreeSplit.insertAfter(prev, fromTextNode(pbNode));
     if (pbNode.hasInsPrevId()) {
       current.setInsPrev(
-        rgaTreeSplit.findNode(fromTextNodeID(pbNode.getInsPrevId())),
+        rgaTreeSplit.findNode(fromTextNodeID(pbNode.getInsPrevId()!)),
       );
     }
     prev = current;
@@ -849,9 +849,9 @@ function fromJSONText(pbText: PbJSONElement.Text): PlainText {
 
   const text = PlainText.create(
     rgaTreeSplit,
-    fromTimeTicket(pbText.getCreatedAt()),
+    fromTimeTicket(pbText.getCreatedAt()!)!,
   );
-  text.remove(fromTimeTicket(pbText.getRemovedAt()));
+  text.remove(fromTimeTicket(pbText.getRemovedAt()!)!);
   return text;
 }
 
@@ -863,7 +863,7 @@ function fromJSONRichText(pbText: PbJSONElement.RichText): RichText {
     const current = rgaTreeSplit.insertAfter(prev, fromRichTextNode(pbNode));
     if (pbNode.hasInsPrevId()) {
       current.setInsPrev(
-        rgaTreeSplit.findNode(fromTextNodeID(pbNode.getInsPrevId())),
+        rgaTreeSplit.findNode(fromTextNodeID(pbNode.getInsPrevId()!)),
       );
     }
     prev = current;
@@ -871,9 +871,9 @@ function fromJSONRichText(pbText: PbJSONElement.RichText): RichText {
 
   const text = RichText.create(
     rgaTreeSplit,
-    fromTimeTicket(pbText.getCreatedAt()),
+    fromTimeTicket(pbText.getCreatedAt()!)!,
   );
-  text.remove(fromTimeTicket(pbText.getRemovedAt()));
+  text.remove(fromTimeTicket(pbText.getRemovedAt()!)!);
   return text;
 }
 
@@ -883,25 +883,25 @@ function fromCounter(pbCounter: PbJSONElement.Counter): Counter {
       fromCounterType(pbCounter.getType()),
       pbCounter.getValue_asU8(),
     ),
-    fromTimeTicket(pbCounter.getCreatedAt()),
+    fromTimeTicket(pbCounter.getCreatedAt()!)!,
   );
-  counter.remove(fromTimeTicket(pbCounter.getRemovedAt()));
+  counter.remove(fromTimeTicket(pbCounter.getRemovedAt()!)!);
   return counter;
 }
 
 function fromJSONElement(pbJSONElement: PbJSONElement): JSONElement {
   if (pbJSONElement.hasJsonObject()) {
-    return fromJSONObject(pbJSONElement.getJsonObject());
+    return fromJSONObject(pbJSONElement.getJsonObject()!);
   } else if (pbJSONElement.hasJsonArray()) {
-    return fromJSONArray(pbJSONElement.getJsonArray());
+    return fromJSONArray(pbJSONElement.getJsonArray()!);
   } else if (pbJSONElement.hasPrimitive()) {
-    return fromJSONPrimitive(pbJSONElement.getPrimitive());
+    return fromJSONPrimitive(pbJSONElement.getPrimitive()!);
   } else if (pbJSONElement.hasText()) {
-    return fromJSONText(pbJSONElement.getText());
+    return fromJSONText(pbJSONElement.getText()!);
   } else if (pbJSONElement.hasRichText()) {
-    return fromJSONRichText(pbJSONElement.getRichText());
+    return fromJSONRichText(pbJSONElement.getRichText()!);
   } else if (pbJSONElement.hasCounter()) {
-    return fromCounter(pbJSONElement.getCounter());
+    return fromCounter(pbJSONElement.getCounter()!);
   } else {
     throw new YorkieError(
       Code.Unimplemented,
@@ -916,7 +916,7 @@ function bytesToObject(bytes: Uint8Array): JSONObject {
   }
 
   const pbJSONElement = PbJSONElement.deserializeBinary(bytes);
-  return fromJSONObject(pbJSONElement.getJsonObject());
+  return fromJSONObject(pbJSONElement.getJsonObject()!);
 }
 
 function objectToBytes(obj: JSONObject): Uint8Array {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -107,7 +107,7 @@ export class Client implements Observable<ClientEvent> {
 
   private rpcClient: RPCClient;
   private watchLoopTimerID?: ReturnType<typeof setTimeout>;
-  private remoteChangeEventStream: any;
+  private remoteChangeEventStream?: any;
   private eventStream: Observable<ClientEvent>;
   private eventStreamObserver!: Observer<ClientEvent>;
 
@@ -123,7 +123,7 @@ export class Client implements Observable<ClientEvent> {
     this.reconnectStreamDelay =
       opts.reconnectStreamDelay || DefaultClientOptions.reconnectStreamDelay;
 
-    this.rpcClient = new RPCClient(rpcAddr, null, null);
+    this.rpcClient = new RPCClient(rpcAddr);
     this.eventStream = createObservable<ClientEvent>((observer) => {
       this.eventStreamObserver = observer;
     });
@@ -176,7 +176,7 @@ export class Client implements Observable<ClientEvent> {
 
     if (this.remoteChangeEventStream) {
       this.remoteChangeEventStream.cancel();
-      this.remoteChangeEventStream = null;
+      this.remoteChangeEventStream = undefined;
     }
 
     return new Promise((resolve, reject) => {
@@ -376,7 +376,7 @@ export class Client implements Observable<ClientEvent> {
     const doLoop = (): void => {
       if (this.remoteChangeEventStream) {
         this.remoteChangeEventStream.cancel();
-        this.remoteChangeEventStream = null;
+        this.remoteChangeEventStream = undefined;
       }
 
       if (this.watchLoopTimerID) {
@@ -406,7 +406,7 @@ export class Client implements Observable<ClientEvent> {
       req.setDocumentKeysList(converter.toDocumentKeys(realtimeSyncDocKeys));
 
       const onStreamDisconnect = () => {
-        this.remoteChangeEventStream = null;
+        this.remoteChangeEventStream = undefined;
         this.watchLoopTimerID = setTimeout(doLoop, this.reconnectStreamDelay!);
         this.eventStreamObserver.next!({
           name: ClientEventType.StreamConnectionStatusChanged,

--- a/src/document/change/change.ts
+++ b/src/document/change/change.ts
@@ -34,7 +34,7 @@ export class Change {
   private operations: Operation[];
 
   // serverSeq is optional and only present for changes stored on the server.
-  private serverSeq: Long;
+  private serverSeq?: Long;
 
   constructor(id: ChangeID, message: string, operations: Operation[]) {
     this.id = id;

--- a/src/document/change/change_id.ts
+++ b/src/document/change/change_id.ts
@@ -29,7 +29,7 @@ export class ChangeID {
   constructor(clientSeq: number, lamport: Long, actor?: ActorID) {
     this.clientSeq = clientSeq;
     this.lamport = lamport;
-    this.actor = typeof actor !== 'undefined' ? actor : undefined;
+    this.actor = actor;
   }
 
   public static of(
@@ -53,7 +53,7 @@ export class ChangeID {
   }
 
   public createTimeTicket(delimiter: number): TimeTicket {
-    return TimeTicket.of(this.lamport, delimiter, this.actor!);
+    return TimeTicket.of(this.lamport, delimiter, this.actor);
   }
 
   public setActor(actorID: ActorID): ChangeID {
@@ -77,7 +77,7 @@ export class ChangeID {
   }
 
   public getAnnotatedString(): string {
-    if (this.actor == null) {
+    if (!this.actor) {
       return `${this.lamport.toString()}:nil:${this.clientSeq}`;
     }
     return `${this.lamport.toString()}:${this.actor.substring(22, 24)}:${

--- a/src/document/change/change_id.ts
+++ b/src/document/change/change_id.ts
@@ -24,12 +24,12 @@ import { TimeTicket } from '../time/ticket';
 export class ChangeID {
   private clientSeq: number;
   private lamport: Long;
-  private actor: ActorID;
+  private actor?: ActorID;
 
   constructor(clientSeq: number, lamport: Long, actor?: ActorID) {
     this.clientSeq = clientSeq;
     this.lamport = lamport;
-    this.actor = typeof actor !== 'undefined' ? actor : null;
+    this.actor = typeof actor !== 'undefined' ? actor : undefined;
   }
 
   public static of(
@@ -53,7 +53,7 @@ export class ChangeID {
   }
 
   public createTimeTicket(delimiter: number): TimeTicket {
-    return TimeTicket.of(this.lamport, delimiter, this.actor);
+    return TimeTicket.of(this.lamport, delimiter, this.actor!);
   }
 
   public setActor(actorID: ActorID): ChangeID {
@@ -73,7 +73,7 @@ export class ChangeID {
   }
 
   public getActorID(): string {
-    return this.actor;
+    return this.actor!;
   }
 
   public getAnnotatedString(): string {

--- a/src/document/change/change_pack.ts
+++ b/src/document/change/change_pack.ts
@@ -77,11 +77,11 @@ export class ChangePack {
     return !!this.snapshot && !!this.snapshot.length;
   }
 
-  public getSnapshot(): Uint8Array {
-    return this.snapshot!;
+  public getSnapshot(): Uint8Array | undefined {
+    return this.snapshot;
   }
 
-  public getMinSyncedTicket(): TimeTicket {
-    return this.minSyncedTicket!;
+  public getMinSyncedTicket(): TimeTicket | undefined {
+    return this.minSyncedTicket;
   }
 }

--- a/src/document/change/change_pack.ts
+++ b/src/document/change/change_pack.ts
@@ -26,15 +26,15 @@ export class ChangePack {
   private key: DocumentKey;
   private checkpoint: Checkpoint;
   private changes: Change[];
-  private snapshot: Uint8Array;
-  private minSyncedTicket: TimeTicket;
+  private snapshot?: Uint8Array;
+  private minSyncedTicket?: TimeTicket;
 
   constructor(
     key: DocumentKey,
     checkpoint: Checkpoint,
     changes: Change[],
-    snapshot: Uint8Array,
-    minSyncedTicket: TimeTicket,
+    snapshot?: Uint8Array,
+    minSyncedTicket?: TimeTicket,
   ) {
     this.key = key;
     this.checkpoint = checkpoint;
@@ -78,10 +78,10 @@ export class ChangePack {
   }
 
   public getSnapshot(): Uint8Array {
-    return this.snapshot;
+    return this.snapshot!;
   }
 
   public getMinSyncedTicket(): TimeTicket {
-    return this.minSyncedTicket;
+    return this.minSyncedTicket!;
   }
 }

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -54,12 +54,12 @@ export interface DocEvent {
 export class Document implements Observable<DocEvent> {
   private key: DocumentKey;
   private root: JSONRoot;
-  private clone: JSONRoot;
+  private clone?: JSONRoot;
   private changeID: ChangeID;
   private checkpoint: Checkpoint;
   private localChanges: Change[];
   private eventStream: Observable<DocEvent>;
-  private eventStreamObserver: Observer<DocEvent>;
+  private eventStreamObserver!: Observer<DocEvent>;
 
   constructor(collection: string, document: string) {
     this.key = DocumentKey.of(collection, document);
@@ -89,16 +89,16 @@ export class Document implements Observable<DocEvent> {
     this.ensureClone();
     const context = ChangeContext.create(
       this.changeID.next(),
-      message,
-      this.clone,
+      message!,
+      this.clone!,
     );
 
     try {
-      const proxy = createProxy(context, this.clone.getObject());
+      const proxy = createProxy(context, this.clone!.getObject());
       updater(proxy);
     } catch (err) {
       // drop clone because it is contaminated.
-      this.clone = null;
+      this.clone = undefined;
       logger.error(err);
       throw err;
     }
@@ -114,7 +114,7 @@ export class Document implements Observable<DocEvent> {
       this.changeID = change.getID();
 
       if (this.eventStreamObserver) {
-        this.eventStreamObserver.next({
+        this.eventStreamObserver.next!({
           name: DocEventType.LocalChange,
           value: [change],
         });
@@ -127,7 +127,7 @@ export class Document implements Observable<DocEvent> {
   }
 
   public subscribe(
-    nextOrObserver: Observer<DocEvent> | NextFn<DocEvent>,
+    nextOrObserver?: Observer<DocEvent> | NextFn<DocEvent>,
     error?: ErrorFn,
     complete?: CompleteFn,
   ): Unsubscribe {
@@ -214,14 +214,14 @@ export class Document implements Observable<DocEvent> {
   }
 
   public getClone(): JSONObject {
-    return this.clone.getObject();
+    return this.clone!.getObject();
   }
 
   public getRootObject(): JSONObject & Indexable {
     this.ensureClone();
 
-    const context = ChangeContext.create(this.changeID.next(), '', this.clone);
-    return createProxy(context, this.clone.getObject());
+    const context = ChangeContext.create(this.changeID.next(), '', this.clone!);
+    return createProxy(context, this.clone!.getObject());
   }
 
   public garbageCollect(ticket: TimeTicket): number {
@@ -257,10 +257,10 @@ export class Document implements Observable<DocEvent> {
     this.changeID = this.changeID.syncLamport(serverSeq);
 
     // drop clone because it is contaminated.
-    this.clone = null;
+    this.clone = undefined;
 
     if (this.eventStreamObserver) {
-      this.eventStreamObserver.next({
+      this.eventStreamObserver.next!({
         name: DocEventType.Snapshot,
         value: snapshot,
       });
@@ -285,7 +285,7 @@ export class Document implements Observable<DocEvent> {
 
     this.ensureClone();
     for (const change of changes) {
-      change.execute(this.clone);
+      change.execute(this.clone!);
     }
 
     for (const change of changes) {
@@ -294,7 +294,7 @@ export class Document implements Observable<DocEvent> {
     }
 
     if (changes.length && this.eventStreamObserver) {
-      this.eventStreamObserver.next({
+      this.eventStreamObserver.next!({
         name: DocEventType.RemoteChange,
         value: changes,
       });

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -144,8 +144,8 @@ export class Document implements Observable<DocEvent> {
   public applyChangePack(pack: ChangePack): void {
     if (pack.hasSnapshot()) {
       this.applySnapshot(
-        pack.getSnapshot(),
         pack.getCheckpoint().getServerSeq(),
+        pack.getSnapshot(),
       );
     } else if (pack.hasChanges()) {
       this.applyChanges(pack.getChanges());
@@ -164,7 +164,7 @@ export class Document implements Observable<DocEvent> {
     this.checkpoint = this.checkpoint.forward(pack.getCheckpoint());
 
     // 04. Do Garbage collection.
-    this.garbageCollect(pack.getMinSyncedTicket());
+    this.garbageCollect(pack.getMinSyncedTicket()!);
 
     if (logger.isEnabled(LogLevel.Trivial)) {
       logger.trivial(`${this.root.toJSON()}`);
@@ -247,7 +247,7 @@ export class Document implements Observable<DocEvent> {
     return this.root.toSortedJSON();
   }
 
-  private applySnapshot(snapshot: Uint8Array, serverSeq: Long): void {
+  private applySnapshot(serverSeq: Long, snapshot?: Uint8Array): void {
     const obj = converter.bytesToObject(snapshot);
     this.root = new JSONRoot(obj);
 

--- a/src/document/json/counter.ts
+++ b/src/document/json/counter.ts
@@ -32,7 +32,7 @@ type CounterValue = number | Long;
  * Counter represents changeable number data type.
  */
 export class Counter extends JSONElement {
-  private valueType: CounterType;
+  private valueType?: CounterType;
   private value: CounterValue;
 
   constructor(value: CounterValue, createdAt: TimeTicket) {
@@ -84,10 +84,10 @@ export class Counter extends JSONElement {
   }
 
   public getType(): CounterType {
-    return this.valueType;
+    return this.valueType!;
   }
 
-  public static getCounterType(value: CounterValue): CounterType {
+  public static getCounterType(value: CounterValue): CounterType | undefined {
     switch (typeof value) {
       case 'number':
         return CounterType.DoubleCnt;
@@ -97,7 +97,7 @@ export class Counter extends JSONElement {
         }
     }
 
-    return null;
+    return;
   }
 
   public static isSupport(value: CounterValue): boolean {

--- a/src/document/json/element.ts
+++ b/src/document/json/element.ts
@@ -21,8 +21,8 @@ import { TimeTicket } from '../time/ticket';
  */
 export abstract class JSONElement {
   private createdAt: TimeTicket;
-  private movedAt: TimeTicket;
-  private removedAt: TimeTicket;
+  private movedAt?: TimeTicket;
+  private removedAt?: TimeTicket;
 
   constructor(createdAt: TimeTicket) {
     this.createdAt = createdAt;
@@ -37,11 +37,11 @@ export abstract class JSONElement {
   }
 
   public getMovedAt(): TimeTicket {
-    return this.movedAt;
+    return this.movedAt!;
   }
 
   public getRemovedAt(): TimeTicket {
-    return this.removedAt;
+    return this.removedAt!;
   }
 
   public setMovedAt(movedAt: TimeTicket): boolean {

--- a/src/document/json/element.ts
+++ b/src/document/json/element.ts
@@ -36,15 +36,15 @@ export abstract class JSONElement {
     return this.createdAt;
   }
 
-  public getMovedAt(): TimeTicket {
-    return this.movedAt!;
+  public getMovedAt(): TimeTicket | undefined {
+    return this.movedAt;
   }
 
-  public getRemovedAt(): TimeTicket {
-    return this.removedAt!;
+  public getRemovedAt(): TimeTicket | undefined {
+    return this.removedAt;
   }
 
-  public setMovedAt(movedAt: TimeTicket): boolean {
+  public setMovedAt(movedAt?: TimeTicket): boolean {
     if (!this.movedAt || (movedAt && movedAt.after(this.movedAt))) {
       this.movedAt = movedAt;
       return true;
@@ -53,7 +53,7 @@ export abstract class JSONElement {
     return false;
   }
 
-  public remove(removedAt: TimeTicket): boolean {
+  public remove(removedAt?: TimeTicket): boolean {
     if (!this.removedAt || (removedAt && removedAt.after(this.removedAt))) {
       this.removedAt = removedAt;
       return true;

--- a/src/document/json/object.ts
+++ b/src/document/json/object.ts
@@ -39,14 +39,14 @@ export class JSONObject extends JSONContainer {
     return new JSONObject(createdAt, RHTPQMap.create());
   }
 
-  public createText(key: string): PlainText {
+  public createText(key: string): PlainText | undefined {
     logger.fatal(`unsupported: this method should be called by proxy: ${key}`);
-    return null;
+    return;
   }
 
-  public createRichText(key: string): RichText {
+  public createRichText(key: string): RichText | undefined {
     logger.fatal(`unsupported: this method should be called by proxy: ${key}`);
-    return null;
+    return;
   }
 
   public purge(value: JSONElement): void {
@@ -58,10 +58,13 @@ export class JSONObject extends JSONContainer {
    * The reason for setting the CounterProxy type as the return value
    * is to provide the CounterProxy interface to the user.
    */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public createCounter(key: string, value: CounterType): CounterProxy {
+  public createCounter(
+    key: string,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    value: CounterType,
+  ): CounterProxy | undefined {
     logger.fatal(`unsupported: this method should be called by proxy: ${key}`);
-    return null;
+    return;
   }
 
   public set(key: string, value: JSONElement): void {
@@ -69,15 +72,15 @@ export class JSONObject extends JSONContainer {
   }
 
   public delete(createdAt: TimeTicket, executedAt: TimeTicket): JSONElement {
-    return this.memberNodes.delete(createdAt, executedAt);
+    return this.memberNodes.delete(createdAt, executedAt)!;
   }
 
   public deleteByKey(key: string, executedAt: TimeTicket): JSONElement {
-    return this.memberNodes.deleteByKey(key, executedAt);
+    return this.memberNodes.deleteByKey(key, executedAt)!;
   }
 
   public get(key: string): JSONElement {
-    return this.memberNodes.get(key);
+    return this.memberNodes.get(key)!;
   }
 
   public has(key: string): boolean {
@@ -101,7 +104,7 @@ export class JSONObject extends JSONContainer {
     const json = [];
     for (const key of keys.sort()) {
       const node = this.memberNodes.get(key);
-      json.push(`"${key}":${node.toSortedJSON()}`);
+      json.push(`"${key}":${node!.toSortedJSON()}`);
     }
 
     return `{${json.join(',')}}`;

--- a/src/document/json/object.ts
+++ b/src/document/json/object.ts
@@ -39,13 +39,15 @@ export class JSONObject extends JSONContainer {
     return new JSONObject(createdAt, RHTPQMap.create());
   }
 
-  public createText(key: string): PlainText | undefined {
+  public createText(key: string): PlainText {
     logger.fatal(`unsupported: this method should be called by proxy: ${key}`);
+    // @ts-ignore
     return;
   }
 
-  public createRichText(key: string): RichText | undefined {
+  public createRichText(key: string): RichText {
     logger.fatal(`unsupported: this method should be called by proxy: ${key}`);
+    // @ts-ignore
     return;
   }
 
@@ -62,8 +64,9 @@ export class JSONObject extends JSONContainer {
     key: string,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     value: CounterType,
-  ): CounterProxy | undefined {
+  ): CounterProxy {
     logger.fatal(`unsupported: this method should be called by proxy: ${key}`);
+    // @ts-ignore
     return;
   }
 

--- a/src/document/json/plain_text.ts
+++ b/src/document/json/plain_text.ts
@@ -26,7 +26,7 @@ import {
 } from './rga_tree_split';
 
 export class PlainText extends TextElement {
-  private onChangesHandler: (changes: Array<Change>) => void;
+  private onChangesHandler?: (changes: Array<Change>) => void;
   private rgaTreeSplit: RGATreeSplit<string>;
   private selectionMap: Map<string, Selection>;
   private remoteChangeLock: boolean;
@@ -45,17 +45,21 @@ export class PlainText extends TextElement {
     return new PlainText(rgaTreeSplit, createdAt);
   }
 
-  public edit(fromIdx: number, toIdx: number, content: string): PlainText {
+  public edit(
+    fromIdx: number,
+    toIdx: number,
+    content: string,
+  ): PlainText | undefined {
     logger.fatal(
       `unsupported: this method should be called by proxy, ${fromIdx}-${toIdx} ${content}`,
     );
-    return null;
+    return;
   }
 
   public editInternal(
     range: RGATreeSplitNodeRange,
     content: string,
-    latestCreatedAtMapByActor: Map<string, TimeTicket>,
+    latestCreatedAtMapByActor: Map<string, TimeTicket> | undefined,
     editedAt: TimeTicket,
   ): Map<string, TimeTicket> {
     const [caretPos, latestCreatedAtMap, changes] = this.rgaTreeSplit.edit(
@@ -155,17 +159,17 @@ export class PlainText extends TextElement {
   private updateSelectionInternal(
     range: RGATreeSplitNodeRange,
     updatedAt: TimeTicket,
-  ): Change {
+  ): Change | undefined {
     if (!this.selectionMap.has(updatedAt.getActorID())) {
       this.selectionMap.set(
         updatedAt.getActorID(),
         Selection.of(range, updatedAt),
       );
-      return null;
+      return;
     }
 
     const prevSelection = this.selectionMap.get(updatedAt.getActorID());
-    if (updatedAt.after(prevSelection.getUpdatedAt())) {
+    if (updatedAt.after(prevSelection!.getUpdatedAt())) {
       this.selectionMap.set(
         updatedAt.getActorID(),
         Selection.of(range, updatedAt),

--- a/src/document/json/plain_text.ts
+++ b/src/document/json/plain_text.ts
@@ -45,14 +45,11 @@ export class PlainText extends TextElement {
     return new PlainText(rgaTreeSplit, createdAt);
   }
 
-  public edit(
-    fromIdx: number,
-    toIdx: number,
-    content: string,
-  ): PlainText | undefined {
+  public edit(fromIdx: number, toIdx: number, content: string): PlainText {
     logger.fatal(
       `unsupported: this method should be called by proxy, ${fromIdx}-${toIdx} ${content}`,
     );
+    // @ts-ignore
     return;
   }
 
@@ -160,25 +157,25 @@ export class PlainText extends TextElement {
     range: RGATreeSplitNodeRange,
     updatedAt: TimeTicket,
   ): Change | undefined {
-    if (!this.selectionMap.has(updatedAt.getActorID())) {
+    if (!this.selectionMap.has(updatedAt.getActorID()!)) {
       this.selectionMap.set(
-        updatedAt.getActorID(),
+        updatedAt.getActorID()!,
         Selection.of(range, updatedAt),
       );
       return;
     }
 
-    const prevSelection = this.selectionMap.get(updatedAt.getActorID());
+    const prevSelection = this.selectionMap.get(updatedAt.getActorID()!);
     if (updatedAt.after(prevSelection!.getUpdatedAt())) {
       this.selectionMap.set(
-        updatedAt.getActorID(),
+        updatedAt.getActorID()!,
         Selection.of(range, updatedAt),
       );
 
       const [from, to] = this.rgaTreeSplit.findIndexesFromRange(range);
       return {
         type: ChangeType.Selection,
-        actor: updatedAt.getActorID(),
+        actor: updatedAt.getActorID()!,
         from,
         to,
       };

--- a/src/document/json/primitive.ts
+++ b/src/document/json/primitive.ts
@@ -43,12 +43,12 @@ export type PrimitiveValue =
  * This is immutable.
  */
 export class JSONPrimitive extends JSONElement {
-  private valueType?: PrimitiveType;
+  private valueType: PrimitiveType;
   private value: PrimitiveValue;
 
   constructor(value: PrimitiveValue, createdAt: TimeTicket) {
     super(createdAt);
-    this.valueType = JSONPrimitive.getPrimitiveType(value);
+    this.valueType = JSONPrimitive.getPrimitiveType(value)!;
     this.value = value;
   }
 

--- a/src/document/json/primitive.ts
+++ b/src/document/json/primitive.ts
@@ -43,7 +43,7 @@ export type PrimitiveValue =
  * This is immutable.
  */
 export class JSONPrimitive extends JSONElement {
-  private valueType: PrimitiveType;
+  private valueType?: PrimitiveType;
   private value: PrimitiveValue;
 
   constructor(value: PrimitiveValue, createdAt: TimeTicket) {
@@ -110,10 +110,10 @@ export class JSONPrimitive extends JSONElement {
   }
 
   public getType(): PrimitiveType {
-    return this.valueType;
+    return this.valueType!;
   }
 
-  public static getPrimitiveType(value: unknown): PrimitiveType {
+  public static getPrimitiveType(value: unknown): PrimitiveType | undefined {
     switch (typeof value) {
       case 'boolean':
         return PrimitiveType.Boolean;
@@ -131,7 +131,7 @@ export class JSONPrimitive extends JSONElement {
         }
     }
 
-    return null;
+    return;
   }
 
   public static isSupport(value: unknown): boolean {

--- a/src/document/json/rga_tree_list.ts
+++ b/src/document/json/rga_tree_list.ts
@@ -21,14 +21,12 @@ import { JSONElement } from './element';
 import { JSONPrimitive } from './primitive';
 
 class RGATreeListNode extends SplayNode<JSONElement> {
-  private prev: RGATreeListNode;
-  private next: RGATreeListNode;
+  private prev?: RGATreeListNode;
+  private next?: RGATreeListNode;
 
   constructor(value: JSONElement) {
     super(value);
     this.value = value;
-    this.prev = null;
-    this.next = null;
   }
 
   public static createAfter(
@@ -56,12 +54,14 @@ class RGATreeListNode extends SplayNode<JSONElement> {
   }
 
   public release(): void {
-    this.prev.next = this.next;
+    if (this.prev) {
+      this.prev.next = this.next;
+    }
     if (this.next) {
       this.next.prev = this.prev;
     }
-    this.prev = null;
-    this.next = null;
+    this.prev = undefined;
+    this.next = undefined;
   }
 
   public getLength(): number {
@@ -69,11 +69,11 @@ class RGATreeListNode extends SplayNode<JSONElement> {
   }
 
   public getPrev(): RGATreeListNode {
-    return this.prev;
+    return this.prev!;
   }
 
   public getNext(): RGATreeListNode {
-    return this.next;
+    return this.next!;
   }
 
   public getValue(): JSONElement {
@@ -133,11 +133,14 @@ export class RGATreeList {
       logger.fatal(`cant find the given node: ${createdAt.toIDString()}`);
     }
 
-    while (node.getNext() && node.getNext().getCreatedAt().after(executedAt)) {
-      node = node.getNext();
+    while (
+      node!.getNext() &&
+      node!.getNext().getCreatedAt().after(executedAt)
+    ) {
+      node = node!.getNext();
     }
 
-    return node;
+    return node!;
   }
 
   private release(node: RGATreeListNode): void {
@@ -187,12 +190,12 @@ export class RGATreeList {
     }
 
     if (
-      !node.getValue().getMovedAt() ||
-      executedAt.after(node.getValue().getMovedAt())
+      !node!.getValue().getMovedAt() ||
+      executedAt.after(node!.getValue().getMovedAt())
     ) {
-      node.release();
-      this.insertAfter(prevNode.getCreatedAt(), node.getValue(), executedAt);
-      node.getValue().setMovedAt(executedAt);
+      node!.release();
+      this.insertAfter(prevNode!.getCreatedAt(), node!.getValue(), executedAt);
+      node!.getValue().setMovedAt(executedAt);
     }
   }
 
@@ -202,7 +205,7 @@ export class RGATreeList {
 
   public get(createdAt: TimeTicket): JSONElement {
     const node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
-    return node.getValue();
+    return node!.getValue();
   }
 
   public purge(element: JSONElement): void {
@@ -216,7 +219,7 @@ export class RGATreeList {
           .toIDString()}`,
       );
     }
-    this.release(node);
+    this.release(node!);
   }
 
   public getByIndex(idx: number): RGATreeListNode {
@@ -239,18 +242,18 @@ export class RGATreeList {
   public getPrevCreatedAt(createdAt: TimeTicket): TimeTicket {
     let node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
     do {
-      node = node.getPrev();
+      node = node!.getPrev();
     } while (this.dummyHead !== node && node.isRemoved());
     return node.getValue().getCreatedAt();
   }
 
   public delete(createdAt: TimeTicket, editedAt: TimeTicket): JSONElement {
     const node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
-    if (node.remove(editedAt)) {
-      this.nodeMapByIndex.splayNode(node);
+    if (node!.remove(editedAt)) {
+      this.nodeMapByIndex.splayNode(node!);
       this.size -= 1;
     }
-    return node.getValue();
+    return node!.getValue();
   }
 
   public deleteByIndex(index: number, editedAt: TimeTicket): JSONElement {

--- a/src/document/json/rga_tree_list.ts
+++ b/src/document/json/rga_tree_list.ts
@@ -68,12 +68,12 @@ class RGATreeListNode extends SplayNode<JSONElement> {
     return this.value.isRemoved() ? 0 : 1;
   }
 
-  public getPrev(): RGATreeListNode {
-    return this.prev!;
+  public getPrev(): RGATreeListNode | undefined {
+    return this.prev;
   }
 
-  public getNext(): RGATreeListNode {
-    return this.next!;
+  public getNext(): RGATreeListNode | undefined {
+    return this.next;
   }
 
   public getValue(): JSONElement {
@@ -135,7 +135,7 @@ export class RGATreeList {
 
     while (
       node!.getNext() &&
-      node!.getNext().getCreatedAt().after(executedAt)
+      node!.getNext()!.getCreatedAt().after(executedAt)
     ) {
       node = node!.getNext();
     }
@@ -144,8 +144,8 @@ export class RGATreeList {
   }
 
   private release(node: RGATreeListNode): void {
-    if (this.last == node) {
-      this.last = node.getPrev();
+    if (this.last === node) {
+      this.last = node.getPrev()!;
     }
 
     node.release();
@@ -191,7 +191,7 @@ export class RGATreeList {
 
     if (
       !node!.getValue().getMovedAt() ||
-      executedAt.after(node!.getValue().getMovedAt())
+      executedAt.after(node!.getValue().getMovedAt()!)
     ) {
       node!.release();
       this.insertAfter(prevNode!.getCreatedAt(), node!.getValue(), executedAt);
@@ -228,11 +228,11 @@ export class RGATreeList {
 
     if (idx === 0 && node === this.dummyHead) {
       do {
-        rgaNode = rgaNode.getNext();
+        rgaNode = rgaNode.getNext()!;
       } while (rgaNode.isRemoved());
     } else if (offset > 0) {
       do {
-        rgaNode = rgaNode.getNext();
+        rgaNode = rgaNode.getNext()!;
       } while (rgaNode.isRemoved());
     }
 
@@ -242,7 +242,7 @@ export class RGATreeList {
   public getPrevCreatedAt(createdAt: TimeTicket): TimeTicket {
     let node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
     do {
-      node = node!.getPrev();
+      node = node!.getPrev()!;
     } while (this.dummyHead !== node && node.isRemoved());
     return node.getValue().getCreatedAt();
   }

--- a/src/document/json/rht.ts
+++ b/src/document/json/rht.ts
@@ -74,12 +74,12 @@ export class RHT {
     return this.nodeMapByKey.has(key);
   }
 
-  public get(key: string): string {
+  public get(key: string): string | undefined {
     if (!this.nodeMapByKey.has(key)) {
-      return null;
+      return;
     }
 
-    return this.nodeMapByKey.get(key).getValue();
+    return this.nodeMapByKey.get(key)!.getValue();
   }
 
   public deepcopy(): RHT {

--- a/src/document/json/rht_pq_map.ts
+++ b/src/document/json/rht_pq_map.ts
@@ -66,18 +66,21 @@ export class RHTPQMap {
     }
 
     const node = RHTPQMapNode.of(key, value);
-    this.elementQueueMapByKey.get(key).push(node);
+    this.elementQueueMapByKey.get(key)!.push(node);
     this.nodeMapByCreatedAt.set(value.getCreatedAt().toIDString(), node);
   }
 
-  public delete(createdAt: TimeTicket, executedAt: TimeTicket): JSONElement {
+  public delete(
+    createdAt: TimeTicket,
+    executedAt: TimeTicket,
+  ): JSONElement | undefined {
     if (!this.nodeMapByCreatedAt.has(createdAt.toIDString())) {
-      return null;
+      return;
     }
 
     const node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
-    node.remove(executedAt);
-    return node.getValue();
+    node!.remove(executedAt);
+    return node!.getValue();
   }
 
   public purge(element: JSONElement): void {
@@ -88,24 +91,27 @@ export class RHTPQMap {
       logger.fatal(`fail to find ${element.getCreatedAt().toIDString()}`);
     }
 
-    const queue = this.elementQueueMapByKey.get(node.getStrKey());
+    const queue = this.elementQueueMapByKey.get(node!.getStrKey());
     if (!queue) {
       logger.fatal(
         `fail to find queue of ${element.getCreatedAt().toIDString()}`,
       );
     }
 
-    queue.release(node);
+    queue!.release(node!);
 
     this.nodeMapByCreatedAt.delete(element.getCreatedAt().toIDString());
   }
 
-  public deleteByKey(key: string, removedAt: TimeTicket): JSONElement {
+  public deleteByKey(
+    key: string,
+    removedAt: TimeTicket,
+  ): JSONElement | undefined {
     if (!this.elementQueueMapByKey.has(key)) {
-      return null;
+      return;
     }
 
-    const node = this.elementQueueMapByKey.get(key).peek() as RHTPQMapNode;
+    const node = this.elementQueueMapByKey.get(key)!.peek() as RHTPQMapNode;
     node.remove(removedAt);
     return node.getValue();
   }
@@ -115,16 +121,16 @@ export class RHTPQMap {
       return false;
     }
 
-    const node = this.elementQueueMapByKey.get(key).peek() as RHTPQMapNode;
+    const node = this.elementQueueMapByKey.get(key)!.peek() as RHTPQMapNode;
     return !node.isRemoved();
   }
 
-  public get(key: string): JSONElement {
+  public get(key: string): JSONElement | undefined {
     if (!this.elementQueueMapByKey.has(key)) {
-      return null;
+      return;
     }
 
-    return this.elementQueueMapByKey.get(key).peek().getValue();
+    return this.elementQueueMapByKey!.get(key)!.peek()!.getValue();
   }
 
   public *[Symbol.iterator](): IterableIterator<RHTPQMapNode> {

--- a/src/document/json/rich_text.ts
+++ b/src/document/json/rich_text.ts
@@ -78,7 +78,7 @@ export class RichTextValue {
 }
 
 export class RichText extends TextElement {
-  private onChangesHandler: (changes: Array<Change>) => void;
+  private onChangesHandler?: (changes: Array<Change>) => void;
   private rgaTreeSplit: RGATreeSplit<RichTextValue>;
   private selectionMap: Map<string, Selection>;
   private remoteChangeLock: boolean;
@@ -99,7 +99,7 @@ export class RichText extends TextElement {
   ): RichText {
     const text = new RichText(rgaTreeSplit, createdAt);
     const range = text.createRange(0, 0);
-    text.editInternal(range, '\n', null, null, createdAt);
+    text.editInternal(range, '\n', undefined, undefined, createdAt);
     return text;
   }
 
@@ -109,11 +109,11 @@ export class RichText extends TextElement {
     content: string,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     attributes?: { [key: string]: string },
-  ): RichText {
+  ): RichText | undefined {
     logger.fatal(
       `unsupported: this method should be called by proxy, ${fromIdx}-${toIdx} ${content}`,
     );
-    return null;
+    return;
   }
 
   public setStyle(
@@ -121,24 +121,24 @@ export class RichText extends TextElement {
     toIdx: number,
     key: string,
     value: string,
-  ): RichText {
+  ): RichText | undefined {
     logger.fatal(
       `unsupported: this method should be called by proxy, ${fromIdx}-${toIdx} ${key} ${value}`,
     );
-    return null;
+    return;
   }
 
   public editInternal(
     range: RGATreeSplitNodeRange,
     content: string,
-    attributes: { [key: string]: string },
-    latestCreatedAtMapByActor: Map<string, TimeTicket>,
+    attributes: { [key: string]: string } | undefined,
+    latestCreatedAtMapByActor: Map<string, TimeTicket> | undefined,
     editedAt: TimeTicket,
   ): Map<string, TimeTicket> {
-    const value = content ? RichTextValue.create(content) : null;
+    const value = content ? RichTextValue.create(content) : undefined;
     if (content && attributes) {
       for (const [k, v] of Object.entries(attributes)) {
-        value.setAttr(k, v, editedAt);
+        value!.setAttr(k, v, editedAt);
       }
     }
 
@@ -313,17 +313,17 @@ export class RichText extends TextElement {
   private updateSelectionInternal(
     range: RGATreeSplitNodeRange,
     updatedAt: TimeTicket,
-  ): Change {
+  ): Change | undefined {
     if (!this.selectionMap.has(updatedAt.getActorID())) {
       this.selectionMap.set(
         updatedAt.getActorID(),
         Selection.of(range, updatedAt),
       );
-      return null;
+      return;
     }
 
     const prevSelection = this.selectionMap.get(updatedAt.getActorID());
-    if (updatedAt.after(prevSelection.getUpdatedAt())) {
+    if (updatedAt.after(prevSelection!.getUpdatedAt())) {
       this.selectionMap.set(
         updatedAt.getActorID(),
         Selection.of(range, updatedAt),

--- a/src/document/json/rich_text.ts
+++ b/src/document/json/rich_text.ts
@@ -109,10 +109,11 @@ export class RichText extends TextElement {
     content: string,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     attributes?: { [key: string]: string },
-  ): RichText | undefined {
+  ): RichText {
     logger.fatal(
       `unsupported: this method should be called by proxy, ${fromIdx}-${toIdx} ${content}`,
     );
+    // @ts-ignore
     return;
   }
 
@@ -121,10 +122,11 @@ export class RichText extends TextElement {
     toIdx: number,
     key: string,
     value: string,
-  ): RichText | undefined {
+  ): RichText {
     logger.fatal(
       `unsupported: this method should be called by proxy, ${fromIdx}-${toIdx} ${key} ${value}`,
     );
+    // @ts-ignore
     return;
   }
 
@@ -195,7 +197,7 @@ export class RichText extends TextElement {
       );
       changes.push({
         type: ChangeType.Style,
-        actor: editedAt.getActorID(),
+        actor: editedAt.getActorID()!,
         from: fromIdx,
         to: toIdx,
         attributes,
@@ -314,25 +316,25 @@ export class RichText extends TextElement {
     range: RGATreeSplitNodeRange,
     updatedAt: TimeTicket,
   ): Change | undefined {
-    if (!this.selectionMap.has(updatedAt.getActorID())) {
+    if (!this.selectionMap.has(updatedAt.getActorID()!)) {
       this.selectionMap.set(
-        updatedAt.getActorID(),
+        updatedAt.getActorID()!,
         Selection.of(range, updatedAt),
       );
       return;
     }
 
-    const prevSelection = this.selectionMap.get(updatedAt.getActorID());
+    const prevSelection = this.selectionMap.get(updatedAt.getActorID()!);
     if (updatedAt.after(prevSelection!.getUpdatedAt())) {
       this.selectionMap.set(
-        updatedAt.getActorID(),
+        updatedAt.getActorID()!,
         Selection.of(range, updatedAt),
       );
 
       const [from, to] = this.rgaTreeSplit.findIndexesFromRange(range);
       return {
         type: ChangeType.Selection,
-        actor: updatedAt.getActorID(),
+        actor: updatedAt.getActorID()!,
         from,
         to,
       };

--- a/src/document/json/root.ts
+++ b/src/document/json/root.ts
@@ -62,7 +62,7 @@ export class JSONRoot {
    * findByCreatedAt returns the element of given creation time.
    */
   public findByCreatedAt(createdAt: TimeTicket): JSONElement {
-    return this.elementMapByCreatedAt.get(createdAt.toIDString());
+    return this.elementMapByCreatedAt.get(createdAt.toIDString())!;
   }
 
   /**
@@ -167,13 +167,13 @@ export class JSONRoot {
     let count = 0;
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const callback = (elem: JSONElement, parent: JSONContainer): boolean => {
+    const callback = (elem: JSONElement, parent?: JSONContainer): boolean => {
       this.deregisterElement(elem);
       count++;
       return false;
     };
 
-    callback(element, null);
+    callback(element, undefined);
 
     if (element instanceof JSONContainer) {
       element.getDescendants(callback);

--- a/src/document/json/root.ts
+++ b/src/document/json/root.ts
@@ -143,7 +143,7 @@ export class JSONRoot {
     for (const [, pair] of this.removedElementPairMapByCreatedAt) {
       if (
         pair.element.getRemovedAt() &&
-        ticket.compare(pair.element.getRemovedAt()) >= 0
+        ticket.compare(pair.element.getRemovedAt()!) >= 0
       ) {
         pair.parent.purge(pair.element);
         count += this._garbageCollect(pair.element);
@@ -173,7 +173,7 @@ export class JSONRoot {
       return false;
     };
 
-    callback(element, undefined);
+    callback(element);
 
     if (element instanceof JSONContainer) {
       element.getDescendants(callback);

--- a/src/document/proxy/array_proxy.ts
+++ b/src/document/proxy/array_proxy.ts
@@ -233,7 +233,7 @@ export class ArrayProxy {
         AddOperation.create(target.getCreatedAt(), prevCreatedAt, obj, ticket),
       );
 
-      for (const [k, v] of Object.entries(value)) {
+      for (const [k, v] of Object.entries(value!)) {
         ObjectProxy.setInternal(context, obj, k, v);
       }
       return obj;

--- a/src/document/proxy/object_proxy.ts
+++ b/src/document/proxy/object_proxy.ts
@@ -157,7 +157,7 @@ export class ObjectProxy {
             ticket,
           ),
         );
-        for (const [k, v] of Object.entries(value)) {
+        for (const [k, v] of Object.entries(value!)) {
           ObjectProxy.setInternal(context, obj, k, v);
         }
       }

--- a/src/document/proxy/proxy.ts
+++ b/src/document/proxy/proxy.ts
@@ -59,7 +59,7 @@ export function toProxy(context: ChangeContext, elem?: JSONElement): any {
     const counter = elem as Counter;
     return CounterProxy.create(context, counter);
   } else if (!elem) {
-    return undefined;
+    return;
   } else {
     throw new TypeError(`Unsupported type of element: ${typeof elem}`);
   }

--- a/src/document/proxy/proxy.ts
+++ b/src/document/proxy/proxy.ts
@@ -39,7 +39,7 @@ export function createProxy(
   return ObjectProxy.create(context, target);
 }
 
-export function toProxy(context: ChangeContext, elem: JSONElement): any {
+export function toProxy(context: ChangeContext, elem?: JSONElement): any {
   if (elem instanceof JSONPrimitive) {
     const primitive = elem as JSONPrimitive;
     return primitive.getValue();
@@ -58,8 +58,8 @@ export function toProxy(context: ChangeContext, elem: JSONElement): any {
   } else if (elem instanceof Counter) {
     const counter = elem as Counter;
     return CounterProxy.create(context, counter);
-  } else if (elem === null) {
-    return null;
+  } else if (!elem) {
+    return undefined;
   } else {
     throw new TypeError(`Unsupported type of element: ${typeof elem}`);
   }

--- a/src/document/proxy/rich_text_proxy.ts
+++ b/src/document/proxy/rich_text_proxy.ts
@@ -110,7 +110,7 @@ export class RichTextProxy {
       range,
       content,
       attributes,
-      null,
+      undefined,
       ticket,
     );
 

--- a/src/document/proxy/text_proxy.ts
+++ b/src/document/proxy/text_proxy.ts
@@ -92,7 +92,7 @@ export class TextProxy {
     const maxCreatedAtMapByActor = target.editInternal(
       range,
       content,
-      null,
+      undefined,
       ticket,
     );
 

--- a/src/document/time/ticket.ts
+++ b/src/document/time/ticket.ts
@@ -25,13 +25,12 @@ export const TicketComparator: Comparator<TimeTicket> = (
   return p1.compare(p2);
 };
 
-// Immutable
 export class TimeTicket {
   private lamport: Long;
   private delimiter: number;
-  private actorID: ActorID;
+  private actorID?: ActorID;
 
-  constructor(lamport: Long, delimiter: number, actorID: string) {
+  constructor(lamport: Long, delimiter: number, actorID?: string) {
     this.lamport = lamport;
     this.delimiter = delimiter;
     this.actorID = actorID;
@@ -40,20 +39,20 @@ export class TimeTicket {
   public static of(
     lamport: Long,
     delimiter: number,
-    actorID: string,
+    actorID?: string,
   ): TimeTicket {
     return new TimeTicket(lamport, delimiter, actorID);
   }
 
   public toIDString(): string {
-    if (this.actorID == null) {
+    if (!this.actorID) {
       return `${this.lamport.toString()}:nil:${this.delimiter}`;
     }
     return `${this.lamport.toString()}:${this.actorID}:${this.delimiter}`;
   }
 
   public getAnnotatedString(): string {
-    if (this.actorID == null) {
+    if (!this.actorID) {
       return `${this.lamport.toString()}:nil:${this.delimiter}`;
     }
     return `${this.lamport.toString()}:${this.actorID.substring(22, 24)}:${
@@ -73,7 +72,7 @@ export class TimeTicket {
     return this.delimiter;
   }
 
-  public getActorID(): string {
+  public getActorID(): string | undefined {
     return this.actorID;
   }
 
@@ -92,7 +91,7 @@ export class TimeTicket {
       return -1;
     }
 
-    const compare = this.actorID.localeCompare(other.actorID);
+    const compare = this.actorID!.localeCompare(other.actorID!);
     if (compare !== 0) {
       return compare;
     }

--- a/src/util/comparator.ts
+++ b/src/util/comparator.ts
@@ -16,7 +16,8 @@
 
 export type Comparator<K> = (keyA: K, keyB: K) => number;
 
-export const DefaultComparator = (a: unknown, b: unknown): number => {
+// eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
+export const DefaultComparator = (a: any, b: any): number => {
   if (a === b) {
     return 0;
   } else if (a < b) {

--- a/src/util/heap.ts
+++ b/src/util/heap.ts
@@ -43,9 +43,9 @@ export class Heap<K, V> {
     this.nodes = [];
   }
 
-  public peek(): HeapNode<K, V> {
+  public peek(): HeapNode<K, V> | undefined {
     if (!this.nodes.length) {
-      return null;
+      return;
     }
 
     return this.nodes[0];
@@ -59,7 +59,7 @@ export class Heap<K, V> {
     const targetIndex = this.nodes.findIndex(
       (_node) => _node.getValue() === node.getValue(),
     );
-    const lastNode = this.nodes.pop();
+    const lastNode = this.nodes.pop()!;
 
     if (targetIndex < 0 || !this.len()) {
       return;
@@ -75,16 +75,16 @@ export class Heap<K, V> {
     this.moveUp(this.nodes.length - 1);
   }
 
-  public pop(): HeapNode<K, V> {
+  public pop(): HeapNode<K, V> | undefined {
     const count = this.nodes.length;
     const head = this.nodes[0];
     if (count <= 0) {
-      return undefined;
+      return;
     } else if (count == 1) {
       // clear array
       this.nodes.length = 0;
     } else {
-      this.nodes[0] = this.nodes.pop();
+      this.nodes[0] = this.nodes.pop()!;
       this.moveDown(0);
     }
 

--- a/src/util/llrb_tree.ts
+++ b/src/util/llrb_tree.ts
@@ -81,13 +81,13 @@ export class LLRBTree<K, V> {
   }
 
   public put(key: K, value: V): V {
-    this.root = this.putInternal(this.root!, key, value);
+    this.root = this.putInternal(this.root, key, value);
     this.root.isRed = false;
     return value;
   }
 
   public get(key: K): V | undefined {
-    const node = this.getInternal(this.root!, key);
+    const node = this.getInternal(this.root, key);
     return node ? node.value : undefined;
   }
 
@@ -145,9 +145,9 @@ export class LLRBTree<K, V> {
     return;
   }
 
-  public lastEntry(): Entry<K, V> {
+  public lastEntry(): Entry<K, V> | undefined {
     if (!this.root) {
-      return this.root!;
+      return this.root;
     }
 
     let node = this.root;
@@ -166,7 +166,7 @@ export class LLRBTree<K, V> {
   }
 
   private getInternal(
-    node: LLRBNode<K, V>,
+    node: LLRBNode<K, V> | undefined,
     key: K,
   ): LLRBNode<K, V> | undefined {
     while (node) {
@@ -183,7 +183,11 @@ export class LLRBTree<K, V> {
     return;
   }
 
-  private putInternal(node: LLRBNode<K, V>, key: K, value: V): LLRBNode<K, V> {
+  private putInternal(
+    node: LLRBNode<K, V> | undefined,
+    key: K,
+    value: V,
+  ): LLRBNode<K, V> {
     if (!node) {
       this.counter += 1;
       return new LLRBNode(key, value, true);
@@ -191,9 +195,9 @@ export class LLRBTree<K, V> {
 
     const compare = this.comparator(key, node.key);
     if (compare < 0) {
-      node.left = this.putInternal(node.left!, key, value);
+      node.left = this.putInternal(node.left, key, value);
     } else if (compare > 0) {
-      node.right = this.putInternal(node.right!, key, value);
+      node.right = this.putInternal(node.right, key, value);
     } else {
       node.value = value;
     }

--- a/src/util/llrb_tree.ts
+++ b/src/util/llrb_tree.ts
@@ -24,17 +24,15 @@ interface Entry<K, V> {
 class LLRBNode<K, V> {
   public key: K;
   public value: V;
-  public parent: LLRBNode<K, V>;
-  public left: LLRBNode<K, V>;
-  public right: LLRBNode<K, V>;
+  public parent?: LLRBNode<K, V>;
+  public left?: LLRBNode<K, V>;
+  public right?: LLRBNode<K, V>;
   public isRed: boolean;
 
   constructor(key: K, value: V, isRed: boolean) {
     this.key = key;
     this.value = value;
     this.isRed = isRed;
-    this.left;
-    this.right;
   }
 }
 
@@ -52,12 +50,12 @@ export class SortedMapIterator<K, V> {
       return;
     }
 
-    this.traverseInorder(node.left);
+    this.traverseInorder(node.left!);
     this.stack.push({
       key: node.key,
       value: node.value,
     });
-    this.traverseInorder(node.right);
+    this.traverseInorder(node.right!);
   }
 }
 
@@ -72,41 +70,40 @@ export class SortedMapIterator<K, V> {
  * Invariant 3: Only the left child can be red (left leaning)
  */
 export class LLRBTree<K, V> {
-  private root: LLRBNode<K, V>;
+  private root?: LLRBNode<K, V>;
   private comparator: Comparator<K>;
   private counter: number;
 
   constructor(comparator?: Comparator<K>) {
-    this.root = null;
     this.comparator =
       typeof comparator !== 'undefined' ? comparator : DefaultComparator;
     this.counter = 0;
   }
 
   public put(key: K, value: V): V {
-    this.root = this.putInternal(this.root, key, value);
+    this.root = this.putInternal(this.root!, key, value);
     this.root.isRed = false;
     return value;
   }
 
-  public get(key: K): V {
-    const node = this.getInternal(this.root, key);
-    return node ? node.value : null;
+  public get(key: K): V | undefined {
+    const node = this.getInternal(this.root!, key);
+    return node ? node.value : undefined;
   }
 
   public remove(key: K): void {
-    if (!this.isRed(this.root.left) && !this.isRed(this.root.right)) {
-      this.root.isRed = true;
+    if (!this.isRed(this.root!.left!) && !this.isRed(this.root!.right!)) {
+      this.root!.isRed = true;
     }
 
-    this.root = this.removeInternal(this.root, key);
+    this.root = this.removeInternal(this.root!, key);
     if (this.root) {
       this.root.isRed = false;
     }
   }
 
   public getIterator(): SortedMapIterator<K, V> {
-    return new SortedMapIterator(this.root);
+    return new SortedMapIterator(this.root!);
   }
 
   public values(): Array<V> {
@@ -117,7 +114,7 @@ export class LLRBTree<K, V> {
     return values;
   }
 
-  public floorEntry(key: K): Entry<K, V> {
+  public floorEntry(key: K): Entry<K, V> | undefined {
     let node = this.root;
     while (node) {
       const compare = this.comparator(key, node.key);
@@ -139,18 +136,18 @@ export class LLRBTree<K, V> {
             childNode = parent;
             parent = parent.parent;
           }
-          return parent;
+          return parent!;
         }
       } else {
         return node;
       }
     }
-    return null;
+    return;
   }
 
   public lastEntry(): Entry<K, V> {
     if (!this.root) {
-      return this.root;
+      return this.root!;
     }
 
     let node = this.root;
@@ -168,19 +165,22 @@ export class LLRBTree<K, V> {
     return this.counter === 0;
   }
 
-  private getInternal(node: LLRBNode<K, V>, key: K): LLRBNode<K, V> {
+  private getInternal(
+    node: LLRBNode<K, V>,
+    key: K,
+  ): LLRBNode<K, V> | undefined {
     while (node) {
       const compare = this.comparator(key, node.key);
       if (compare === 0) {
         return node;
       } else if (compare < 0) {
-        node = node.left;
+        node = node.left!;
       } else if (compare > 0) {
-        node = node.right;
+        node = node.right!;
       }
     }
 
-    return null;
+    return;
   }
 
   private putInternal(node: LLRBNode<K, V>, key: K, value: V): LLRBNode<K, V> {
@@ -191,56 +191,59 @@ export class LLRBTree<K, V> {
 
     const compare = this.comparator(key, node.key);
     if (compare < 0) {
-      node.left = this.putInternal(node.left, key, value);
+      node.left = this.putInternal(node.left!, key, value);
     } else if (compare > 0) {
-      node.right = this.putInternal(node.right, key, value);
+      node.right = this.putInternal(node.right!, key, value);
     } else {
       node.value = value;
     }
 
-    if (this.isRed(node.right) && !this.isRed(node.left)) {
+    if (this.isRed(node.right!) && !this.isRed(node.left!)) {
       node = this.rotateLeft(node);
     }
 
-    if (this.isRed(node.left) && this.isRed(node.left.left)) {
+    if (this.isRed(node.left!) && this.isRed(node.left!.left!)) {
       node = this.rotateRight(node);
     }
 
-    if (this.isRed(node.left) && this.isRed(node.right)) {
+    if (this.isRed(node.left!) && this.isRed(node.right!)) {
       this.flipColors(node);
     }
 
     return node;
   }
 
-  private removeInternal(node: LLRBNode<K, V>, key: K): LLRBNode<K, V> {
+  private removeInternal(
+    node: LLRBNode<K, V>,
+    key: K,
+  ): LLRBNode<K, V> | undefined {
     if (this.comparator(key, node.key) < 0) {
-      if (!this.isRed(node.left) && !this.isRed(node.left.left)) {
+      if (!this.isRed(node.left!) && !this.isRed(node.left!.left!)) {
         node = this.moveRedLeft(node);
       }
-      node.left = this.removeInternal(node.left, key);
+      node.left = this.removeInternal(node.left!, key);
     } else {
-      if (this.isRed(node.left)) {
+      if (this.isRed(node.left!)) {
         node = this.rotateRight(node);
       }
 
       if (this.comparator(key, node.key) === 0 && !node.right) {
         this.counter -= 1;
-        return null;
+        return;
       }
 
-      if (!this.isRed(node.right) && !this.isRed(node.right.left)) {
+      if (!this.isRed(node.right!) && !this.isRed(node.right!.left!)) {
         node = this.moveRedRight(node);
       }
 
       if (this.comparator(key, node.key) === 0) {
         this.counter -= 1;
-        const smallest = this.min(node.right);
+        const smallest = this.min(node.right!);
         node.value = smallest.value;
         node.key = smallest.key;
-        node.right = this.removeMin(node.right);
+        node.right = this.removeMin(node.right!);
       } else {
-        node.right = this.removeInternal(node.right, key);
+        node.right = this.removeInternal(node.right!, key);
       }
     }
 
@@ -255,29 +258,29 @@ export class LLRBTree<K, V> {
     }
   }
 
-  private removeMin(node: LLRBNode<K, V>): LLRBNode<K, V> {
+  private removeMin(node: LLRBNode<K, V>): LLRBNode<K, V> | undefined {
     if (!node.left) {
-      return null;
+      return;
     }
 
-    if (!this.isRed(node.left) && !this.isRed(node.left.left)) {
+    if (!this.isRed(node.left) && !this.isRed(node.left!.left!)) {
       node = this.moveRedLeft(node);
     }
 
-    node.left = this.removeMin(node.left);
+    node.left = this.removeMin(node.left!);
     return this.fixUp(node);
   }
 
   private fixUp(node: LLRBNode<K, V>): LLRBNode<K, V> {
-    if (this.isRed(node.right)) {
+    if (this.isRed(node.right!)) {
       node = this.rotateLeft(node);
     }
 
-    if (this.isRed(node.left) && this.isRed(node.left.left)) {
+    if (this.isRed(node.left!) && this.isRed(node.left!.left!)) {
       node = this.rotateRight(node);
     }
 
-    if (this.isRed(node.left) && this.isRed(node.right)) {
+    if (this.isRed(node.left!) && this.isRed(node.right!)) {
       this.flipColors(node);
     }
 
@@ -286,8 +289,8 @@ export class LLRBTree<K, V> {
 
   private moveRedLeft(node: LLRBNode<K, V>): LLRBNode<K, V> {
     this.flipColors(node);
-    if (this.isRed(node.right.left)) {
-      node.right = this.rotateRight(node.right);
+    if (this.isRed(node.right!.left!)) {
+      node.right = this.rotateRight(node.right!);
       node = this.rotateLeft(node);
       this.flipColors(node);
     }
@@ -296,7 +299,7 @@ export class LLRBTree<K, V> {
 
   private moveRedRight(node: LLRBNode<K, V>): LLRBNode<K, V> {
     this.flipColors(node);
-    if (this.isRed(node.left.left)) {
+    if (this.isRed(node.left!.left!)) {
       node = this.rotateRight(node);
       this.flipColors(node);
     }
@@ -308,7 +311,7 @@ export class LLRBTree<K, V> {
   }
 
   private rotateLeft(node: LLRBNode<K, V>): LLRBNode<K, V> {
-    const x = node.right;
+    const x = node.right!;
     node.right = x.left;
     x.left = node;
     x.isRed = x.left.isRed;
@@ -317,7 +320,7 @@ export class LLRBTree<K, V> {
   }
 
   private rotateRight(node: LLRBNode<K, V>): LLRBNode<K, V> {
-    const x = node.left;
+    const x = node.left!;
     node.left = x.right;
     x.right = node;
     x.isRed = x.right.isRed;
@@ -326,8 +329,8 @@ export class LLRBTree<K, V> {
   }
 
   private flipColors(node: LLRBNode<K, V>): void {
-    node.isRed = !node.isRed;
-    node.left.isRed = !node.left.isRed;
-    node.right.isRed = !node.right.isRed;
+    node.isRed = !node.isRed!;
+    node.left!.isRed = !node.left!.isRed;
+    node.right!.isRed = !node.right!.isRed;
   }
 }

--- a/src/util/observable.ts
+++ b/src/util/observable.ts
@@ -45,7 +45,7 @@ class ObserverProxy<T> implements Observer<T> {
   private unsubscribes: Unsubscribe[] = [];
   private observerCount = 0;
   private task = Promise.resolve();
-  private finalError: Error;
+  private finalError?: Error;
 
   constructor(executor: Executor<T>, onNoObservers?: Executor<T>) {
     this.onNoObservers = onNoObservers;
@@ -60,26 +60,26 @@ class ObserverProxy<T> implements Observer<T> {
 
   public next(value: T): void {
     this.forEachObserver((observer: Observer<T>) => {
-      observer.next(value);
+      observer.next!(value);
     });
   }
 
   public error(error: Error): void {
     this.forEachObserver((observer: Observer<T>) => {
-      observer.error(error);
+      observer.error!(error);
     });
     this.close(error);
   }
 
   public complete(): void {
     this.forEachObserver((observer: Observer<T>) => {
-      observer.complete();
+      observer.complete!();
     });
     this.close();
   }
 
   public subscribe(
-    nextOrObserver: Observer<T> | NextFn<T>,
+    nextOrObserver?: Observer<T> | NextFn<T>,
     error?: ErrorFn,
     complete?: CompleteFn,
   ): Unsubscribe {
@@ -119,9 +119,9 @@ class ObserverProxy<T> implements Observer<T> {
       this.task.then(() => {
         try {
           if (this.finalError) {
-            observer.error(this.finalError);
+            observer.error!(this.finalError);
           } else {
-            observer.complete();
+            observer.complete!();
           }
         } catch (err) {
           // nothing

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -149,7 +149,7 @@ export class SplayTree<V> {
 
     let index = 0;
     let current: SplayNode<V> | undefined = node;
-    let prev = null;
+    let prev: SplayNode<V> | undefined;
     while (current) {
       if (!prev || prev === current.getRight()) {
         index +=

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -22,7 +22,7 @@ export abstract class SplayNode<V> {
   private left?: SplayNode<V>;
   private right?: SplayNode<V>;
   private parent?: SplayNode<V>;
-  private weight?: number;
+  private weight!: number;
 
   constructor(value: V) {
     this.value = value;
@@ -48,15 +48,15 @@ export abstract class SplayNode<V> {
   }
 
   public getWeight(): number {
-    return this.weight!;
+    return this.weight;
   }
 
-  public getLeft(): SplayNode<V> {
-    return this.left!;
+  public getLeft(): SplayNode<V> | undefined {
+    return this.left;
   }
 
-  public getRight(): SplayNode<V> {
-    return this.right!;
+  public getRight(): SplayNode<V> | undefined {
+    return this.right;
   }
 
   public setRight(right?: SplayNode<V>): void {
@@ -79,12 +79,12 @@ export abstract class SplayNode<V> {
     this.parent = parent;
   }
 
-  public setLeft(left: SplayNode<V>): void {
+  public setLeft(left?: SplayNode<V>): void {
     this.left = left;
   }
 
-  public getParent(): SplayNode<V> {
-    return this.parent!;
+  public getParent(): SplayNode<V> | undefined {
+    return this.parent;
   }
 
   public increaseWeight(weight: number): void {
@@ -116,13 +116,13 @@ export class SplayTree<V> {
     let node = this.root;
     for (;;) {
       if (node.hasLeft() && pos <= node.getLeftWeight()) {
-        node = node.getLeft();
+        node = node.getLeft()!;
       } else if (
         node.hasRight() &&
         node.getLeftWeight() + node.getLength() < pos
       ) {
         pos -= node.getLeftWeight() + node.getLength();
-        node = node.getRight();
+        node = node.getRight()!;
       } else {
         pos -= node.getLeftWeight();
         break;
@@ -148,7 +148,7 @@ export class SplayTree<V> {
     }
 
     let index = 0;
-    let current = node;
+    let current: SplayNode<V> | undefined = node;
     let prev = null;
     while (current) {
       if (!prev || prev === current.getRight()) {
@@ -183,11 +183,11 @@ export class SplayTree<V> {
     this.root = newNode;
     newNode.setRight(target.getRight());
     if (target.hasRight()) {
-      target.getRight().setParent(newNode);
+      target.getRight()!.setParent(newNode);
     }
     newNode.setLeft(target);
     target.setParent(newNode);
-    target.setRight(undefined);
+    target.setRight();
     this.updateSubtree(target);
     this.updateSubtree(newNode);
 
@@ -224,14 +224,14 @@ export class SplayTree<V> {
         this.rotateLeft(node);
       } else if (this.isLeftChild(node.getParent()) && this.isLeftChild(node)) {
         // zig-zig
-        this.rotateRight(node.getParent());
+        this.rotateRight(node.getParent()!);
         this.rotateRight(node);
       } else if (
         this.isRightChild(node.getParent()) &&
         this.isRightChild(node)
       ) {
         // zig-zig
-        this.rotateLeft(node.getParent());
+        this.rotateLeft(node.getParent()!);
         this.rotateLeft(node);
       } else {
         // zig
@@ -250,12 +250,12 @@ export class SplayTree<V> {
 
     const leftTree = new SplayTree(node.getLeft());
     if (leftTree.root) {
-      leftTree.root.setParent(undefined);
+      leftTree.root.setParent();
     }
 
     const rightTree = new SplayTree(node.getRight());
     if (rightTree.root) {
-      rightTree.root.setParent(undefined);
+      rightTree.root.setParent();
     }
 
     if (leftTree.root) {
@@ -281,13 +281,13 @@ export class SplayTree<V> {
   private getMaximum(): SplayNode<V> {
     let node = this.root!;
     while (node.hasRight()) {
-      node = node.getRight();
+      node = node.getRight()!;
     }
     return node;
   }
 
   private traverseInorder(
-    node: SplayNode<V>,
+    node: SplayNode<V> | undefined,
     stack: Array<SplayNode<V>>,
   ): void {
     if (!node) {
@@ -300,12 +300,12 @@ export class SplayTree<V> {
   }
 
   private rotateLeft(pivot: SplayNode<V>): void {
-    const root = pivot.getParent();
+    const root = pivot.getParent()!;
     if (root.hasParent()) {
-      if (root === root.getParent().getLeft()) {
-        root.getParent().setLeft(pivot);
+      if (root === root.getParent()!.getLeft()) {
+        root.getParent()!.setLeft(pivot);
       } else {
-        root.getParent().setRight(pivot);
+        root.getParent()!.setRight(pivot);
       }
     } else {
       this.root = pivot;
@@ -314,23 +314,23 @@ export class SplayTree<V> {
 
     root.setRight(pivot.getLeft());
     if (root.hasRight()) {
-      root.getRight().setParent(root);
+      root.getRight()!.setParent(root);
     }
 
     pivot.setLeft(root);
-    pivot.getLeft().setParent(pivot);
+    pivot.getLeft()!.setParent(pivot);
 
     this.updateSubtree(root);
     this.updateSubtree(pivot);
   }
 
   private rotateRight(pivot: SplayNode<V>): void {
-    const root = pivot.getParent();
+    const root = pivot.getParent()!;
     if (root.hasParent()) {
-      if (root === root.getParent().getLeft()) {
-        root.getParent().setLeft(pivot);
+      if (root === root.getParent()!.getLeft()) {
+        root.getParent()!.setLeft(pivot);
       } else {
-        root.getParent().setRight(pivot);
+        root.getParent()!.setRight(pivot);
       }
     } else {
       this.root = pivot;
@@ -339,21 +339,27 @@ export class SplayTree<V> {
 
     root.setLeft(pivot.getRight());
     if (root.hasLeft()) {
-      root.getLeft().setParent(root);
+      root.getLeft()!.setParent(root);
     }
 
     pivot.setRight(root);
-    pivot.getRight().setParent(pivot);
+    pivot.getRight()!.setParent(pivot);
 
     this.updateSubtree(root);
     this.updateSubtree(pivot);
   }
 
-  private isLeftChild(node: SplayNode<V>): boolean {
-    return node && node.hasParent() && node.getParent().getLeft() === node;
+  private isLeftChild(node?: SplayNode<V>): boolean {
+    if (node && node.hasParent()) {
+      return node.getParent()!.getLeft() === node;
+    }
+    return false;
   }
 
-  private isRightChild(node: SplayNode<V>): boolean {
-    return node && node.hasParent() && node.getParent().getRight() === node;
+  private isRightChild(node?: SplayNode<V>): boolean {
+    if (node && node.hasParent()) {
+      return node.getParent()!.getRight() === node;
+    }
+    return false;
   }
 }

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -19,10 +19,10 @@ import { logger } from './logger';
 export abstract class SplayNode<V> {
   protected value: V;
 
-  private left: SplayNode<V>;
-  private right: SplayNode<V>;
-  private parent: SplayNode<V>;
-  private weight: number;
+  private left?: SplayNode<V>;
+  private right?: SplayNode<V>;
+  private parent?: SplayNode<V>;
+  private weight?: number;
 
   constructor(value: V) {
     this.value = value;
@@ -40,26 +40,26 @@ export abstract class SplayNode<V> {
   }
 
   public getLeftWeight(): number {
-    return !this.hasLeft() ? 0 : this.left.getWeight();
+    return !this.hasLeft() ? 0 : this.left!.getWeight();
   }
 
   public getRightWeight(): number {
-    return !this.hasRight() ? 0 : this.right.getWeight();
+    return !this.hasRight() ? 0 : this.right!.getWeight();
   }
 
   public getWeight(): number {
-    return this.weight;
+    return this.weight!;
   }
 
   public getLeft(): SplayNode<V> {
-    return this.left;
+    return this.left!;
   }
 
   public getRight(): SplayNode<V> {
-    return this.right;
+    return this.right!;
   }
 
-  public setRight(right: SplayNode<V>): void {
+  public setRight(right?: SplayNode<V>): void {
     this.right = right;
   }
 
@@ -75,7 +75,7 @@ export abstract class SplayNode<V> {
     return !!this.parent;
   }
 
-  public setParent(parent: SplayNode<V>): void {
+  public setParent(parent?: SplayNode<V>): void {
     this.parent = parent;
   }
 
@@ -84,11 +84,11 @@ export abstract class SplayNode<V> {
   }
 
   public getParent(): SplayNode<V> {
-    return this.parent;
+    return this.parent!;
   }
 
   public increaseWeight(weight: number): void {
-    this.weight += weight;
+    this.weight! += weight;
   }
 
   public initWeight(): void {
@@ -102,15 +102,15 @@ export abstract class SplayNode<V> {
  *  - https://www.cs.cmu.edu/~sleator/papers/self-adjusting.pdf
  */
 export class SplayTree<V> {
-  private root: SplayNode<V>;
+  private root?: SplayNode<V>;
 
   constructor(root?: SplayNode<V>) {
     this.root = root;
   }
 
-  public find(pos: number): [SplayNode<V>, number] {
+  public find(pos: number): [SplayNode<V> | undefined, number] {
     if (!this.root) {
-      return [null, 0];
+      return [undefined, 0];
     }
 
     let node = this.root;
@@ -163,11 +163,11 @@ export class SplayTree<V> {
   }
 
   public getRoot(): SplayNode<V> {
-    return this.root;
+    return this.root!;
   }
 
   public insert(newNode: SplayNode<V>): SplayNode<V> {
-    return this.insertAfter(this.root, newNode);
+    return this.insertAfter(this.root!, newNode);
   }
 
   public insertAfter(
@@ -187,7 +187,7 @@ export class SplayTree<V> {
     }
     newNode.setLeft(target);
     target.setParent(newNode);
-    target.setRight(null);
+    target.setRight(undefined);
     this.updateSubtree(target);
     this.updateSubtree(newNode);
 
@@ -250,12 +250,12 @@ export class SplayTree<V> {
 
     const leftTree = new SplayTree(node.getLeft());
     if (leftTree.root) {
-      leftTree.root.setParent(null);
+      leftTree.root.setParent(undefined);
     }
 
     const rightTree = new SplayTree(node.getRight());
     if (rightTree.root) {
-      rightTree.root.setParent(null);
+      rightTree.root.setParent(undefined);
     }
 
     if (leftTree.root) {
@@ -270,7 +270,7 @@ export class SplayTree<V> {
 
   public getAnnotatedString(): string {
     const metaString: Array<SplayNode<V>> = [];
-    this.traverseInorder(this.root, metaString);
+    this.traverseInorder(this.root!, metaString);
     return metaString
       .map(
         (node) => `[${node.getWeight()},${node.getLength()}]${node.getValue()}`,
@@ -279,7 +279,7 @@ export class SplayTree<V> {
   }
 
   private getMaximum(): SplayNode<V> {
-    let node = this.root;
+    let node = this.root!;
     while (node.hasRight()) {
       node = node.getRight();
     }

--- a/test/api/converter_test.ts
+++ b/test/api/converter_test.ts
@@ -17,6 +17,8 @@
 import { assert } from 'chai';
 import { Document } from '../../src/document/document';
 import { converter } from '../../src/api/converter';
+import { PlainText } from '../../src/document/json/plain_text';
+import { CounterProxy } from '../../src/document/proxy/counter_proxy';
 
 describe('Converter', function () {
   it('should encode/decode bytes', function () {
@@ -43,7 +45,7 @@ describe('Converter', function () {
         // new Date(),
       ];
 
-      const text = root.createText('k3');
+      const text = root.createText('k3') as PlainText;
       text.edit(0, 0, 'ㅎ');
       text.edit(0, 1, '하');
       text.edit(0, 1, '한');
@@ -51,7 +53,7 @@ describe('Converter', function () {
       text.edit(1, 1, '느');
       text.edit(1, 2, '늘');
 
-      const counter = root.createCounter('k4', 0);
+      const counter = root.createCounter('k4', 0) as CounterProxy;
       counter.increase(1).increase(2).increase(3);
     });
 

--- a/test/api/converter_test.ts
+++ b/test/api/converter_test.ts
@@ -17,8 +17,6 @@
 import { assert } from 'chai';
 import { Document } from '../../src/document/document';
 import { converter } from '../../src/api/converter';
-import { PlainText } from '../../src/document/json/plain_text';
-import { CounterProxy } from '../../src/document/proxy/counter_proxy';
 
 describe('Converter', function () {
   it('should encode/decode bytes', function () {
@@ -45,7 +43,7 @@ describe('Converter', function () {
         // new Date(),
       ];
 
-      const text = root.createText('k3') as PlainText;
+      const text = root.createText('k3');
       text.edit(0, 0, 'ㅎ');
       text.edit(0, 1, '하');
       text.edit(0, 1, '한');
@@ -53,7 +51,7 @@ describe('Converter', function () {
       text.edit(1, 1, '느');
       text.edit(1, 2, '늘');
 
-      const counter = root.createCounter('k4', 0) as CounterProxy;
+      const counter = root.createCounter('k4', 0);
       counter.increase(1).increase(2).increase(3);
     });
 

--- a/test/document/document_test.ts
+++ b/test/document/document_test.ts
@@ -20,6 +20,8 @@ import { InitialCheckpoint } from '../../src/document/checkpoint/checkpoint';
 import { MaxTimeTicket } from '../../src/document/time/ticket';
 import { JSONElement } from '../../src/document/json/element';
 import { JSONArray } from '../../src/document/json/array';
+import { PlainText } from '../../src/document/json/plain_text';
+import { RichText } from '../../src/document/json/rich_text';
 
 describe('Document', function () {
   it('should apply updates of string', function () {
@@ -126,7 +128,7 @@ describe('Document', function () {
     //           |            |      |
     // [init] - [A] - [12] - {BC} - [D]
     doc.update((root) => {
-      const text = root.createText('k1');
+      const text = root.createText('k1') as PlainText;
       text.edit(0, 0, 'ABCD');
       text.edit(1, 3, '12');
     }, 'set {"k1":"A12D"}');
@@ -161,7 +163,7 @@ describe('Document', function () {
     assert.equal('{}', doc.toSortedJSON());
 
     doc.update((root) => {
-      const text = root.createRichText('k1');
+      const text = root.createRichText('k1') as RichText;
       text.edit(0, 0, 'ABCD', { b: '1' });
       text.edit(3, 3, '\n');
     }, 'set {"k1":"ABC\nD"}');
@@ -187,7 +189,7 @@ describe('Document', function () {
     //           |              |
     // [init] - [ABC] - [\n] - [D]
     doc.update((root) => {
-      const text = root.createText('k1');
+      const text = root.createText('k1') as PlainText;
       text.edit(0, 0, 'ABCD');
       text.edit(3, 3, '\n');
     }, 'set {"k1":"ABC\nD"}');
@@ -207,7 +209,7 @@ describe('Document', function () {
     assert.equal('{}', doc.toSortedJSON());
 
     doc.update((root) => {
-      const text = root.createText('k1');
+      const text = root.createText('k1') as PlainText;
       text.edit(0, 0, 'ㅎ');
       text.edit(0, 1, '하');
       text.edit(0, 1, '한');
@@ -352,7 +354,7 @@ describe('Document', function () {
 
     let expected_msg = '{"k1":"Hello mario"}';
     doc.update((root) => {
-      const text = root.createText('k1');
+      const text = root.createText('k1') as PlainText;
       text.edit(0, 0, 'Hello world');
       text.edit(6, 11, 'mario');
       assert.equal(expected_msg, root.toJSON());
@@ -386,7 +388,7 @@ describe('Document', function () {
     let expected_msg =
       '{"k1":[{"attrs":{"b":"1"},"content":Hello },{"attrs":{},"content":mario},{"attrs":{},"content":\n}]}';
     doc.update((root) => {
-      const text = root.createRichText('k1');
+      const text = root.createRichText('k1') as RichText;
       text.edit(0, 0, 'Hello world', { b: '1' });
       text.edit(6, 11, 'mario');
       assert.equal(expected_msg, root.toJSON());
@@ -421,7 +423,7 @@ describe('Document', function () {
 
     // 01. initial
     doc.update((root) => {
-      const text = root.createText('k1');
+      const text = root.createText('k1') as PlainText;
       for (let i = 0; i < size; i++) {
         text.edit(i, i, 'a');
       }
@@ -450,7 +452,7 @@ describe('Document', function () {
 
     // 01. long text by one node
     doc.update((root) => {
-      const text = root.createText('k1');
+      const text = root.createText('k1') as PlainText;
       let str = '';
       for (let i = 0; i < size; i++) {
         str += 'a';

--- a/test/document/document_test.ts
+++ b/test/document/document_test.ts
@@ -400,7 +400,7 @@ describe('Document', function () {
     doc.update((root) => {
       const text = root['k1'];
       text.edit(0, 5, 'Hi', { b: '1' });
-      text.edit(3, 4, 'j', null);
+      text.edit(3, 4, 'j');
       text.edit(4, 8, 'ane', { b: '1' });
       assert.equal(expected_msg, root.toJSON());
     }, 'edit rich text k1');

--- a/test/document/document_test.ts
+++ b/test/document/document_test.ts
@@ -20,8 +20,6 @@ import { InitialCheckpoint } from '../../src/document/checkpoint/checkpoint';
 import { MaxTimeTicket } from '../../src/document/time/ticket';
 import { JSONElement } from '../../src/document/json/element';
 import { JSONArray } from '../../src/document/json/array';
-import { PlainText } from '../../src/document/json/plain_text';
-import { RichText } from '../../src/document/json/rich_text';
 
 describe('Document', function () {
   it('should apply updates of string', function () {
@@ -128,7 +126,7 @@ describe('Document', function () {
     //           |            |      |
     // [init] - [A] - [12] - {BC} - [D]
     doc.update((root) => {
-      const text = root.createText('k1') as PlainText;
+      const text = root.createText('k1');
       text.edit(0, 0, 'ABCD');
       text.edit(1, 3, '12');
     }, 'set {"k1":"A12D"}');
@@ -163,7 +161,7 @@ describe('Document', function () {
     assert.equal('{}', doc.toSortedJSON());
 
     doc.update((root) => {
-      const text = root.createRichText('k1') as RichText;
+      const text = root.createRichText('k1');
       text.edit(0, 0, 'ABCD', { b: '1' });
       text.edit(3, 3, '\n');
     }, 'set {"k1":"ABC\nD"}');
@@ -189,7 +187,7 @@ describe('Document', function () {
     //           |              |
     // [init] - [ABC] - [\n] - [D]
     doc.update((root) => {
-      const text = root.createText('k1') as PlainText;
+      const text = root.createText('k1');
       text.edit(0, 0, 'ABCD');
       text.edit(3, 3, '\n');
     }, 'set {"k1":"ABC\nD"}');
@@ -209,7 +207,7 @@ describe('Document', function () {
     assert.equal('{}', doc.toSortedJSON());
 
     doc.update((root) => {
-      const text = root.createText('k1') as PlainText;
+      const text = root.createText('k1');
       text.edit(0, 0, 'ㅎ');
       text.edit(0, 1, '하');
       text.edit(0, 1, '한');
@@ -354,7 +352,7 @@ describe('Document', function () {
 
     let expected_msg = '{"k1":"Hello mario"}';
     doc.update((root) => {
-      const text = root.createText('k1') as PlainText;
+      const text = root.createText('k1');
       text.edit(0, 0, 'Hello world');
       text.edit(6, 11, 'mario');
       assert.equal(expected_msg, root.toJSON());
@@ -388,7 +386,7 @@ describe('Document', function () {
     let expected_msg =
       '{"k1":[{"attrs":{"b":"1"},"content":Hello },{"attrs":{},"content":mario},{"attrs":{},"content":\n}]}';
     doc.update((root) => {
-      const text = root.createRichText('k1') as RichText;
+      const text = root.createRichText('k1');
       text.edit(0, 0, 'Hello world', { b: '1' });
       text.edit(6, 11, 'mario');
       assert.equal(expected_msg, root.toJSON());
@@ -423,7 +421,7 @@ describe('Document', function () {
 
     // 01. initial
     doc.update((root) => {
-      const text = root.createText('k1') as PlainText;
+      const text = root.createText('k1');
       for (let i = 0; i < size; i++) {
         text.edit(i, i, 'a');
       }
@@ -452,7 +450,7 @@ describe('Document', function () {
 
     // 01. long text by one node
     doc.update((root) => {
-      const text = root.createText('k1') as PlainText;
+      const text = root.createText('k1');
       let str = '';
       for (let i = 0; i < size; i++) {
         str += 'a';

--- a/test/document/json/rht_test.ts
+++ b/test/document/json/rht_test.ts
@@ -36,10 +36,10 @@ describe('RHT', function () {
     assert.equal(actualValue, testValue);
 
     const notExistsValue = rht.get(notExistsKey);
-    assert.equal(notExistsValue, null);
+    assert.equal(notExistsValue, undefined);
   });
 
-  it('should return null when a key does not exist', function () {
+  it('should return undefined when a key does not exist', function () {
     const notExistsKey = 'not-exists-key';
 
     const rht = RHT.create();
@@ -48,7 +48,7 @@ describe('RHT', function () {
     assert.equal(rht.toJSON(), '{}');
 
     const notExistsValue = rht.get(notExistsKey);
-    assert.equal(notExistsValue, null);
+    assert.equal(notExistsValue, undefined);
   });
 
   it('should check if a key exists', function () {

--- a/test/util/heap_test.ts
+++ b/test/util/heap_test.ts
@@ -27,7 +27,7 @@ describe('Heap', function () {
     }
 
     for (const idx of range(0, 10).reverse()) {
-      assert.equal(idx, heap.pop().getValue());
+      assert.equal(idx, heap.pop()!.getValue());
     }
   });
 

--- a/test/util/llrb_tree_test.ts
+++ b/test/util/llrb_tree_test.ts
@@ -55,13 +55,13 @@ describe('LLRBTree', function () {
         tree.put(idx, idx);
       }
 
-      assert.equal(8, tree.floorEntry(8).value);
+      assert.equal(8, tree.floorEntry(8)!.value);
 
       tree.remove(8);
-      assert.equal(7, tree.floorEntry(8).value);
+      assert.equal(7, tree.floorEntry(8)!.value);
 
       tree.remove(7);
-      assert.equal(6, tree.floorEntry(8).value);
+      assert.equal(6, tree.floorEntry(8)!.value);
     }
   });
 });

--- a/test/yorkie_test.ts
+++ b/test/yorkie_test.ts
@@ -26,8 +26,6 @@ import {
 import { Document, DocEvent, DocEventType } from '../src/document/document';
 import { JSONElement } from '../src/document/json/element';
 import yorkie from '../src/yorkie';
-import { PlainText } from '../src/document/json/plain_text';
-import { RichText } from '../src/document/json/rich_text';
 
 const __karma__ = (global as any).__karma__;
 const testRPCAddr = __karma__.config.testRPCAddr || 'http://localhost:8080';
@@ -385,7 +383,7 @@ describe('Yorkie', function () {
     await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root.createText('k1');
-        (root['k1'] as PlainText).edit(0, 0, 'ABCD');
+        root['k1'].edit(0, 0, 'ABCD');
       }, 'set new text by c1');
       await c1.sync();
       await c2.sync();
@@ -394,7 +392,7 @@ describe('Yorkie', function () {
 
       d1.update((root) => {
         root.createText('k1');
-        (root['k1'] as PlainText).edit(0, 0, '1234');
+        root['k1'].edit(0, 0, '1234');
       }, 'edit 0,0 1234 by c1');
       await c1.sync();
       await c2.sync();
@@ -415,11 +413,11 @@ describe('Yorkie', function () {
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
       d1.update((root) => {
-        (root['k1'] as PlainText).edit(0, 0, 'ABCD');
+        root['k1'].edit(0, 0, 'ABCD');
       }, 'edit 0,0 ABCD by c1');
       assert.equal(d1.toSortedJSON(), `{"k1":"ABCD"}`);
       d2.update((root) => {
-        (root['k1'] as PlainText).edit(0, 0, '1234');
+        root['k1'].edit(0, 0, '1234');
       }, 'edit 0,0 1234 by c2');
       assert.equal(d2.toSortedJSON(), `{"k1":"1234"}`);
       await c1.sync();
@@ -428,10 +426,10 @@ describe('Yorkie', function () {
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
       d1.update((root) => {
-        (root['k1'] as PlainText).edit(2, 3, 'XX');
+        root['k1'].edit(2, 3, 'XX');
       }, 'edit 2,3 XX by c1');
       d2.update((root) => {
-        (root['k1'] as PlainText).edit(2, 3, 'YY');
+        root['k1'].edit(2, 3, 'YY');
       }, 'edit 2,3 YY by c1');
       await c1.sync();
       await c2.sync();
@@ -439,10 +437,10 @@ describe('Yorkie', function () {
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
       d1.update((root) => {
-        (root['k1'] as PlainText).edit(4, 5, 'ZZ');
+        root['k1'].edit(4, 5, 'ZZ');
       }, 'edit 4,5 ZZ by c1');
       d2.update((root) => {
-        (root['k1'] as PlainText).edit(2, 3, 'TT');
+        root['k1'].edit(2, 3, 'TT');
       }, 'edit 2,3 TT by c1');
 
       await c1.sync();
@@ -558,9 +556,9 @@ describe('Yorkie', function () {
     await client2.attach(doc2);
 
     doc1.update((root) => {
-      const text = root.createText('text') as PlainText;
+      const text = root.createText('text');
       text.edit(0, 0, 'Hello World');
-      const richText = root.createRichText('richText') as RichText;
+      const richText = root.createRichText('richText');
       richText.edit(0, 0, 'Hello World');
     }, 'sets test and richText');
 
@@ -574,9 +572,9 @@ describe('Yorkie', function () {
     await client2.sync();
 
     doc2.update((root) => {
-      (root['text'] as PlainText).edit(0, 1, 'a');
-      (root['text'] as PlainText).edit(1, 2, 'b');
-      (root['richText'] as RichText).edit(0, 1, 'a', { b: '1' });
+      root['text'].edit(0, 1, 'a');
+      root['text'].edit(1, 2, 'b');
+      root['richText'].edit(0, 1, 'a', { b: '1' });
     }, 'edit text type elements');
     assert.equal(0, doc1.getGarbageLen());
     assert.equal(3, doc2.getGarbageLen());
@@ -631,9 +629,9 @@ describe('Yorkie', function () {
       root['1'] = 1;
       root['2'] = [1, 2, 3];
       root['3'] = 3;
-      const text = root.createText('4') as PlainText;
+      const text = root.createText('4');
       text.edit(0, 0, 'hi');
-      const richText = root.createRichText('5') as RichText;
+      const richText = root.createRichText('5');
       richText.edit(0, 0, 'hi');
     }, 'sets 1, 2, 3, 4, 5');
 
@@ -648,8 +646,8 @@ describe('Yorkie', function () {
 
     doc1.update((root) => {
       delete root['2'];
-      (root['4'] as PlainText).edit(0, 1, 'h');
-      (root['5'] as RichText).edit(0, 1, 'h', { b: '1' });
+      root['4'].edit(0, 1, 'h');
+      root['5'].edit(0, 1, 'h', { b: '1' });
     }, 'removes 2 and edit text type elements');
     assert.equal(6, doc1.getGarbageLen());
     assert.equal(0, doc2.getGarbageLen());

--- a/test/yorkie_test.ts
+++ b/test/yorkie_test.ts
@@ -26,6 +26,8 @@ import {
 import { Document, DocEvent, DocEventType } from '../src/document/document';
 import { JSONElement } from '../src/document/json/element';
 import yorkie from '../src/yorkie';
+import { PlainText } from '../src/document/json/plain_text';
+import { RichText } from '../src/document/json/rich_text';
 
 const __karma__ = (global as any).__karma__;
 const testRPCAddr = __karma__.config.testRPCAddr || 'http://localhost:8080';
@@ -73,7 +75,7 @@ function createSpy(emitter: EventEmitter) {
 // to access test title in test codes.
 describe('Yorkie', function () {
   it('Can be activated, deactivated', async function () {
-    const docKey = `${this.test.title}-${new Date().getTime()}`;
+    const docKey = `${this.test!.title}-${new Date().getTime()}`;
     const clientWithKey = yorkie.createClient(testRPCAddr, {
       key: docKey,
       syncLoopDuration: 50,
@@ -97,7 +99,7 @@ describe('Yorkie', function () {
   });
 
   it('Can attach/detach documents', async function () {
-    const docKey = `${this.test.title}-${new Date().getTime()}`;
+    const docKey = `${this.test!.title}-${new Date().getTime()}`;
     const doc1 = yorkie.createDocument(testCollection, docKey);
     const doc2 = yorkie.createDocument(testCollection, docKey);
 
@@ -159,7 +161,7 @@ describe('Yorkie', function () {
       await c1.sync();
       await c2.sync();
       assert.equal(2, spy.callCount);
-    }, this.test.title);
+    }, this.test!.title);
   });
 
   it('Can watch documents', async function () {
@@ -168,7 +170,7 @@ describe('Yorkie', function () {
     await c1.activate();
     await c2.activate();
 
-    const docKey = `${this.test.title}-${new Date().getTime()}`;
+    const docKey = `${this.test!.title}-${new Date().getTime()}`;
     const d1 = yorkie.createDocument(testCollection, docKey);
     const d2 = yorkie.createDocument(testCollection, docKey);
     await c1.attach(d1);
@@ -213,7 +215,7 @@ describe('Yorkie', function () {
       await c1.sync();
       await c2.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-    }, this.test.title);
+    }, this.test!.title);
   });
 
   it('Can handle concurrent set/delete operations', async function () {
@@ -268,7 +270,7 @@ describe('Yorkie', function () {
       await c2.sync();
       await c1.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-    }, this.test.title);
+    }, this.test!.title);
   });
 
   it('Can handle concurrent add operations', async function () {
@@ -290,7 +292,7 @@ describe('Yorkie', function () {
       await c2.sync();
       await c1.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-    }, this.test.title);
+    }, this.test!.title);
   });
 
   it('Can handle concurrent insertAfter operations', async function () {
@@ -332,7 +334,7 @@ describe('Yorkie', function () {
       await c2.sync();
       await c1.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-    }, this.test.title);
+    }, this.test!.title);
   });
 
   it('Can handle concurrent moveBefore operations', async function () {
@@ -376,14 +378,14 @@ describe('Yorkie', function () {
       await c1.sync();
       await c2.sync();
       await c1.sync();
-    }, this.test.title);
+    }, this.test!.title);
   });
 
   it('should handle edit operations', async function () {
     await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root.createText('k1');
-        root['k1'].edit(0, 0, 'ABCD');
+        (root['k1'] as PlainText).edit(0, 0, 'ABCD');
       }, 'set new text by c1');
       await c1.sync();
       await c2.sync();
@@ -392,14 +394,14 @@ describe('Yorkie', function () {
 
       d1.update((root) => {
         root.createText('k1');
-        root['k1'].edit(0, 0, '1234');
+        (root['k1'] as PlainText).edit(0, 0, '1234');
       }, 'edit 0,0 1234 by c1');
       await c1.sync();
       await c2.sync();
       await c1.sync();
       assert.equal(d1.toSortedJSON(), `{"k1":"1234"}`);
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-    }, this.test.title);
+    }, this.test!.title);
   });
 
   it('should handle concurrent edit operations', async function () {
@@ -413,11 +415,11 @@ describe('Yorkie', function () {
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
       d1.update((root) => {
-        root['k1'].edit(0, 0, 'ABCD');
+        (root['k1'] as PlainText).edit(0, 0, 'ABCD');
       }, 'edit 0,0 ABCD by c1');
       assert.equal(d1.toSortedJSON(), `{"k1":"ABCD"}`);
       d2.update((root) => {
-        root['k1'].edit(0, 0, '1234');
+        (root['k1'] as PlainText).edit(0, 0, '1234');
       }, 'edit 0,0 1234 by c2');
       assert.equal(d2.toSortedJSON(), `{"k1":"1234"}`);
       await c1.sync();
@@ -426,10 +428,10 @@ describe('Yorkie', function () {
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
       d1.update((root) => {
-        root['k1'].edit(2, 3, 'XX');
+        (root['k1'] as PlainText).edit(2, 3, 'XX');
       }, 'edit 2,3 XX by c1');
       d2.update((root) => {
-        root['k1'].edit(2, 3, 'YY');
+        (root['k1'] as PlainText).edit(2, 3, 'YY');
       }, 'edit 2,3 YY by c1');
       await c1.sync();
       await c2.sync();
@@ -437,17 +439,17 @@ describe('Yorkie', function () {
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
       d1.update((root) => {
-        root['k1'].edit(4, 5, 'ZZ');
+        (root['k1'] as PlainText).edit(4, 5, 'ZZ');
       }, 'edit 4,5 ZZ by c1');
       d2.update((root) => {
-        root['k1'].edit(2, 3, 'TT');
+        (root['k1'] as PlainText).edit(2, 3, 'TT');
       }, 'edit 2,3 TT by c1');
 
       await c1.sync();
       await c2.sync();
       await c1.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-    }, this.test.title);
+    }, this.test!.title);
   });
 
   it('should handle snapshot', async function () {
@@ -471,11 +473,11 @@ describe('Yorkie', function () {
       await c2.sync();
       await c1.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-    }, this.test.title);
+    }, this.test!.title);
   });
 
   it('Can handle garbage collection for container type', async function () {
-    const docKey = `${this.test.title}-${new Date().getTime()}`;
+    const docKey = `${this.test!.title}-${new Date().getTime()}`;
     const doc1 = yorkie.createDocument(testCollection, docKey);
     const doc2 = yorkie.createDocument(testCollection, docKey);
 
@@ -542,7 +544,7 @@ describe('Yorkie', function () {
   });
 
   it('Can handle garbage collection for text type', async function () {
-    const docKey = `${this.test.title}-${new Date().getTime()}`;
+    const docKey = `${this.test!.title}-${new Date().getTime()}`;
     const doc1 = yorkie.createDocument(testCollection, docKey);
     const doc2 = yorkie.createDocument(testCollection, docKey);
 
@@ -556,9 +558,9 @@ describe('Yorkie', function () {
     await client2.attach(doc2);
 
     doc1.update((root) => {
-      const text = root.createText('text');
+      const text = root.createText('text') as PlainText;
       text.edit(0, 0, 'Hello World');
-      const richText = root.createRichText('richText');
+      const richText = root.createRichText('richText') as RichText;
       richText.edit(0, 0, 'Hello World');
     }, 'sets test and richText');
 
@@ -572,9 +574,9 @@ describe('Yorkie', function () {
     await client2.sync();
 
     doc2.update((root) => {
-      root['text'].edit(0, 1, 'a');
-      root['text'].edit(1, 2, 'b');
-      root['richText'].edit(0, 1, 'a', { b: '1' });
+      (root['text'] as PlainText).edit(0, 1, 'a');
+      (root['text'] as PlainText).edit(1, 2, 'b');
+      (root['richText'] as RichText).edit(0, 1, 'a', { b: '1' });
     }, 'edit text type elements');
     assert.equal(0, doc1.getGarbageLen());
     assert.equal(3, doc2.getGarbageLen());
@@ -612,7 +614,7 @@ describe('Yorkie', function () {
   });
 
   it('Can handle garbage collection with detached document test', async function () {
-    const docKey = `${this.test.title}-${new Date().getTime()}`;
+    const docKey = `${this.test!.title}-${new Date().getTime()}`;
     const doc1 = yorkie.createDocument(testCollection, docKey);
     const doc2 = yorkie.createDocument(testCollection, docKey);
 
@@ -629,9 +631,9 @@ describe('Yorkie', function () {
       root['1'] = 1;
       root['2'] = [1, 2, 3];
       root['3'] = 3;
-      const text = root.createText('4');
+      const text = root.createText('4') as PlainText;
       text.edit(0, 0, 'hi');
-      const richText = root.createRichText('5');
+      const richText = root.createRichText('5') as RichText;
       richText.edit(0, 0, 'hi');
     }, 'sets 1, 2, 3, 4, 5');
 
@@ -646,8 +648,8 @@ describe('Yorkie', function () {
 
     doc1.update((root) => {
       delete root['2'];
-      root['4'].edit(0, 1, 'h');
-      root['5'].edit(0, 1, 'h', { b: '1' });
+      (root['4'] as PlainText).edit(0, 1, 'h');
+      (root['5'] as RichText).edit(0, 1, 'h', { b: '1' });
     }, 'removes 2 and edit text type elements');
     assert.equal(6, doc1.getGarbageLen());
     assert.equal(0, doc2.getGarbageLen());
@@ -688,7 +690,7 @@ describe('Yorkie', function () {
       await c1.sync();
       await c2.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-    }, this.test.title);
+    }, this.test!.title);
   });
 
   it('Can handle concurrent increase operation', async function () {
@@ -715,7 +717,7 @@ describe('Yorkie', function () {
       await c1.sync();
 
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-    }, this.test.title);
+    }, this.test!.title);
   });
 
   it('Can recover from temporary disconnect (manual sync)', async function () {
@@ -737,7 +739,7 @@ describe('Yorkie', function () {
           {
             'Content-Type': 'application/grpc-web-text+proto',
           },
-          null,
+          '',
         );
       };
 
@@ -760,7 +762,7 @@ describe('Yorkie', function () {
       await c2.sync();
       await c1.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-    }, this.test.title);
+    }, this.test!.title);
   });
 
   it('Can recover from temporary disconnect (realtime sync)', async function () {
@@ -769,7 +771,7 @@ describe('Yorkie', function () {
     await c1.activate();
     await c2.activate();
 
-    const docKey = `${this.test.title}-${new Date().getTime()}`;
+    const docKey = `${this.test!.title}-${new Date().getTime()}`;
     const d1 = yorkie.createDocument(testCollection, docKey);
     const d2 = yorkie.createDocument(testCollection, docKey);
 
@@ -816,7 +818,7 @@ describe('Yorkie', function () {
         {
           'Content-Type': 'application/grpc-web-text+proto',
         },
-        null,
+        '',
       );
     };
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,6 @@
     "declaration": true,
     "outDir": "dist",
     "strict": true,
-    "strictNullChecks": false,
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules"],


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
1. Cleanup typescript undefined
2. Use undefined instead of null

#### Any background context you want to provide?
In the test code, as I added `undefined` type to `createText` function,
```javascript
public createText(key: string): PlainText | undefined {
   logger.fatal(`unsupported: this method should be called by proxy: ${key}`);	
   return;
 }
```
also changed test code like this
```javascript
const text = root.createText('k3') as PlainText
```
I'm not sure this approach is right, so if there are good alternatives, please feel free to comment on this PR :)

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #128 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
