### PR TITLE
Add testcases for array splice

### DIFF
--- a/test/integration/array_test.ts
+++ b/test/integration/array_test.ts
@@ -740,7 +740,7 @@ describe('Array', function () {
     assert.equal('{"k1":["1","4","3"]}', doc.toSortedJSON());
   });
 
-  it('Can handle array splice methods - add(just right after length of array)', function () {
+  it('Can handle array splice methods - add(within the range of array length)', function () {
     const doc = DocumentReplica.create('test-col', 'test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
@@ -748,8 +748,12 @@ describe('Array', function () {
       root['k1'] = ['1', '2', '3'];
       root['k1'].splce(3, 1, 4);
     }, 'set {"k1":["1","2","3","4"]}');
-
     assert.equal('{"k1":["1","2","3","4"]}', doc.toSortedJSON());
+
+    doc.update((root) => {
+      root['k1'].splce(3, 0, 5);
+    }, 'set {"k1":["1","2","3","5","4"]}');
+    assert.equal('{"k1":["1","2","3","5","4"]}', doc.toSortedJSON());
   });
 
   it('Can handle array splice methods - add(over length of array)', function () {
@@ -760,7 +764,11 @@ describe('Array', function () {
       root['k1'] = ['1', '2', '3'];
       root['k1'].splce(100, 1, 4);
     }, 'set {"k1":["1","2","3","4"]}');
-
     assert.equal('{"k1":["1","2","3","4"]}', doc.toSortedJSON());
+
+    doc.update((root) => {
+      root['k1'].splce(100, 0, 5);
+    }, 'set {"k1":["1","2","3","4","5"]}');
+    assert.equal('{"k1":["1","2","3","4","5"]}', doc.toSortedJSON());
   });
 });

--- a/test/integration/array_test.ts
+++ b/test/integration/array_test.ts
@@ -715,4 +715,52 @@ describe('Array', function () {
 
     assert.equal('{"list":[0,1]}', doc.toSortedJSON());
   });
+
+  it('Can handle array splice methods - delete', function () {
+    const doc = DocumentReplica.create('test-col', 'test-doc');
+    assert.equal('{}', doc.toSortedJSON());
+
+    doc.update((root) => {
+      root['k1'] = ['1', '2', '3'];
+      root['k1'].splce(1, 1);
+    }, 'set {"k1":["1","3"]}');
+
+    assert.equal('{"k1":["1","3"]}', doc.toSortedJSON());
+  });
+
+  it('Can handle array splice methods - modify', function () {
+    const doc = DocumentReplica.create('test-col', 'test-doc');
+    assert.equal('{}', doc.toSortedJSON());
+
+    doc.update((root) => {
+      root['k1'] = ['1', '2', '3'];
+      root['k1'].splce(1, 1, 4);
+    }, 'set {"k1":["1","4","3"]}');
+
+    assert.equal('{"k1":["1","4","3"]}', doc.toSortedJSON());
+  });
+
+  it('Can handle array splice methods - add(just right after length of array)', function () {
+    const doc = DocumentReplica.create('test-col', 'test-doc');
+    assert.equal('{}', doc.toSortedJSON());
+
+    doc.update((root) => {
+      root['k1'] = ['1', '2', '3'];
+      root['k1'].splce(3, 1, 4);
+    }, 'set {"k1":["1","2","3","4"]}');
+
+    assert.equal('{"k1":["1","2","3","4"]}', doc.toSortedJSON());
+  });
+
+  it('Can handle array splice methods - add(over length of array)', function () {
+    const doc = DocumentReplica.create('test-col', 'test-doc');
+    assert.equal('{}', doc.toSortedJSON());
+
+    doc.update((root) => {
+      root['k1'] = ['1', '2', '3'];
+      root['k1'].splce(100, 1, 4);
+    }, 'set {"k1":["1","2","3","4"]}');
+
+    assert.equal('{"k1":["1","2","3","4"]}', doc.toSortedJSON());
+  });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

In Javascript array method, splice,  is one of way to manipulate array. 

#### Any background context you want to provide?

Some examples regarding splice below:

```javascript
/* delete */
a = [1, 2, 3];
a.splice(1, 1); // [1, 3]

/* modify */
a = [1, 2, 3];
a.splice(1, 1, 4); // [1, 4, 2]

/* add */
a = [1, 2, 3];
a.splice(3, 1, 4); // [1, 2, 3, 4]
a.splice(3, 1, 5); // [1, 2, 3, 5, 4] 
```

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #282 

### todo:

- [x] Add testcases
- [ ] Implement array.splice in ArrayProxy

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
