### PR TITLE
Fix invalid states of SplayTree when deleting a node

### DIFF
--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -87,6 +87,16 @@ export abstract class SplayNode<V> {
     return this.parent;
   }
 
+  public unlink(): void {
+    this.parent = undefined;
+    this.right = undefined;
+    this.left = undefined;
+  }
+
+  public hasLinks(): boolean {
+    return this.hasParent() || this.hasLeft() || this.hasRight();
+  }
+
   public increaseWeight(weight: number): void {
     this.weight! += weight;
   }
@@ -143,7 +153,7 @@ export class SplayTree<V> {
    * @returns the index of given node
    */
   public indexOf(node: SplayNode<V>): number {
-    if (!node) {
+    if (!node || !node.hasLinks()) {
       return -1;
     }
 
@@ -262,9 +272,17 @@ export class SplayTree<V> {
       const maxNode = leftTree.getMaximum();
       leftTree.splayNode(maxNode);
       leftTree.root.setRight(rightTree.root);
+      if (rightTree.root) {
+        rightTree.root.setParent(leftTree.root);
+      }
       this.root = leftTree.root;
     } else {
       this.root = rightTree.root;
+    }
+
+    node.unlink();
+    if (this.root) {
+      this.updateSubtree(this.root);
     }
   }
 

--- a/test/util/splay_tree_test.ts
+++ b/test/util/splay_tree_test.ts
@@ -58,4 +58,25 @@ describe('SplayTree', function () {
     assert.equal(tree.indexOf(nodeC), 5);
     assert.equal(tree.indexOf(nodeD), 9);
   });
+
+  it('Can delete the given node', function () {
+    const tree = new SplayTree<string>();
+
+    const nodeH = tree.insert(StringNode.create('H'));
+    assert.equal('[1,1]H', tree.getAnnotatedString());
+    const nodeE = tree.insert(StringNode.create('E'));
+    assert.equal('[1,1]H[2,1]E', tree.getAnnotatedString());
+    const nodeL = tree.insert(StringNode.create('LL'));
+    assert.equal('[1,1]H[2,1]E[4,2]LL', tree.getAnnotatedString());
+    const nodeO = tree.insert(StringNode.create('O'));
+    assert.equal('[1,1]H[2,1]E[4,2]LL[5,1]O', tree.getAnnotatedString());
+
+    tree.delete(nodeE);
+    assert.equal('[4,1]H[3,2]LL[1,1]O', tree.getAnnotatedString());
+
+    assert.equal(tree.indexOf(nodeH), 0);
+    assert.equal(tree.indexOf(nodeE), -1);
+    assert.equal(tree.indexOf(nodeL), 1);
+    assert.equal(tree.indexOf(nodeO), 3);
+  });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fix invalid states of SplayTree when [deleting a node](https://www.codesdope.com/course/data-structures-splay-trees/#:~:text=To%20delete%20a%20node%20in,child%20of%20the%20left%20subtree.).

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address https://github.com/yorkie-team/yorkie-codepair/issues/44#issuecomment-792292239

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
