### PR TITLE
Implement Array.moveLast

### DIFF
--- a/src/document/json/rga_tree_list.ts
+++ b/src/document/json/rga_tree_list.ts
@@ -248,8 +248,9 @@ export class RGATreeList {
     }
 
     if (
-      !node!.getValue().getMovedAt() ||
-      executedAt.after(node!.getValue().getMovedAt()!)
+      prevNode !== node &&
+      (!node!.getValue().getMovedAt() ||
+        executedAt.after(node!.getValue().getMovedAt()!))
     ) {
       this.release(node!);
       this.insertAfter(prevNode!.getCreatedAt(), node!.getValue(), executedAt);

--- a/src/document/proxy/array_proxy.ts
+++ b/src/document/proxy/array_proxy.ts
@@ -99,6 +99,10 @@ export class ArrayProxy {
           return (itemID: TimeTicket): void => {
             ArrayProxy.moveFrontInternal(context, target, itemID);
           };
+        } else if (method === 'moveAfter') {
+          return (itemID: TimeTicket): void => {
+            ArrayProxy.moveAfterInternal(context, target, itemID);
+          };
         } else if (isNumericString(method)) {
           return toProxy(context, target.getByIndex(+(method as string)));
         } else if (method === 'push') {
@@ -229,6 +233,23 @@ export class ArrayProxy {
         createdAt,
         ticket,
       ),
+    );
+  }
+
+  /**
+   * `moveAfterInternal` moves the given `createdAt` element
+   * at the last of array.
+   */
+  public static moveAfterInternal(
+    context: ChangeContext,
+    target: JSONArray,
+    createdAt: TimeTicket,
+  ): void {
+    const ticket = context.issueTimeTicket();
+    const last = target.getLastCreatedAt();
+    target.moveAfter(last, createdAt, ticket);
+    context.push(
+      MoveOperation.create(target.getCreatedAt(), last, createdAt, ticket),
     );
   }
 

