### PR TITLE
Remove errors that occur when insPrev does not exist

### DIFF
--- a/src/document/json/rga_tree_split.ts
+++ b/src/document/json/rga_tree_split.ts
@@ -507,9 +507,9 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
     }
 
     if (id.getOffset() > 0 && node!.getID().getOffset() == id.getOffset()) {
-      // TODO(hackerwins): InsPrev may not be present due to GC. We have to check the GC algorithm.
+      // NOTE: InsPrev may not be present due to GC.
       if (!node!.hasInsPrev()) {
-        logger.fatal('insPrev should be presence');
+        return node!;
       }
       node = node!.getInsPrev();
     }

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -79,7 +79,9 @@ export class TextView {
     }
 
     if (enableLog) {
-      console.log(`apply: ${oldValue}->${this.value} [${changeLogs.join(',')}]`);
+      console.log(
+        `apply: ${oldValue}->${this.value} [${changeLogs.join(',')}]`,
+      );
     }
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Remove errors that occur when `insPrev` does not exist.

InsPrev can be removed due to GC, so remove the panic code added as an assertion.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/yorkie-codepair/issues/71

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
