### PR TITLE
Change function not to occur error when retrieving deleted element after garbage collection

### DIFF
--- a/src/document/json/array.ts
+++ b/src/document/json/array.ts
@@ -73,7 +73,7 @@ export class JSONArray extends JSONContainer {
   /**
    * `get` returns the element of the given createAt.
    */
-  public get(createdAt: TimeTicket): JSONElement {
+  public get(createdAt: TimeTicket): JSONElement | undefined {
     return this.elements.get(createdAt);
   }
 

--- a/src/document/json/rga_tree_list.ts
+++ b/src/document/json/rga_tree_list.ts
@@ -268,9 +268,13 @@ export class RGATreeList {
   /**
    * `get` returns the element of the given index.
    */
-  public get(createdAt: TimeTicket): JSONElement {
+  public get(createdAt: TimeTicket): JSONElement | undefined {
     const node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
-    return node!.getValue();
+    if (!node) {
+      return;
+    }
+
+    return node.getValue();
   }
 
   /**


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?


Modify to return `undefiend` when searching through already deleted element ID. (current version -> occur an error)

Why?
Users can try to retrieve the element with the deleted element's createdID that is already removed by garbage collection

#### Any background context you want to provide?

Currently, only reflected `getElementByID`(this PR), but I wonder if `deleteByID` needs to be reflected as well

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #208

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