--- a/src/document/proxy/array_proxy.ts
+++ b/src/document/proxy/array_proxy.ts
@@ -99,9 +99,9 @@ export class ArrayProxy {
           return (itemID: TimeTicket): void => {
             ArrayProxy.moveFrontInternal(context, target, itemID);
           };
-        } else if (method === 'moveAfter') {
+        } else if (method === 'moveLast') {
           return (itemID: TimeTicket): void => {
-            ArrayProxy.moveAfterInternal(context, target, itemID);
+            ArrayProxy.moveLastInternal(context, target, itemID);
           };
         } else if (isNumericString(method)) {
           return toProxy(context, target.getByIndex(+(method as string)));
@@ -240,7 +240,7 @@ export class ArrayProxy {
    * `moveAfterInternal` moves the given `createdAt` element
    * at the last of array.
    */
-  public static moveAfterInternal(
+  public static moveLastInternal(
     context: ChangeContext,
     target: JSONArray,
     createdAt: TimeTicket,

--- a/test/integration/array_test.ts
+++ b/test/integration/array_test.ts
@@ -200,19 +200,19 @@ describe('Array', function () {
 
     doc.update((root) => {
       const item = root['list'].getElementByIndex(2);
-      root['list'].moveAfter(item.getID());
+      root['list'].moveLast(item.getID());
       assert.equal('{"list":[0,1,2]}', root.toJSON());
     });
 
     doc.update((root) => {
       const item = root['list'].getElementByIndex(1);
-      root['list'].moveAfter(item.getID());
+      root['list'].moveLast(item.getID());
       assert.equal('{"list":[0,2,1]}', root.toJSON());
     });
 
     doc.update((root) => {
       const item = root['list'].getElementByIndex(0);
-      root['list'].moveAfter(item.getID());
+      root['list'].moveLast(item.getID());
       assert.equal('{"list":[2,1,0]}', root.toJSON());
     });
   });
@@ -417,13 +417,13 @@ describe('Array', function () {
 
       d1.update((root) => {
         const item = root['k1'].getElementByIndex(1);
-        root['k1'].moveAfter(item.getID());
+        root['k1'].moveLast(item.getID());
         assert.equal('{"k1":[0,2,1]}', root.toJSON());
       });
 
       d2.update((root) => {
         const item = root['k1'].getElementByIndex(0);
-        root['k1'].moveAfter(item.getID());
+        root['k1'].moveLast(item.getID());
         assert.equal('{"k1":[1,2,0]}', root.toJSON());
       });
 

--- a/test/integration/array_test.ts
+++ b/test/integration/array_test.ts
@@ -163,7 +163,7 @@ describe('Array', function () {
     });
   });
 
-  it('can insert an element at the first of array', function () {
+  it('can move an element at the first of array', function () {
     const doc = DocumentReplica.create('test-col', 'test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
@@ -187,6 +187,33 @@ describe('Array', function () {
       const item = root['list'].getElementByIndex(0);
       root['list'].moveFront(item.getID());
       assert.equal('{"list":[0,2,1]}', root.toJSON());
+    });
+  });
+
+  it('can move an element at the last of array', function () {
+    const doc = DocumentReplica.create('test-col', 'test-doc');
+    assert.equal('{}', doc.toSortedJSON());
+
+    doc.update((root) => {
+      root['list'] = [0, 1, 2];
+    }, 'set {"list":[0,1,2]}');
+
+    doc.update((root) => {
+      const item = root['list'].getElementByIndex(2);
+      root['list'].moveAfter(item.getID());
+      assert.equal('{"list":[0,1,2]}', root.toJSON());
+    });
+
+    doc.update((root) => {
+      const item = root['list'].getElementByIndex(1);
+      root['list'].moveAfter(item.getID());
+      assert.equal('{"list":[0,2,1]}', root.toJSON());
+    });
+
+    doc.update((root) => {
+      const item = root['list'].getElementByIndex(0);
+      root['list'].moveAfter(item.getID());
+      assert.equal('{"list":[2,1,0]}', root.toJSON());
     });
   });
 
@@ -369,6 +396,35 @@ describe('Array', function () {
         const item = root['k1'].getElementByIndex(2);
         root['k1'].moveFront(item.getID());
         assert.equal('{"k1":[2,0,1]}', root.toJSON());
+      });
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, this.test!.title);
+  });
+
+  it('Can handle concurrent moveAfter operations', async function () {
+    await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root['k1'] = [0, 1, 2];
+        assert.equal('{"k1":[0,1,2]}', root.toJSON());
+      });
+      await c1.sync();
+      await c2.sync();
+      assert.equal(d1.toJSON(), d2.toJSON());
+
+      d1.update((root) => {
+        const item = root['k1'].getElementByIndex(1);
+        root['k1'].moveAfter(item.getID());
+        assert.equal('{"k1":[0,2,1]}', root.toJSON());
+      });
+
+      d2.update((root) => {
+        const item = root['k1'].getElementByIndex(0);
+        root['k1'].moveAfter(item.getID());
+        assert.equal('{"k1":[1,2,0]}', root.toJSON());
       });
 
       await c1.sync();

--- a/test/unit/document/document_test.ts
+++ b/test/unit/document/document_test.ts
@@ -187,6 +187,49 @@ describe('DocumentReplica', function () {
     assert.equal(4, doc.getRoot().data.length);
   });
 
+  it('move elements at the last of array', function () {
+    const doc = DocumentReplica.create('test-col', 'test-doc');
+    doc.update((root) => {
+      root.data = [0, 1, 2];
+    });
+    assert.equal('{"data":[0,1,2]}', doc.toSortedJSON());
+    assert.equal(3, doc.getRoot().data.length);
+
+    doc.update((root) => {
+      const two = root.data.getElementByIndex(2);
+      root.data.moveLast(two.getID());
+    });
+    assert.equal('{"data":[0,1,2]}', doc.toSortedJSON());
+    assert.equal(3, doc.getRoot().data.length);
+
+    doc.update((root) => {
+      root.data.push(3);
+      const two = root.data.getElementByIndex(2);
+      root.data.moveLast(two.getID());
+      assert.equal('{"data":[0,1,3,2]}', root.toJSON());
+    });
+    assert.equal('{"data":[0,1,3,2]}', doc.toSortedJSON());
+    assert.equal(4, doc.getRoot().data.length);
+  });
+
+  it('simple move elements at the last of array', function () {
+    const doc = DocumentReplica.create('test-col', 'test-doc');
+    doc.update((root) => {
+      root.data = [0, 1, 2];
+    });
+    assert.equal('{"data":[0,1,2]}', doc.toSortedJSON());
+    assert.equal(3, doc.getRoot().data.length);
+
+    doc.update((root) => {
+      root.data.push(3);
+      const one = root.data.getElementByIndex(1);
+      root.data.moveLast(one.getID());
+      assert.equal('{"data":[0,2,3,1]}', root.toJSON());
+    });
+    assert.equal('{"data":[0,2,3,1]}', doc.toSortedJSON());
+    assert.equal(4, doc.getRoot().data.length);
+  });
+
   it('change paths test', async function () {
     const doc = DocumentReplica.create('test-col', 'test-doc');
     await new Promise((resolve) => setTimeout(resolve, 0));


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Implement  Array.moveLast

#### Any background context you want to provide?
when we test the below code, we got an error `can't find the node` in `findNextBeforeExecutedAt` function.
```
d1.update((root) => {
    const item = root['k1'].getElementByIndex(1);
    root['k1'].moveAfter(item.getID());
    assert.equal('{"k1":[0,2,1]}', root.toJSON());
  });
```

Because the last node and the node which will move to last are the same and the node is released(deleted), the target node was not found in `findNextBeforeExecutedAt`. So I added a condition to prevent execution of insertAfter if prevNode and node are the same

<img width="1260" alt="Screen Shot 2021-05-29 at 7 57 28 PM" src="https://user-images.githubusercontent.com/4694139/120067722-1b54f480-c0b8-11eb-9896-a93a45e79e71.png">

I'm curious if there is another good way.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
