### PR TITLE
Convert undefined to null

### DIFF
--- a/src/document/json/primitive.ts
+++ b/src/document/json/primitive.ts
@@ -45,7 +45,7 @@ export class JSONPrimitive extends JSONElement {
   constructor(value: PrimitiveValue, createdAt: TimeTicket) {
     super(createdAt);
     this.valueType = JSONPrimitive.getPrimitiveType(value)!;
-    this.value = value;
+    this.value = value === undefined ? null : value;
   }
 
   /**
@@ -134,6 +134,8 @@ export class JSONPrimitive extends JSONElement {
    */
   public static getPrimitiveType(value: unknown): PrimitiveType | undefined {
     switch (typeof value) {
+      case 'undefined':
+        return PrimitiveType.Null;
       case 'boolean':
         return PrimitiveType.Boolean;
       case 'number':
@@ -143,8 +145,7 @@ export class JSONPrimitive extends JSONElement {
       case 'object':
         if (value === null) {
           return PrimitiveType.Null;
-        }
-        if (value instanceof Long) {
+        } else if (value instanceof Long) {
           return PrimitiveType.Long;
         } else if (value instanceof Uint8Array) {
           return PrimitiveType.Bytes;

--- a/test/yorkie_test.ts
+++ b/test/yorkie_test.ts
@@ -198,6 +198,7 @@ describe('Yorkie', function () {
         root['k5'] = '4';
         root['k6'] = new Uint8Array([65, 66]);
         root['k7'] = new Date();
+        root['k8'] = undefined;
       });
 
       await c1.sync();


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

For the sake of simplicity, we do not completely reproduce JavaScript's behavior, but instead, convert `undefined` to `null`.

#### Any background context you want to provide?

There are `undefined` and `null` in JavaScript, but only `null` in Yorkie Document.

And there is a slight difference in the behavior of `undefined` and `null` in JavaScript. When serializing to JSON, `null` is preserved, but `undefined` disappears. In Array, `undefined` is changed to `null` and in Object, `undefined` disappears.

```typescript
 > JSON.stringify({a: undefined, b: null});
 < "{"b":null}"
 
 > JSON.stringify([undefined, null])
 < "[null,null]"
```

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #156

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
