### PR TITLE
Handle special characters in keys of the path in change events

### DIFF
--- a/src/document/json/root.ts
+++ b/src/document/json/root.ts
@@ -95,9 +95,11 @@ export class JSONRoot {
     const keys: Array<string> = [];
     while (pair.parent) {
       const createdAt = pair.element.getCreatedAt();
-      const key = pair.parent.keyOf(createdAt);
+      let key = pair.parent.keyOf(createdAt);
       if (key === undefined) {
         logger.fatal(`cant find the given element: ${createdAt.toIDString()}`);
+      } else {
+        key = key.replace(/[$.]/g, '\\$&');
       }
 
       keys.unshift(key!);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Handle special characters in keys of the path in change events

#### Any background context you want to provide?
We pass the path so the user knows which element of the document has changed. And sometimes the special characters `.` and `$` can be included in the key. To user deal with the path without confusion, I escaped the special character `$` and `.` for keys.
ex) o$j, n.um => o\$j, n\.um

In terms of the `changing path test`, in my view, it seems too big so I split to `object`, `array`, `counter`, `text`, `rich_text` test. 

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #183

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
