### PR TITLE
Fix reduce array size when deleting the same position

### DIFF
--- a/src/document/json/rga_tree_list.ts
+++ b/src/document/json/rga_tree_list.ts
@@ -343,7 +343,8 @@ export class RGATreeList {
    */
   public delete(createdAt: TimeTicket, editedAt: TimeTicket): JSONElement {
     const node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
-    if (node!.remove(editedAt) && node!.isRemoved() === false) {
+    const alreadyRemoved = node!.isRemoved();
+    if (node!.remove(editedAt) && !alreadyRemoved) {
       this.nodeMapByIndex.splayNode(node!);
       this.size -= 1;
     }

--- a/src/document/json/rga_tree_list.ts
+++ b/src/document/json/rga_tree_list.ts
@@ -343,7 +343,7 @@ export class RGATreeList {
    */
   public delete(createdAt: TimeTicket, editedAt: TimeTicket): JSONElement {
     const node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
-    if (node!.isRemoved() === false && node!.remove(editedAt)) {
+    if (node!.remove(editedAt) && node!.isRemoved() === false) {
       this.nodeMapByIndex.splayNode(node!);
       this.size -= 1;
     }

--- a/src/document/json/rga_tree_list.ts
+++ b/src/document/json/rga_tree_list.ts
@@ -343,7 +343,7 @@ export class RGATreeList {
    */
   public delete(createdAt: TimeTicket, editedAt: TimeTicket): JSONElement {
     const node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
-    if (node!.remove(editedAt)) {
+    if (!node!.isRemoved() && node!.remove(editedAt)) {
       this.nodeMapByIndex.splayNode(node!);
       this.size -= 1;
     }

--- a/src/document/json/rga_tree_list.ts
+++ b/src/document/json/rga_tree_list.ts
@@ -343,7 +343,7 @@ export class RGATreeList {
    */
   public delete(createdAt: TimeTicket, editedAt: TimeTicket): JSONElement {
     const node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
-    if (!node!.isRemoved() && node!.remove(editedAt)) {
+    if (node!.isRemoved() === false && node!.remove(editedAt)) {
       this.nodeMapByIndex.splayNode(node!);
       this.size -= 1;
     }

--- a/test/integration/array_test.ts
+++ b/test/integration/array_test.ts
@@ -650,18 +650,14 @@ describe('Array', function () {
 
       d1.update((root) => {
         const prev = root['k1'].getElementByIndex(3);
-
         assert.equal(4, root['k1'].length);
-
         root['k1'].insertBefore(prev.getID(), 6);
         assert.equal('{"k1":[1,5,3,6,4]}', root.toJSON());
         assert.equal(5, root['k1'].length);
       });
       d2.update((root) => {
         const prev = root['k1'].getElementByIndex(0);
-
         assert.equal(4, root['k1'].length);
-
         root['k1'].insertBefore(prev.getID(), 7);
         assert.equal('{"k1":[7,1,5,3,4]}', root.toJSON());
         assert.equal(5, root['k1'].length);

--- a/test/integration/array_test.ts
+++ b/test/integration/array_test.ts
@@ -602,16 +602,21 @@ describe('Array', function () {
       d1.update((root) => {
         root['k1'].deleteByID(prev.getID());
         assert.equal('{"k1":[]}', root.toJSON());
+        assert.equal(0, root['k1'].length);
       });
       d2.update((root) => {
         root['k1'].insertBefore(prev.getID(), 2);
         assert.equal('{"k1":[2,1]}', root.toJSON());
+        assert.equal(2, root['k1'].length);
       });
       await c1.sync();
       await c2.sync();
       await c1.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-      assert.equal('{"k1":[2]}', d1.toJSON());
+      d1.update((root) => {
+        assert.equal('{"k1":[2]}', root.toJSON());
+        assert.equal(1, root['k1'].length);
+      });
     }, this.test!.title);
   });
 
@@ -630,10 +635,12 @@ describe('Array', function () {
       d1.update((root) => {
         root['k1'].deleteByID(prev.getID());
         assert.equal('{"k1":[1,3,4]}', root.toJSON());
+        assert.equal(3, root['k1'].length);
       });
       d2.update((root) => {
         root['k1'].insertBefore(prev.getID(), 5);
         assert.equal('{"k1":[1,5,2,3,4]}', root.toJSON());
+        assert.equal(5, root['k1'].length);
       });
       await c1.sync();
       await c2.sync();
@@ -643,19 +650,30 @@ describe('Array', function () {
 
       d1.update((root) => {
         const prev = root['k1'].getElementByIndex(3);
+
+        assert.equal(4, root['k1'].length);
+
         root['k1'].insertBefore(prev.getID(), 6);
         assert.equal('{"k1":[1,5,3,6,4]}', root.toJSON());
+        assert.equal(5, root['k1'].length);
       });
       d2.update((root) => {
         const prev = root['k1'].getElementByIndex(0);
+
+        assert.equal(4, root['k1'].length);
+
         root['k1'].insertBefore(prev.getID(), 7);
         assert.equal('{"k1":[7,1,5,3,4]}', root.toJSON());
+        assert.equal(5, root['k1'].length);
       });
       await c1.sync();
       await c2.sync();
       await c1.sync();
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-      assert.equal('{"k1":[7,1,5,3,6,4]}', d1.toJSON());
+      d1.update((root) => {
+        assert.equal('{"k1":[7,1,5,3,6,4]}', root.toJSON());
+        assert.equal(6, root['k1'].length);
+      });
     }, this.test!.title);
   });
 

--- a/test/integration/array_test.ts
+++ b/test/integration/array_test.ts
@@ -558,7 +558,36 @@ describe('Array', function () {
     }, this.test!.title);
   });
 
-  it('Can handle concurrent concurrent delete operations', async function() {
+  it('Can handle concurrent delete operations', async function () {
+    await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
+      let prev: JSONElement;
+      d1.update((root) => {
+        root['k1'] = [1, 2, 3, 4];
+      });
+      await c1.sync();
+      await c2.sync();
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+
+      d1.update((root) => {
+        prev = root['k1'].getElementByIndex(2);
+        root['k1'].deleteByID(prev.getCreatedAt());
+      });
+
+      d2.update((root) => {
+        prev = root['k1'].getElementByIndex(2);
+        root['k1'].deleteByID(prev.getCreatedAt());
+      });
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+      d1.update((root) => {
+        assert.equal(3, root['k1'].length);
+      });
+    }, this.test!.title);
+  });
+
+  it('Can handle concurrent concurrent delete operations', async function () {
     await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
       let prev: JSONElement;
       d1.update((root) => {

--- a/test/integration/array_test.ts
+++ b/test/integration/array_test.ts
@@ -587,35 +587,6 @@ describe('Array', function () {
     }, this.test!.title);
   });
 
-  it('Can handle concurrent concurrent delete operations', async function () {
-    await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
-      let prev: JSONElement;
-      d1.update((root) => {
-        root['k1'] = [1, 2, 3, 4];
-      });
-      await c1.sync();
-      await c2.sync();
-      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-
-      d1.update((root) => {
-        prev = root['k1'].getElementByIndex(2);
-        root['k1'].deleteByID(prev.getCreatedAt());
-      });
-
-      d2.update((root) => {
-        prev = root['k1'].getElementByIndex(2);
-        root['k1'].deleteByID(prev.getCreatedAt());
-      });
-
-      await c1.sync();
-      await c2.sync();
-      await c1.sync();
-      d1.update((root) => {
-        assert.equal(3, root['k1'].length);
-      });
-    }, this.test!.title);
-  });
-
   it('Can handle concurrent insertBefore and delete operations', async function () {
     await withTwoClientsAndDocuments(async (c1, d1, c2, d2) => {
       let prev: JSONElement;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- fixed the array size reducing problem when deleting the same index.
- Add test

#### Any background context you want to provide?
I think I don't need to do a splay operation again for the removed node, so I fixed to perform a splay operation only when deleting an undeleted node. Please let me know if it's wrong.

#### What are the relevant tickets?

Fixes #225 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything

