### PR TITLE
Rename `Document.getKey().toIDString()` to `Document.getKey()`

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -121,7 +121,7 @@
 
         client.subscribe((event) => {
           if (event.type === 'peers-changed') {
-            displayPeers(event.value[doc.getKey().toIDString()], client.getID());
+            displayPeers(event.value[doc.getKey()], client.getID());
           }
         });
 

--- a/examples/quill.html
+++ b/examples/quill.html
@@ -90,7 +90,7 @@
 
         client.subscribe((event) => {
           if (event.type === 'peers-changed') {
-            peers = event.value[doc.getKey().toIDString()];
+            peers = event.value[doc.getKey()];
             displayPeers(peers, metadata['username']);
           }
         });

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -231,16 +231,14 @@ export class Client implements Observable<ClientEvent> {
         const pack = converter.fromChangePack(res.getChangePack()!);
         doc.applyChangePack(pack);
 
-        this.attachmentMap.set(doc.getKey().toIDString(), {
+        this.attachmentMap.set(doc.getKey(), {
           doc,
           isRealtimeSync: !isManualSync,
           peerClients: new Map(),
         });
         this.runWatchLoop();
 
-        logger.info(
-          `[AD] c:"${this.getKey()}" attaches d:"${doc.getKey().toIDString()}"`,
-        );
+        logger.info(`[AD] c:"${this.getKey()}" attaches d:"${doc.getKey()}"`);
         resolve(doc);
       });
     });
@@ -274,14 +272,12 @@ export class Client implements Observable<ClientEvent> {
         const pack = converter.fromChangePack(res.getChangePack()!);
         doc.applyChangePack(pack);
 
-        if (this.attachmentMap.has(doc.getKey().toIDString())) {
-          this.attachmentMap.delete(doc.getKey().toIDString());
+        if (this.attachmentMap.has(doc.getKey())) {
+          this.attachmentMap.delete(doc.getKey());
         }
         this.runWatchLoop();
 
-        logger.info(
-          `[DD] c:"${this.getKey()}" detaches d:"${doc.getKey().toIDString()}"`,
-        );
+        logger.info(`[DD] c:"${this.getKey()}" detaches d:"${doc.getKey()}"`);
         resolve(doc);
       });
     });
@@ -407,7 +403,7 @@ export class Client implements Observable<ClientEvent> {
       const realtimeSyncDocKeys: Array<DocumentKey> = [];
       for (const [, attachment] of this.attachmentMap) {
         if (attachment.isRealtimeSync) {
-          realtimeSyncDocKeys.push(attachment.doc.getKey());
+          realtimeSyncDocKeys.push(attachment.doc.getDocumentKey());
         }
       }
 
@@ -553,7 +549,7 @@ export class Client implements Observable<ClientEvent> {
             value: DocumentSyncResultType.Synced,
           });
 
-          const docKey = doc.getKey().toIDString();
+          const docKey = doc.getKey();
           const remoteSize = respPack.getChangeSize();
           logger.info(
             `[PP] c:"${this.getKey()}" sync d:"${docKey}", push:${localSize} pull:${remoteSize} cp:${respPack

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -256,9 +256,18 @@ export class Document<T = Indexable> implements Observable<DocEvent> {
   }
 
   /**
-   * `getKey` returns the key of this document.
+   * `getKey` returns the key of this document as a string. The string is
+   * a combination pattern of collection and document.
+   * e.g. `Collection$Document`;
    */
-  public getKey(): DocumentKey {
+  public getKey(): string {
+    return this.key.toIDString();
+  }
+
+  /**
+   * `getDocumentKey` returns the key of this document.
+   */
+  public getDocumentKey(): DocumentKey {
     return this.key;
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Rename `Document.getKey().toIDString()` to `Document.getKey()`.

The user will use the document's Key more as a string.

```typescript
const doc = yorkie.createDocument('documents', 'doc1');
client.subscribe((event) => {
  if (event.type === 'peers-changed') {
    // AS-IS
    // const peers = event.value[doc.getKey().toIDString()];

    // TO-BE
    const peers = event.value[doc.getKey()];
    console.log(peers);
  }
});
```

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
