### PR TITLE
Fix the concurrent editing issue of Move Operation

### DIFF
--- a/src/document/json/rga_tree_list.ts
+++ b/src/document/json/rga_tree_list.ts
@@ -174,7 +174,9 @@ export class RGATreeList {
 
     while (
       node!.getNext() &&
-      node!.getNext()!.getCreatedAt().after(executedAt)
+      (node!.getNext()!.getCreatedAt().after(executedAt) ||
+        (node!.getNext()!.getValue().getMovedAt() &&
+          node!.getNext()!.getValue().getMovedAt()!.after(executedAt)))
     ) {
       node = node!.getNext();
     }

--- a/src/document/json/rga_tree_list.ts
+++ b/src/document/json/rga_tree_list.ts
@@ -66,6 +66,18 @@ class RGATreeListNode extends SplayNode<JSONElement> {
   }
 
   /**
+   * `getPositionedAt` returns time this element was positioned in the array.
+   */
+  public getPositionedAt(): TimeTicket {
+    const movedAt = this.value.getMovedAt();
+    if (movedAt) {
+      return movedAt;
+    }
+
+    return this.value.getCreatedAt();
+  }
+
+  /**
    * `release` releases prev and next node.
    */
   public release(): void {
@@ -174,9 +186,7 @@ export class RGATreeList {
 
     while (
       node!.getNext() &&
-      (node!.getNext()!.getCreatedAt().after(executedAt) ||
-        (node!.getNext()!.getValue().getMovedAt() &&
-          node!.getNext()!.getValue().getMovedAt()!.after(executedAt)))
+      node!.getNext()!.getPositionedAt().after(executedAt)
     ) {
       node = node!.getNext();
     }

--- a/test/integration/array_test.ts
+++ b/test/integration/array_test.ts
@@ -202,15 +202,15 @@ describe('Array', function () {
       });
 
       d2.update((root) => {
-        const next = root['k1'].getElementByIndex(1);
-        const item = root['k1'].getElementByIndex(2);
+        const next = root['k1'].getElementByIndex(0);
+        const item = root['k1'].getElementByIndex(1);
         root['k1'].moveBefore(next.getID(), item.getID());
-        assert.equal('{"k1":[0,2,1]}', root.toJSON());
+        assert.equal('{"k1":[1,0,2]}', root.toJSON());
       });
 
       d2.update((root) => {
-        const next = root['k1'].getElementByIndex(1);
-        const item = root['k1'].getElementByIndex(2);
+        const next = root['k1'].getElementByIndex(0);
+        const item = root['k1'].getElementByIndex(1);
         root['k1'].moveBefore(next.getID(), item.getID());
         assert.equal('{"k1":[0,1,2]}', root.toJSON());
       });
@@ -218,6 +218,7 @@ describe('Array', function () {
       await c1.sync();
       await c2.sync();
       await c1.sync();
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
     }, this.test!.title);
   });
 
@@ -244,15 +245,15 @@ describe('Array', function () {
       });
 
       d2.update((root) => {
-        const item = root['k1'].getElementByIndex(2);
+        const item = root['k1'].getElementByIndex(1);
         root['k1'].moveFront(item.getID());
-        assert.equal('{"k1":[2,0,1]}', root.toJSON());
+        assert.equal('{"k1":[1,0,2]}', root.toJSON());
       });
 
       d2.update((root) => {
-        const item = root['k1'].getElementByIndex(2);
+        const item = root['k1'].getElementByIndex(1);
         root['k1'].moveFront(item.getID());
-        assert.equal('{"k1":[1,2,0]}', root.toJSON());
+        assert.equal('{"k1":[0,1,2]}', root.toJSON());
       });
 
       await c1.sync();


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Fix the concurrent editing issue of Move Operation

https://github.com/yorkie-team/yorkie-js-sdk/issues/195

#### Any background context you want to provide?
Currently, In the `findNextBeforeExecutedAt` function, we find next node with `createdAt`. I think we also need to find the next node with `movedAt`. So I add one condition
```
(node!.getNext()!.getValue().getMovedAt() &&
          node!.getNext()!.getValue().getMovedAt()!.after(executedAt)))
```
I'm not sure this approach is good. So please feel free to comment on my PR :)

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #195 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
