### PR TITLE
Fix a bug when pushing an array element in Array

### DIFF
--- a/src/document/proxy/array_proxy.ts
+++ b/src/document/proxy/array_proxy.ts
@@ -258,8 +258,9 @@ export class ArrayProxy {
       return primitive;
     } else if (Array.isArray(value)) {
       const array = JSONArray.create(ticket);
-      target.insertAfter(prevCreatedAt, array);
-      context.registerElement(array, target);
+      const clone = array.deepcopy();
+      target.insertAfter(prevCreatedAt, clone);
+      context.registerElement(clone, target);
       context.push(
         AddOperation.create(
           target.getCreatedAt(),
@@ -269,7 +270,7 @@ export class ArrayProxy {
         ),
       );
       for (const element of value) {
-        ArrayProxy.pushInternal(context, array, element);
+        ArrayProxy.pushInternal(context, clone, element);
       }
       return array;
     } else if (typeof value === 'object') {

--- a/test/integration/array_test.ts
+++ b/test/integration/array_test.ts
@@ -64,6 +64,17 @@ describe('Array', function () {
     assert.equal('{"k1":["1","3","4",{"a":"1","b":"2"}]}', doc.toJSON());
   });
 
+  it('can push array', function () {
+    const doc = DocumentReplica.create('test-col', 'test-doc');
+
+    doc.update((root) => {
+      root.arr = [1, 2, 3];
+      root.arr.push([4, 5, 6]);
+      assert.equal('{"arr":[1,2,3,[4,5,6]]}', root.toJSON());
+    });
+    assert.equal('{"arr":[1,2,3,[4,5,6]]}', doc.toJSON());
+  });
+
   it('can push element then delete it by ID in array', function () {
     const doc = DocumentReplica.create('test-col', 'test-doc');
     assert.equal('{}', doc.toSortedJSON());

--- a/test/integration/array_test.ts
+++ b/test/integration/array_test.ts
@@ -20,6 +20,50 @@ describe('Array', function () {
     assert.equal('{"k1":["1","3","4"]}', doc.toSortedJSON());
   });
 
+  it('can push array element after delete operation', function () {
+    const doc = DocumentReplica.create('test-col', 'test-doc');
+    assert.equal('{}', doc.toSortedJSON());
+
+    doc.update((root) => {
+      root['k1'] = ['1', '2', '3'];
+    }, 'set {"k1":["1","2","3"]}');
+    assert.equal('{"k1":["1","2","3"]}', doc.toSortedJSON());
+
+    doc.update((root) => {
+      delete root['k1'][1];
+      root['k1'].push('4');
+    }, 'set {"k1":["1","3","4"]}');
+
+    doc.update((root) => {
+      root['k1'].push([4, 5, 6]);
+      assert.equal('{"k1":["1","3","4",[4,5,6]]}', root.toJSON());
+    });
+
+    assert.equal('{"k1":["1","3","4",[4,5,6]]}', doc.toJSON());
+  });
+
+  it('can push object element after delete operation', function () {
+    const doc = DocumentReplica.create('test-col', 'test-doc');
+    assert.equal('{}', doc.toSortedJSON());
+
+    doc.update((root) => {
+      root['k1'] = ['1', '2', '3'];
+    }, 'set {"k1":["1","2","3"]}');
+    assert.equal('{"k1":["1","2","3"]}', doc.toSortedJSON());
+
+    doc.update((root) => {
+      delete root['k1'][1];
+      root['k1'].push('4');
+    }, 'set {"k1":["1","3","4"]}');
+
+    doc.update((root) => {
+      root['k1'].push({ a: '1', b: '2' });
+      assert.equal('{"k1":["1","3","4",{"a":"1","b":"2"}]}', root.toJSON());
+    });
+
+    assert.equal('{"k1":["1","3","4",{"a":"1","b":"2"}]}', doc.toJSON());
+  });
+
   it('can push element then delete it by ID in array', function () {
     const doc = DocumentReplica.create('test-col', 'test-doc');
     assert.equal('{}', doc.toSortedJSON());


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Fix a bug when pushing an array element in Array

#### Any background context you want to provide?

I tried deep coy of the array before `insertAfter`

```
const clone = array.deepcopy(); 
target.insertAfter(prevCreatedAt, clone);
context.registerElement(clone, target);
```

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #193

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
