### PR TITLE
Clean up element caches in root.ts

### DIFF
--- a/src/document/change/context.ts
+++ b/src/document/change/context.ts
@@ -56,19 +56,16 @@ export class ChangeContext {
     this.operations.push(operation);
   }
 
-  public registerElement(element: JSONElement): void {
-    this.root.registerElement(element);
+  public registerElement(element: JSONElement, parent: JSONContainer): void {
+    this.root.registerElement(element, parent);
   }
 
-  public registerRemovedElementPair(
-    parent: JSONContainer,
-    deleted: JSONElement,
-  ): void {
-    this.root.registerRemovedElementPair(parent, deleted);
+  public registerRemovedElement(deleted: JSONElement): void {
+    this.root.registerRemovedElement(deleted);
   }
 
-  public registerRemovedNodeTextElement(textType: TextElement): void {
-    this.root.registerRemovedNodeTextElement(textType);
+  public registerRemovedNodeTextElement(text: TextElement): void {
+    this.root.registerTextWithGarbage(text);
   }
 
   public getChange(): Change {

--- a/src/document/json/root.ts
+++ b/src/document/json/root.ts
@@ -18,6 +18,11 @@ import { InitialTimeTicket, TimeTicket } from '../time/ticket';
 import { JSONContainer, JSONElement, TextElement } from './element';
 import { JSONObject } from './object';
 
+interface JSONElementPair {
+  element: JSONElement;
+  parent?: JSONContainer;
+}
+
 /**
  * JSONRoot is a structure represents the root of JSON. It has a hash table of
  * all JSON elements to find a specific element when appling remote changes
@@ -26,32 +31,29 @@ import { JSONObject } from './object';
  * Every element has a unique time ticket at creation, which allows us to find
  * a particular element.
  */
-class JSONElementPair {
-  public parent: JSONContainer;
-  public element: JSONElement;
-
-  constructor(parent: JSONContainer, element: JSONElement) {
-    this.parent = parent;
-    this.element = element;
-  }
-}
 export class JSONRoot {
   private rootObject: JSONObject;
-  private elementMapByCreatedAt: Map<string, JSONElement>;
-  private removedElementPairMapByCreatedAt: Map<string, JSONElementPair>;
-  private removedNodeTextElementMapByCreatedAt: Map<string, TextElement>;
+  private elementPairMapByCreatedAt: Map<string, JSONElementPair>;
+  private removedElementSetByCreatedAt: Set<string>;
+  private textWithGarbageSetByCreatedAt: Set<string>;
 
   constructor(rootObject: JSONObject) {
     this.rootObject = rootObject;
-    this.elementMapByCreatedAt = new Map();
-    this.removedElementPairMapByCreatedAt = new Map();
-    this.removedNodeTextElementMapByCreatedAt = new Map();
+    this.elementPairMapByCreatedAt = new Map();
+    this.removedElementSetByCreatedAt = new Set();
+    this.textWithGarbageSetByCreatedAt = new Set();
 
-    this.registerElement(this.rootObject);
-    rootObject.getDescendants((elem: JSONElement): boolean => {
-      this.registerElement(elem);
-      return false;
-    });
+    this.elementPairMapByCreatedAt.set(
+      this.rootObject.getCreatedAt().toIDString(),
+      { element: this.rootObject },
+    );
+
+    rootObject.getDescendants(
+      (elem: JSONElement, parent: JSONContainer): boolean => {
+        this.registerElement(elem, parent);
+        return false;
+      },
+    );
   }
 
   public static create(): JSONRoot {
@@ -61,52 +63,48 @@ export class JSONRoot {
   /**
    * findByCreatedAt returns the element of given creation time.
    */
-  public findByCreatedAt(createdAt: TimeTicket): JSONElement {
-    return this.elementMapByCreatedAt.get(createdAt.toIDString())!;
+  public findByCreatedAt(createdAt: TimeTicket): JSONElement | undefined {
+    const pair = this.elementPairMapByCreatedAt.get(createdAt.toIDString());
+    if (!pair) {
+      return;
+    }
+
+    return pair.element;
   }
 
   /**
    * registerElement registers the given element to hash table.
    */
-  public registerElement(element: JSONElement): void {
-    this.elementMapByCreatedAt.set(
-      element.getCreatedAt().toIDString(),
+  public registerElement(element: JSONElement, parent: JSONContainer): void {
+    this.elementPairMapByCreatedAt.set(element.getCreatedAt().toIDString(), {
+      parent,
       element,
-    );
+    });
   }
 
   /**
    * deregisterElement deregister the given element from hash table.
    */
   public deregisterElement(element: JSONElement): void {
-    this.elementMapByCreatedAt.delete(element.getCreatedAt().toIDString());
-    this.removedElementPairMapByCreatedAt.delete(
+    this.elementPairMapByCreatedAt.delete(element.getCreatedAt().toIDString());
+    this.removedElementSetByCreatedAt.delete(
       element.getCreatedAt().toIDString(),
     );
   }
 
   /**
-   * registerRemovedElementPair register the given element pair to hash table.
+   * registerRemovedElement register the given element pair to hash table.
    */
-  public registerRemovedElementPair(
-    parent: JSONContainer,
-    element: JSONElement,
-  ): void {
-    this.removedElementPairMapByCreatedAt.set(
-      element.getCreatedAt().toIDString(),
-      new JSONElementPair(parent, element),
-    );
+  public registerRemovedElement(element: JSONElement): void {
+    this.removedElementSetByCreatedAt.add(element.getCreatedAt().toIDString());
   }
 
-  public registerRemovedNodeTextElement(textType: TextElement): void {
-    this.removedNodeTextElementMapByCreatedAt.set(
-      textType.getCreatedAt().toIDString(),
-      textType,
-    );
+  public registerTextWithGarbage(text: TextElement): void {
+    this.textWithGarbageSetByCreatedAt.add(text.getCreatedAt().toIDString());
   }
 
   public getElementMapSize(): number {
-    return this.elementMapByCreatedAt.size;
+    return this.elementPairMapByCreatedAt.size;
   }
 
   public getObject(): JSONObject {
@@ -116,8 +114,9 @@ export class JSONRoot {
   public getGarbageLen(): number {
     let count = 0;
 
-    for (const [, pair] of this.removedElementPairMapByCreatedAt) {
+    for (const createdAt of this.removedElementSetByCreatedAt) {
       count++;
+      const pair = this.elementPairMapByCreatedAt.get(createdAt)!;
       if (pair.element instanceof JSONContainer) {
         pair.element.getDescendants(() => {
           count++;
@@ -126,7 +125,9 @@ export class JSONRoot {
       }
     }
 
-    for (const [, text] of this.removedNodeTextElementMapByCreatedAt) {
+    for (const createdAt of this.textWithGarbageSetByCreatedAt) {
+      const pair = this.elementPairMapByCreatedAt.get(createdAt)!;
+      const text = pair.element as TextElement;
       count += text.getRemovedNodesLen();
     }
 
@@ -140,20 +141,24 @@ export class JSONRoot {
   public garbageCollect(ticket: TimeTicket): number {
     let count = 0;
 
-    for (const [, pair] of this.removedElementPairMapByCreatedAt) {
+    for (const createdAt of this.removedElementSetByCreatedAt) {
+      const pair = this.elementPairMapByCreatedAt.get(createdAt)!;
       if (
         pair.element.getRemovedAt() &&
         ticket.compare(pair.element.getRemovedAt()!) >= 0
       ) {
-        pair.parent.purge(pair.element);
-        count += this._garbageCollect(pair.element);
+        pair.parent!.purge(pair.element);
+        count += this.garbageCollectInternal(pair.element);
       }
     }
 
-    for (const [, text] of this.removedNodeTextElementMapByCreatedAt) {
+    for (const createdAt of this.textWithGarbageSetByCreatedAt) {
+      const pair = this.elementPairMapByCreatedAt.get(createdAt)!;
+      const text = pair.element as TextElement;
+
       const removedNodeCnt = text.cleanupRemovedNodes(ticket);
       if (removedNodeCnt > 0) {
-        this.removedNodeTextElementMapByCreatedAt.delete(
+        this.textWithGarbageSetByCreatedAt.delete(
           text.getCreatedAt().toIDString(),
         );
       }
@@ -163,7 +168,7 @@ export class JSONRoot {
     return count;
   }
 
-  private _garbageCollect(element: JSONElement): number {
+  private garbageCollectInternal(element: JSONElement): number {
     let count = 0;
 
     // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/src/document/operation/add_operation.ts
+++ b/src/document/operation/add_operation.ts
@@ -51,7 +51,7 @@ export class AddOperation extends Operation {
       const array = parentObject as JSONArray;
       const value = this.value.deepcopy();
       array.insertAfter(this.prevCreatedAt, value);
-      root.registerElement(value);
+      root.registerElement(value, array);
     } else {
       logger.fatal(`fail to execute, only array can execute add`);
     }

--- a/src/document/operation/edit_operation.ts
+++ b/src/document/operation/edit_operation.ts
@@ -71,7 +71,7 @@ export class EditOperation extends Operation {
         this.maxCreatedAtMapByActor,
       );
       if (this.fromPos.compare(this.toPos) !== 0) {
-        root.registerRemovedNodeTextElement(text);
+        root.registerTextWithGarbage(text);
       }
     } else {
       logger.fatal(`fail to execute, only PlainText can execute edit`);

--- a/src/document/operation/remove_operation.ts
+++ b/src/document/operation/remove_operation.ts
@@ -45,7 +45,7 @@ export class RemoveOperation extends Operation {
     if (parentObject instanceof JSONContainer) {
       const obj = parentObject;
       const elem = obj.delete(this.createdAt, this.getExecutedAt());
-      root.registerRemovedElementPair(parentObject, elem);
+      root.registerRemovedElement(elem);
     } else {
       logger.fatal(`only object and array can execute remove: ${parentObject}`);
     }

--- a/src/document/operation/rich_edit_operation.ts
+++ b/src/document/operation/rich_edit_operation.ts
@@ -77,7 +77,7 @@ export class RichEditOperation extends Operation {
         this.maxCreatedAtMapByActor,
       );
       if (this.fromPos.compare(this.toPos) !== 0) {
-        root.registerRemovedNodeTextElement(text);
+        root.registerTextWithGarbage(text);
       }
     } else {
       logger.fatal(`fail to execute, only RichText can execute edit`);

--- a/src/document/operation/set_operation.ts
+++ b/src/document/operation/set_operation.ts
@@ -51,7 +51,7 @@ export class SetOperation extends Operation {
       const obj = parentObject as JSONObject;
       const value = this.value.deepcopy();
       obj.set(this.key, value);
-      root.registerElement(value);
+      root.registerElement(value, obj);
     } else {
       logger.fatal(`fail to execute, only object can execute set`);
     }

--- a/src/document/proxy/array_proxy.ts
+++ b/src/document/proxy/array_proxy.ts
@@ -199,7 +199,7 @@ export class ArrayProxy {
     if (JSONPrimitive.isSupport(value)) {
       const primitive = JSONPrimitive.of(value as PrimitiveValue, ticket);
       target.insertAfter(prevCreatedAt, primitive);
-      context.registerElement(primitive);
+      context.registerElement(primitive, target);
       context.push(
         AddOperation.create(
           target.getCreatedAt(),
@@ -212,7 +212,7 @@ export class ArrayProxy {
     } else if (Array.isArray(value)) {
       const array = JSONArray.create(ticket);
       target.insertAfter(prevCreatedAt, array);
-      context.registerElement(array);
+      context.registerElement(array, target);
       context.push(
         AddOperation.create(
           target.getCreatedAt(),
@@ -228,7 +228,7 @@ export class ArrayProxy {
     } else if (typeof value === 'object') {
       const obj = JSONObject.create(ticket);
       target.insertAfter(prevCreatedAt, obj);
-      context.registerElement(obj);
+      context.registerElement(obj, target);
       context.push(
         AddOperation.create(target.getCreatedAt(), prevCreatedAt, obj, ticket),
       );
@@ -260,7 +260,7 @@ export class ArrayProxy {
         ticket,
       ),
     );
-    context.registerRemovedElementPair(target, deleted);
+    context.registerRemovedElement(deleted);
     return deleted;
   }
 
@@ -278,7 +278,7 @@ export class ArrayProxy {
         ticket,
       ),
     );
-    context.registerRemovedElementPair(target, deleted);
+    context.registerRemovedElement(deleted);
     return deleted;
   }
 

--- a/src/document/proxy/object_proxy.ts
+++ b/src/document/proxy/object_proxy.ts
@@ -125,14 +125,14 @@ export class ObjectProxy {
     if (JSONPrimitive.isSupport(value)) {
       const primitive = JSONPrimitive.of(value as PrimitiveValue, ticket);
       target.set(key, primitive);
-      context.registerElement(primitive);
+      context.registerElement(primitive, target);
       context.push(
         SetOperation.create(key, primitive, target.getCreatedAt(), ticket),
       );
     } else if (Array.isArray(value)) {
       const array = JSONArray.create(ticket);
       target.set(key, array);
-      context.registerElement(array);
+      context.registerElement(array, target);
       context.push(
         SetOperation.create(
           key,
@@ -147,7 +147,7 @@ export class ObjectProxy {
     } else if (typeof value === 'object') {
       if (value instanceof PlainText) {
         target.set(key, value);
-        context.registerElement(value);
+        context.registerElement(value, target);
         context.push(
           SetOperation.create(
             key,
@@ -159,7 +159,7 @@ export class ObjectProxy {
       } else {
         const obj = JSONObject.create(ticket);
         target.set(key, obj);
-        context.registerElement(obj);
+        context.registerElement(obj, target);
         context.push(
           SetOperation.create(
             key,
@@ -185,7 +185,7 @@ export class ObjectProxy {
     const ticket = context.issueTimeTicket();
     const text = PlainText.create(RGATreeSplit.create(), ticket);
     target.set(key, text);
-    context.registerElement(text);
+    context.registerElement(text, target);
     context.push(
       SetOperation.create(key, text.deepcopy(), target.getCreatedAt(), ticket),
     );
@@ -200,7 +200,7 @@ export class ObjectProxy {
     const ticket = context.issueTimeTicket();
     const text = RichText.create(RGATreeSplit.create(), ticket);
     target.set(key, text);
-    context.registerElement(text);
+    context.registerElement(text, target);
     context.push(
       SetOperation.create(key, text.deepcopy(), target.getCreatedAt(), ticket),
     );
@@ -216,7 +216,7 @@ export class ObjectProxy {
     const ticket = context.issueTimeTicket();
     const counter = Counter.of(value, ticket);
     target.set(key, counter);
-    context.registerElement(counter);
+    context.registerElement(counter, target);
     context.push(
       SetOperation.create(
         key,
@@ -246,7 +246,7 @@ export class ObjectProxy {
         ticket,
       ),
     );
-    context.registerRemovedElementPair(target, deleted);
+    context.registerRemovedElement(deleted);
   }
 
   public getHandlers(): any {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Clean up element caches in root.ts.

In order to provide element's path to events, we need to know the parents of
elements. Therefore, when caching, we save pair and simplifies the cache for GC.

#### Any background context you want to provide?

Code cleanup before addressing #155

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
