### PR TITLE
Add type parameter to Document

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -71,7 +71,7 @@ export interface ClientEvent {
 }
 
 interface Attachment {
-  doc: Document;
+  doc: Document<unknown>;
   isRealtimeSync: boolean;
   peerClients?: Map<string, { [key: string]: string }>;
   remoteChangeEventReceived?: boolean;
@@ -131,8 +131,8 @@ export class Client implements Observable<ClientEvent> {
 
   /**
    * ativate activates this client. That is, it register itself to the agent
-   * and receives a unique ID from the agent. The given ID is used to distinguish
-   * different clients.
+   * and receives a unique ID from the agent. The given ID is used to
+   * distinguish different clients.
    */
   public activate(): Promise<void> {
     if (this.isActive()) {
@@ -206,7 +206,10 @@ export class Client implements Observable<ClientEvent> {
    * attach attaches the given document to this client. It tells the agent that
    * this client will synchronize the given document.
    */
-  public attach(doc: Document, isManualSync?: boolean): Promise<Document> {
+  public attach(
+    doc: Document<unknown>,
+    isManualSync?: boolean,
+  ): Promise<Document<unknown>> {
     if (!this.isActive()) {
       throw new YorkieError(Code.ClientNotActive, `${this.key} is not active`);
     }
@@ -247,11 +250,11 @@ export class Client implements Observable<ClientEvent> {
    * detach dettaches the given document from this client. It tells the
    * agent that this client will no longer synchronize the given document.
    *
-   * To collect garbage things like CRDT tombstones left on the document, all the
-   * changes should be applied to other replicas before GC time. For this, if the
-   * document is no longer used by this client, it should be detached.
+   * To collect garbage things like CRDT tombstones left on the document, all
+   * the changes should be applied to other replicas before GC time. For this,
+   * if the document is no longer used by this client, it should be detached.
    */
-  public detach(doc: Document): Promise<Document> {
+  public detach(doc: Document<unknown>): Promise<Document<unknown>> {
     if (!this.isActive()) {
       throw new YorkieError(Code.ClientNotActive, `${this.key} is not active`);
     }
@@ -289,7 +292,7 @@ export class Client implements Observable<ClientEvent> {
    * receives changes of the remote replica from the agent then apply them to
    * local documents.
    */
-  public sync(): Promise<Document[]> {
+  public sync(): Promise<Document<unknown>[]> {
     const promises = [];
     for (const [, attachment] of this.attachmentMap) {
       promises.push(this.syncInternal(attachment.doc));
@@ -512,7 +515,7 @@ export class Client implements Observable<ClientEvent> {
     }
   }
 
-  private syncInternal(doc: Document): Promise<Document> {
+  private syncInternal(doc: Document<unknown>): Promise<Document<unknown>> {
     return new Promise((resolve, reject) => {
       const req = new PushPullRequest();
       req.setClientId(converter.toUint8Array(this.id!));

--- a/src/document/proxy/proxy.ts
+++ b/src/document/proxy/proxy.ts
@@ -28,15 +28,11 @@ import { RichTextProxy } from './rich_text_proxy';
 import { CounterProxy } from './counter_proxy';
 import { Counter } from '../json/counter';
 
-export type Indexable = {
-  [index: string]: any;
-};
-
-export function createProxy(
+export function createProxy<T>(
   context: ChangeContext,
   target: JSONObject,
-): JSONObject & Indexable {
-  return ObjectProxy.create(context, target);
+): T & JSONObject {
+  return ObjectProxy.create(context, target) as T & JSONObject;
 }
 
 export function toProxy(context: ChangeContext, elem?: JSONElement): any {

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -16,7 +16,7 @@
 
 import Long from 'long';
 import { Client, ClientOptions } from './core/client';
-import { Document } from './document/document';
+import { Document, Indexable } from './document/document';
 
 export { Client, Document };
 export { ActorID } from './document/time/actor_id';
@@ -39,8 +39,11 @@ const yorkie = {
   createClient(rpcAddr: string, opts?: ClientOptions): Client {
     return new Client(rpcAddr, opts);
   },
-  createDocument(collection: string, document: string): Document {
-    return new Document(collection, document);
+  createDocument<T = Indexable>(
+    collection: string,
+    document: string,
+  ): Document<T> {
+    return new Document<T>(collection, document);
   },
   Long,
 };

--- a/test/document/document_test.ts
+++ b/test/document/document_test.ts
@@ -544,4 +544,34 @@ describe('Document', function () {
     }, 'Unsupported type of value: boolean');
     assert.equal(`{"k1":{"age":8.5,"length":18.5}}`, doc.toSortedJSON());
   });
+
+  it('generic type parameter test', function () {
+    type Todos = { todos: Array<{ title: string; done: boolean }> };
+
+    const doc = Document.create<Todos>('test-col', 'test-doc');
+    doc.update((root) => {
+      root.todos = [
+        {
+          title: 'buy milk',
+          done: false,
+        },
+      ];
+    });
+    assert.equal(
+      `{"todos":[{"title":"buy milk","done":false}]}`,
+      doc.toSortedJSON(),
+    );
+
+    doc.update((root) => {
+      root.todos.push({
+        title: 'drink water',
+        done: true,
+      });
+    });
+    const expectedTodos = [
+      '{"title":"buy milk","done":false}',
+      '{"title":"drink water","done":true}',
+    ];
+    assert.equal(`{"todos":[${expectedTodos.join(',')}]}`, doc.toSortedJSON());
+  });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Add [type parameter](https://www.typescriptlang.org/docs/handbook/generics.html) to `Document`.

When users edit a document, they can specify a type parameter to use the document more precisely.

```typescript
type Todos = { todos: Array<{ title: string; done: boolean }> };

const doc = Document.create<Todos>('test-col', 'test-doc');
doc.update((root) => {
  root.todos = [
    { title: 'buy milk', done: false },
  ];
});
assert.equal(root.todos[0], {title: 'buy milk', done: false});
assert.equal(root.todos[0], {title: 'buy milk'}); // Compile Error ❌: Property 'done' is missing in type ...
```

If the type parameter is not specified, type checking is not performed as before.

```typescript
const doc = Document.create('test-col', 'test-doc');
doc.update((root) => {
  root.anything = 'anything';
});
```

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
