### PR TITLE
Export enum and resolve issue not exporting other modules excepts for default

### DIFF
--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -15,7 +15,7 @@ services:
     depends_on:
       - yorkie
   yorkie:
-    image: 'yorkieteam/yorkie:latest'
+    image: 'yorkieteam/yorkie:0.1.6'
     container_name: 'yorkie'
     command: [
       'agent',

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -43,21 +43,33 @@ import { DocumentKey } from '../document/key/document_key';
 import { DocumentReplica } from '../document/document';
 import { AuthUnaryInterceptor, AuthStreamInterceptor } from './auth';
 
+/**
+ * `ClientStatus` is client status types
+ */
 export enum ClientStatus {
   Deactivated = 'deactivated',
   Activated = 'activated',
 }
 
+/**
+ * `StreamConnectionStatus` is stream connection status types
+ */
 export enum StreamConnectionStatus {
   Connected = 'connected',
   Disconnected = 'disconnected',
 }
 
+/**
+ * `DocumentSyncResultType` is document sync result types
+ */
 export enum DocumentSyncResultType {
   Synced = 'synced',
   SyncFailed = 'sync-failed',
 }
 
+/**
+ * `ClientEventType` is client event types
+ */
 export enum ClientEventType {
   StatusChanged = 'status-changed',
   DocumentsChanged = 'documents-changed',

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -37,6 +37,9 @@ import { createProxy } from './proxy/proxy';
 import { Checkpoint, InitialCheckpoint } from './checkpoint/checkpoint';
 import { TimeTicket } from './time/ticket';
 
+/**
+ * `DocEventType` is document event types
+ */
 export enum DocEventType {
   Snapshot = 'snapshot',
   LocalChange = 'local-change',

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -38,6 +38,11 @@ export {
 export { TimeTicket } from './document/time/ticket';
 export { ActorID } from './document/time/actor_id';
 export { TextChange, TextChangeType } from './document/json/rga_tree_split';
+export { JSONElement } from './document/json/element';
+export { JSONObject } from './document/json/object';
+export { JSONArray } from './document/json/array';
+export { PlainText } from './document/json/plain_text';
+export { RichText } from './document/json/rich_text';
 
 /**
  * `createClient` creates a new instance of `Client`.

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -18,8 +18,15 @@ import { Client, ClientOptions } from './core/client';
 import { DocumentReplica, Indexable } from './document/document';
 
 export { Client, ClientOptions, DocumentReplica };
-export { Metadata, ClientEvent } from './core/client';
-export { DocEvent } from './document/document';
+export {
+  Metadata,
+  ClientEvent,
+  ClientStatus,
+  StreamConnectionStatus,
+  DocumentSyncResultType,
+  ClientEventType,
+} from './core/client';
+export { DocEvent, DocEventType } from './document/document';
 export {
   Observer,
   Observable,
@@ -30,11 +37,6 @@ export {
 } from './util/observable';
 export { TimeTicket } from './document/time/ticket';
 export { ActorID } from './document/time/actor_id';
-export { JSONElement } from './document/json/element';
-export { JSONObject } from './document/json/object';
-export { JSONArray } from './document/json/array';
-export { PlainText } from './document/json/plain_text';
-export { RichText } from './document/json/rich_text';
 export { TextChange, TextChangeType } from './document/json/rga_tree_split';
 
 /**

--- a/test/unit/document/json/root_test.ts
+++ b/test/unit/document/json/root_test.ts
@@ -11,7 +11,7 @@ import { InitialTimeTicket } from '../../../../src/document/time/ticket';
 import { MaxTimeTicket } from '../../../../src/document/time/ticket';
 import { RGATreeList } from '../../../../src/document/json/rga_tree_list';
 import { JSONPrimitive } from '../../../../src/document/json/primitive';
-import { JSONArray } from '../../../../src/yorkie';
+import { JSONArray } from '../../../../src/document/json/array';
 
 describe('ROOT', function () {
   it('basic test', function () {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,7 +59,6 @@ module.exports = {
   output: {
     library: 'yorkie',
     libraryTarget: 'umd',
-    libraryExport: 'default',
     filename: 'yorkie-js-sdk.js',
     path: path.resolve(__dirname, './dist'),
   },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
export enum ClientStatus, StreamConnectionStatus, DocumentSyncResultType, ClientEventType, DocEventType

#### Any background context you want to provide?
export enum ClientStatus, StreamConnectionStatus, DocumentSyncResultType, ClientEventType, DocEventType and update comments

I removed these modules because it doesn't seem to need to export 🤔 

```
export { JSONElement } from './document/json/element';
export { JSONObject } from './document/json/object';
export { JSONArray } from './document/json/array';
export { PlainText } from './document/json/plain_text';
export { RichText } from './document/json/rich_text';
```

And There was an issue not exporting other modules except for default. And I figured it out it happened because of webpack config. ` libraryExport: 'default'` https://webpack.js.org/configuration/output/#outputlibraryexport-1

```
output: {
    library: 'yorkie',
    libraryTarget: 'umd',
    libraryExport: 'default', <--- this config
    filename: 'yorkie-js-sdk.js',
    path: path.resolve(__dirname, './dist'),
  },
```
#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #109 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
