### PR TITLE
Clean up bunch of warning messages after run `npm run build`

### DIFF
--- a/api-extractor.json
+++ b/api-extractor.json
@@ -3,8 +3,11 @@
   "mainEntryPointFilePath": "<projectFolder>/lib/yorkie.d.ts",
   "bundledPackages": [],
   "apiReport": {
-    "enabled": false,
-    "reportFolder": "<projectFolder>/api-review/"
+    "enabled": true,
+    "reportFolder": "<projectFolder>/lib/"
+  },
+  "compiler": {
+    "skipLibCheck": true
   },
   "docModel": {
     "enabled": false

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -45,6 +45,7 @@ import { AuthUnaryInterceptor, AuthStreamInterceptor } from './auth';
 
 /**
  * `ClientStatus` is client status types
+ * @public
  */
 export enum ClientStatus {
   Deactivated = 'deactivated',
@@ -53,6 +54,7 @@ export enum ClientStatus {
 
 /**
  * `StreamConnectionStatus` is stream connection status types
+ * @public
  */
 export enum StreamConnectionStatus {
   Connected = 'connected',
@@ -61,6 +63,7 @@ export enum StreamConnectionStatus {
 
 /**
  * `DocumentSyncResultType` is document sync result types
+ * @public
  */
 export enum DocumentSyncResultType {
   Synced = 'synced',
@@ -69,6 +72,7 @@ export enum DocumentSyncResultType {
 
 /**
  * `ClientEventType` is client event types
+ * @public
  */
 export enum ClientEventType {
   StatusChanged = 'status-changed',

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -39,6 +39,7 @@ import { TimeTicket } from './time/ticket';
 
 /**
  * `DocEventType` is document event types
+ * @public
  */
 export enum DocEventType {
   Snapshot = 'snapshot',


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Clean up bunch of warning messages after run `npm run build`

#### Any background context you want to provide?
According to this document(https://api-extractor.com/pages/setup/configure_api_report/), I redirected warnings to the API report file in the hidden folder with "reportFolder" config. In my view, some warning messages we can ignore. for example, `ae-forgotten-export`, `ae-internal-missing-underscore`. these are already set in the `api-extractor-default.json`. So I followed this rule

So after configuring `api-extractor.json`, we are getting the following messages.

- ae-missing-release-tag -> I added `@public` tag to solve it
<img width="1227" alt="Screen Shot 2021-08-14 at 11 01 25 PM" src="https://user-images.githubusercontent.com/4694139/129449414-2d8e317e-ad31-4431-afc2-f3871ae920e7.png">

+ to fix the following error, I added `skipLibCheck` config
<img width="1373" alt="Screen Shot 2021-08-14 at 11 01 44 PM" src="https://user-images.githubusercontent.com/4694139/129449471-be671c08-a9dd-4181-a558-64b94d9d20c9.png">

```
"compiler": {
    "skipLibCheck": true <--
  },
```

reference: https://github.com/microsoft/rushstack/blob/master/apps/api-extractor/src/schemas/api-extractor-defaults.json

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #224 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
