### PR TITLE
Handle Object.keys, Object.values and Object.entries

### DIFF
--- a/src/document/json/object.ts
+++ b/src/document/json/object.ts
@@ -98,6 +98,15 @@ export class JSONObject extends JSONContainer {
     return `{${json.join(',')}}`;
   }
 
+  public getKeys(): Array<string> {
+    const keys = Array<string>();
+    for (const [key] of this) {
+      keys.push(key);
+    }
+
+    return keys;
+  }
+
   public toSortedJSON(): string {
     const keys = Array<string>();
     for (const [key] of this) {

--- a/src/document/proxy/object_proxy.ts
+++ b/src/document/proxy/object_proxy.ts
@@ -87,6 +87,17 @@ export class ObjectProxy {
         return toProxy(context, target.get(keyOrMethod));
       },
 
+      ownKeys: (target: JSONObject): Array<string> => {
+        return target.getKeys();
+      },
+
+      getOwnPropertyDescriptor: () => {
+        return {
+          enumerable: true,
+          configurable: true,
+        };
+      },
+
       deleteProperty: (target: JSONObject, key: string): boolean => {
         if (logger.isEnabled(LogLevel.Trivial)) {
           logger.trivial(`obj[${key}]`);

--- a/test/document/document_test.ts
+++ b/test/document/document_test.ts
@@ -284,6 +284,21 @@ describe('Document', function () {
     }
   });
 
+  it('Object.keys, Object.values and Object.entries test', function () {
+    const doc = Document.create('test-col', 'test-doc');
+    assert.equal('{}', doc.toSortedJSON());
+
+    doc.update((root) => {
+      root.content = { a: 1, b: 2, c: 3 };
+    }, 'set a, b, c');
+    assert.equal('{"content":{"a":1,"b":2,"c":3}}', doc.toSortedJSON());
+
+    const content = doc.getRootObject().content;
+    assert.equal('a,b,c', Object.keys(content).join(','));
+    assert.equal('1,2,3', Object.values(content).join(','));
+    assert.equal('a,1,b,2,c,3', Object.entries(content).join(','));
+  });
+
   it('garbage collection test', function () {
     const doc = Document.create('test-col', 'test-doc');
     assert.equal('{}', doc.toSortedJSON());


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Handle `Object.keys`, `Object.values` and `Object.entries`

Before this PR, `Object.keys`, `Object.values` and `Object.entries` ​​did not work properly.

```typescript
const doc = Document.create('test-col', 'test-doc');
assert.equal('{}', doc.toSortedJSON());

doc.update((root) => {
  root.content = { a: 1, b: 2, c: 3 };
}, 'set a, b, c');

assert.equal('{"content":{"a":1,"b":2,"c":3}}', doc.toSortedJSON());
const content = doc.getRootObject().content;
assert.equal('a,b,c', Object.keys(content).join(','));
assert.equal('1,2,3', Object.values(content).join(','));
assert.equal('a,1,b,2,c,3', Object.entries(content).join(','));
```

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
