### PR TITLE
Fix `tsconfig` is not recognized in VSCode

### DIFF
--- a/config/api-extractor.json
+++ b/config/api-extractor.json
@@ -9,7 +9,7 @@
   },
   "compiler": {
     "skipLibCheck": true,
-    "tsconfigFilePath": "<projectFolder>/config/tsconfig.json"
+    "tsconfigFilePath": "<projectFolder>/tsconfig.json"
   },
   "docModel": {
     "enabled": false

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -52,7 +52,7 @@ module.exports = {
         use: {
           loader: 'ts-loader',
           options: {
-            configFile: path.resolve(__dirname, './tsconfig.json'),
+            configFile: path.resolve(__dirname, '../tsconfig.json'),
           },
         },
         exclude: /node_modules/,

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -29,7 +29,7 @@ module.exports = {
         use: {
           loader: 'ts-loader',
           options: {
-            configFile: path.resolve(__dirname, './tsconfig.json'),
+            configFile: path.resolve(__dirname, '../tsconfig.json'),
           },
         },
         exclude: /node_modules/,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,9 +5,9 @@
     "removeComments": false,
     "allowSyntheticDefaultImports": true,
     "declaration": true,
-    "outDir": "../lib",
+    "outDir": "./lib",
     "strict": true,
-    "baseUrl": "../",
+    "baseUrl": ".",
     "paths": {
       "@yorkie-js-sdk/src/*": ["src/*"],
       "@yorkie-js-sdk/test/*": ["test/*"]
@@ -17,7 +17,7 @@
       { "transform": "typescript-transform-paths", "afterDeclarations": true }
     ]
   },
-  "include": ["../src/**/*", "../test/**/*"],
-  "exclude": ["../node_modules"],
-  "typeRoots": ["../node_modules/@types"]
+  "include": ["./src/**/*", "./test/**/*"],
+  "exclude": ["./node_modules"],
+  "typeRoots": ["./node_modules/@types"]
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Move `tsconfig` path from config directory to root directory

#### Any background context you want to provide?
![image](https://user-images.githubusercontent.com/4694139/162607970-f38c30f5-1840-4a27-bb3c-a2b3d24f2a6e.png)
We are having alias path is not recognized warning message in vscode although we configured alias path in tsconfig and webpack. 

I found out this answer from stackoverflow. https://stackoverflow.com/questions/68625074/can-i-set-a-typescript-configuration-tsconfig-json-path-on-the-vscode-ide-to-u. it seems this error invoked because tsconfig path is not root directory. 

https://www.typescriptlang.org/docs/handbook/tsconfig-json.html

> The presence of a tsconfig.json file in a directory indicates that the directory is the root of a TypeScript project. The tsconfig.json file specifies the root files and the compiler options required to compile the project.

So I move the file to the root directory and changed base URL and etc. I'm not sure this is good way. So please feel free to comment on my pr!

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
