### PR TITLE
Exchange the names of getRootObject and getRoot

### DIFF
--- a/examples/drawing.html
+++ b/examples/drawing.html
@@ -69,7 +69,7 @@
         }, 'create points if not exists');
 
         doc.subscribe((event) => {
-          paintCanvas(doc.getRootObject().shapes);
+          paintCanvas(doc.getRoot().shapes);
         });
         await client.sync();
 
@@ -115,7 +115,7 @@
         });
 
         // 05. set initial value.
-        paintCanvas(doc.getRootObject().shapes);
+        paintCanvas(doc.getRoot().shapes);
       } catch (e) {
         console.error(e);
       }

--- a/examples/index.html
+++ b/examples/index.html
@@ -33,7 +33,7 @@
 
     function displayLog(doc) {
       logHolder.innerText = doc.toJSON();
-      textLogHolder.innerText = doc.getRootObject().content.getAnnotatedString();
+      textLogHolder.innerText = doc.getRoot().content.getAnnotatedString();
     }
 
     function displayPeers(peers, clientID) {
@@ -175,7 +175,7 @@
         });
 
         // 04-2. document to codemirror(remote).
-        const text = doc.getRootObject().content;
+        const text = doc.getRoot().content;
         text.onChanges((changes) => {
           for (const change of changes) {
             if (change.type === 'content') {

--- a/examples/quill.html
+++ b/examples/quill.html
@@ -33,11 +33,11 @@
 
     function displayLog(doc) {
       logHolder.innerText = doc.toJSON();
-      textLogHolder.innerText = doc.getRootObject().content.getAnnotatedString();
+      textLogHolder.innerText = doc.getRoot().content.getAnnotatedString();
     }
 
     function toDelta(doc) {
-      const obj = doc.getRootObject();
+      const obj = doc.getRoot();
       const deltas = [];
       for (const val of obj.content.getValue()) {
         deltas.push({
@@ -184,7 +184,7 @@
         });
 
         // 04-2. document to codemirror(remote).
-        const text = doc.getRootObject().content;
+        const text = doc.getRoot().content;
         text.onChanges((changes) => {
           const delta = [];
           let prevTo = 0;

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -241,7 +241,7 @@ export class Document<T = Indexable> implements Observable<DocEvent> {
     return this.clone.getObject();
   }
 
-  public getRootObject(): T {
+  public getRoot(): T {
     this.ensureClone();
 
     const context = ChangeContext.create(this.changeID.next(), this.clone!);
@@ -255,7 +255,7 @@ export class Document<T = Indexable> implements Observable<DocEvent> {
     return this.root.garbageCollect(ticket);
   }
 
-  public getRoot(): JSONObject {
+  public getRootObject(): JSONObject {
     return this.root.getObject();
   }
 

--- a/test/api/converter_test.ts
+++ b/test/api/converter_test.ts
@@ -55,7 +55,7 @@ describe('Converter', function () {
       counter.increase(1).increase(2).increase(3);
     });
 
-    const bytes = converter.objectToBytes(doc.getRoot());
+    const bytes = converter.objectToBytes(doc.getRootObject());
     const obj = converter.bytesToObject(bytes);
     assert.equal(doc.toSortedJSON(), obj.toSortedJSON());
   });

--- a/test/document/document_test.ts
+++ b/test/document/document_test.ts
@@ -293,7 +293,7 @@ describe('Document', function () {
     }, 'insert 2');
     assert.equal('{"list":[1,2,3,4]}', doc.toSortedJSON());
 
-    const root = doc.getRootObject();
+    const root = doc.getRoot();
     for (let idx = 0; idx < root['list'].length; idx++) {
       assert.equal(idx + 1, root['list'][idx]);
       assert.equal(idx + 1, root['list'].getElementByIndex(idx).getValue());
@@ -309,7 +309,7 @@ describe('Document', function () {
     }, 'set a, b, c');
     assert.equal('{"content":{"a":1,"b":2,"c":3}}', doc.toSortedJSON());
 
-    const content = doc.getRootObject().content;
+    const content = doc.getRoot().content;
     assert.equal('a,b,c', Object.keys(content).join(','));
     assert.equal('1,2,3', Object.values(content).join(','));
     assert.equal('a,1,b,2,c,3', Object.entries(content).join(','));
@@ -367,7 +367,7 @@ describe('Document', function () {
     assert.equal(1, doc.garbageCollect(MaxTimeTicket));
     assert.equal(0, doc.getGarbageLen());
 
-    const root = (doc.getRoot().get('list') as JSONArray)
+    const root = (doc.getRootObject().get('list') as JSONArray)
       .getElements()
       .getAnnotatedString();
     const clone = (doc.getClone()!.get('list') as JSONArray)

--- a/test/yorkie_test.ts
+++ b/test/yorkie_test.ts
@@ -454,7 +454,7 @@ describe('Yorkie', function () {
         root['key'] = 'value';
       });
       await c2.sync();
-      assert.equal(d2.getRootObject()['key'], 'value');
+      assert.equal(d2.getRoot()['key'], 'value');
 
       await c1.sync();
       await c2.sync();


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Exchange the names of getRootObject and getRoot.

Users edit the document by taking the `root` variable as an argument in the
`document.update`. So it is natural to use `getRoot` to return the root.

```typescript
document.update((root) => {
  root.content = 'content';
});

// AS-IS
document.getRootObject().content; // 'content'

// TO-BE
document.getRoot().content; // 'content'
```

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
