### PR TITLE
Add ban-types for null

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,11 +1,8 @@
+// eslint-disable-next-line no-undef
 module.exports = {
   root: true,
   parser: '@typescript-eslint/parser',
-  plugins: [
-    '@typescript-eslint',
-    'prettier',
-    'eslint-plugin-tsdoc',
-  ],
+  plugins: ['@typescript-eslint', 'prettier', 'eslint-plugin-tsdoc'],
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/eslint-recommended',
@@ -16,6 +13,14 @@ module.exports = {
     '@typescript-eslint/no-non-null-assertion': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/ban-ts-comment': 'off',
+    '@typescript-eslint/ban-types': [
+      'error',
+      {
+        types: {
+          null: 'Use undefined instead of null',
+        },
+      },
+    ],
     'tsdoc/syntax': 'error',
     'object-shorthand': ['error', 'always'],
     'no-unreachable': 'error',


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Yorkie decided to use `undefined` instead of `null`, so it would be nice to use `ban-types` to avoid using null types.(#142)

We can also use ban-types to define rules like this:
```ts
function foo(): Array<T> {...}
//  vs
function foo(): []<T> {...}
```


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
