### PR TITLE
Rename types exposed to the user to more generic names

### DIFF
--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -37,17 +37,17 @@ import { Checkpoint } from '@yorkie-js-sdk/src/document/change/checkpoint';
 import { RHTPQMap } from '@yorkie-js-sdk/src/document/json/rht_pq_map';
 import { RGATreeList } from '@yorkie-js-sdk/src/document/json/rga_tree_list';
 import { JSONElement } from '@yorkie-js-sdk/src/document/json/element';
-import { JSONObject } from '@yorkie-js-sdk/src/document/json/object';
-import { JSONArray } from '@yorkie-js-sdk/src/document/json/array';
+import { ObjectInternal } from '@yorkie-js-sdk/src/document/json/object';
+import { ArrayInternal } from '@yorkie-js-sdk/src/document/json/array';
 import {
   RGATreeSplit,
   RGATreeSplitNode,
   RGATreeSplitNodeID,
   RGATreeSplitNodePos,
 } from '@yorkie-js-sdk/src/document/json/rga_tree_split';
-import { PlainText } from '@yorkie-js-sdk/src/document/json/plain_text';
+import { PlainTextInternal } from '@yorkie-js-sdk/src/document/json/plain_text';
 import {
-  RichText,
+  RichTextInternal,
   RichTextValue,
 } from '@yorkie-js-sdk/src/document/json/rich_text';
 import {
@@ -74,7 +74,10 @@ import {
   ValueType as PbValueType,
 } from '@yorkie-js-sdk/src/api/resources_pb';
 import { IncreaseOperation } from '@yorkie-js-sdk/src/document/operation/increase_operation';
-import { CounterType, Counter } from '@yorkie-js-sdk/src/document/json/counter';
+import {
+  CounterType,
+  CounterInternal,
+} from '@yorkie-js-sdk/src/document/json/counter';
 
 /**
  * `fromPresence` converts the given Protobuf format to model format.
@@ -191,16 +194,16 @@ function toCounterType(valueType: CounterType): PbValueType {
  */
 function toJSONElementSimple(jsonElement: JSONElement): PbJSONElementSimple {
   const pbJSONElement = new PbJSONElementSimple();
-  if (jsonElement instanceof JSONObject) {
+  if (jsonElement instanceof ObjectInternal) {
     pbJSONElement.setType(PbValueType.JSON_OBJECT);
     pbJSONElement.setCreatedAt(toTimeTicket(jsonElement.getCreatedAt()));
-  } else if (jsonElement instanceof JSONArray) {
+  } else if (jsonElement instanceof ArrayInternal) {
     pbJSONElement.setType(PbValueType.JSON_ARRAY);
     pbJSONElement.setCreatedAt(toTimeTicket(jsonElement.getCreatedAt()));
-  } else if (jsonElement instanceof PlainText) {
+  } else if (jsonElement instanceof PlainTextInternal) {
     pbJSONElement.setType(PbValueType.TEXT);
     pbJSONElement.setCreatedAt(toTimeTicket(jsonElement.getCreatedAt()));
-  } else if (jsonElement instanceof RichText) {
+  } else if (jsonElement instanceof RichTextInternal) {
     pbJSONElement.setType(PbValueType.RICH_TEXT);
     pbJSONElement.setCreatedAt(toTimeTicket(jsonElement.getCreatedAt()));
   } else if (jsonElement instanceof JSONPrimitive) {
@@ -208,8 +211,8 @@ function toJSONElementSimple(jsonElement: JSONElement): PbJSONElementSimple {
     pbJSONElement.setType(toValueType(primitive.getType()));
     pbJSONElement.setCreatedAt(toTimeTicket(jsonElement.getCreatedAt()));
     pbJSONElement.setValue(jsonElement.toBytes());
-  } else if (jsonElement instanceof Counter) {
-    const counter = jsonElement as Counter;
+  } else if (jsonElement instanceof CounterInternal) {
+    const counter = jsonElement as CounterInternal;
     pbJSONElement.setType(toCounterType(counter.getType()));
     pbJSONElement.setCreatedAt(toTimeTicket(jsonElement.getCreatedAt()));
     pbJSONElement.setValue(jsonElement.toBytes());
@@ -466,7 +469,7 @@ function toTextNodes(rgaTreeSplit: RGATreeSplit<string>): Array<PbTextNode> {
 /**
  * `toJSONObject` converts the given model to Protobuf format.
  */
-function toJSONObject(obj: JSONObject): PbJSONElement {
+function toJSONObject(obj: ObjectInternal): PbJSONElement {
   const pbJSONObject = new PbJSONElement.JSONObject();
   pbJSONObject.setNodesList(toRHTNodes(obj.getRHT()));
   pbJSONObject.setCreatedAt(toTimeTicket(obj.getCreatedAt()));
@@ -481,7 +484,7 @@ function toJSONObject(obj: JSONObject): PbJSONElement {
 /**
  * `toJSONArray` converts the given model to Protobuf format.
  */
-function toJSONArray(arr: JSONArray): PbJSONElement {
+function toJSONArray(arr: ArrayInternal): PbJSONElement {
   const pbJSONArray = new PbJSONElement.JSONArray();
   pbJSONArray.setNodesList(toRGANodes(arr.getElements()));
   pbJSONArray.setCreatedAt(toTimeTicket(arr.getCreatedAt()));
@@ -512,7 +515,7 @@ function toJSONPrimitive(primitive: JSONPrimitive): PbJSONElement {
 /**
  * `toPlainText` converts the given model to Protobuf format.
  */
-function toPlainText(text: PlainText): PbJSONElement {
+function toPlainText(text: PlainTextInternal): PbJSONElement {
   const pbText = new PbJSONElement.Text();
   pbText.setNodesList(toTextNodes(text.getRGATreeSplit()));
   pbText.setCreatedAt(toTimeTicket(text.getCreatedAt()));
@@ -527,7 +530,7 @@ function toPlainText(text: PlainText): PbJSONElement {
 /**
  * `toCounter` converts the given model to Protobuf format.
  */
-function toCounter(counter: Counter): PbJSONElement {
+function toCounter(counter: CounterInternal): PbJSONElement {
   const pbJSONCounter = new PbJSONElement.Counter();
   pbJSONCounter.setType(toCounterType(counter.getType()));
   pbJSONCounter.setValue(counter.toBytes());
@@ -544,15 +547,15 @@ function toCounter(counter: Counter): PbJSONElement {
  * `toJSONElement` converts the given model to Protobuf format.
  */
 function toJSONElement(jsonElement: JSONElement): PbJSONElement {
-  if (jsonElement instanceof JSONObject) {
+  if (jsonElement instanceof ObjectInternal) {
     return toJSONObject(jsonElement);
-  } else if (jsonElement instanceof JSONArray) {
+  } else if (jsonElement instanceof ArrayInternal) {
     return toJSONArray(jsonElement);
   } else if (jsonElement instanceof JSONPrimitive) {
     return toJSONPrimitive(jsonElement);
-  } else if (jsonElement instanceof PlainText) {
+  } else if (jsonElement instanceof PlainTextInternal) {
     return toPlainText(jsonElement);
-  } else if (jsonElement instanceof Counter) {
+  } else if (jsonElement instanceof CounterInternal) {
     return toCounter(jsonElement);
   } else {
     throw new YorkieError(
@@ -655,16 +658,20 @@ function fromJSONElementSimple(
 ): JSONElement {
   switch (pbJSONElement.getType()) {
     case PbValueType.JSON_OBJECT:
-      return JSONObject.create(fromTimeTicket(pbJSONElement.getCreatedAt())!);
+      return ObjectInternal.create(
+        fromTimeTicket(pbJSONElement.getCreatedAt())!,
+      );
     case PbValueType.JSON_ARRAY:
-      return JSONArray.create(fromTimeTicket(pbJSONElement.getCreatedAt())!);
+      return ArrayInternal.create(
+        fromTimeTicket(pbJSONElement.getCreatedAt())!,
+      );
     case PbValueType.TEXT:
-      return PlainText.create(
+      return PlainTextInternal.create(
         RGATreeSplit.create(),
         fromTimeTicket(pbJSONElement.getCreatedAt())!,
       );
     case PbValueType.RICH_TEXT:
-      return RichText.create(
+      return RichTextInternal.create(
         RGATreeSplit.create(),
         fromTimeTicket(pbJSONElement.getCreatedAt())!,
       );
@@ -686,8 +693,8 @@ function fromJSONElementSimple(
     case PbValueType.INTEGER_CNT:
     case PbValueType.DOUBLE_CNT:
     case PbValueType.LONG_CNT:
-      return Counter.of(
-        Counter.valueFromBytes(
+      return CounterInternal.of(
+        CounterInternal.valueFromBytes(
           fromCounterType(pbJSONElement.getType()),
           pbJSONElement.getValue_asU8(),
         ),
@@ -905,14 +912,14 @@ function fromChangePack(pbPack: PbChangePack): ChangePack {
 /**
  * `fromJSONObject` converts the given Protobuf format to model format.
  */
-function fromJSONObject(pbObject: PbJSONElement.JSONObject): JSONObject {
+function fromJSONObject(pbObject: PbJSONElement.JSONObject): ObjectInternal {
   const rht = new RHTPQMap();
   for (const pbRHTNode of pbObject.getNodesList()) {
     // eslint-disable-next-line
     rht.set(pbRHTNode.getKey(), fromJSONElement(pbRHTNode.getElement()!));
   }
 
-  const obj = new JSONObject(fromTimeTicket(pbObject.getCreatedAt())!, rht);
+  const obj = new ObjectInternal(fromTimeTicket(pbObject.getCreatedAt())!, rht);
   obj.setMovedAt(fromTimeTicket(pbObject.getMovedAt()));
   obj.setRemovedAt(fromTimeTicket(pbObject.getRemovedAt()));
   return obj;
@@ -921,14 +928,14 @@ function fromJSONObject(pbObject: PbJSONElement.JSONObject): JSONObject {
 /**
  * `fromJSONArray` converts the given Protobuf format to model format.
  */
-function fromJSONArray(pbArray: PbJSONElement.JSONArray): JSONArray {
+function fromJSONArray(pbArray: PbJSONElement.JSONArray): ArrayInternal {
   const rgaTreeList = new RGATreeList();
   for (const pbRGANode of pbArray.getNodesList()) {
     // eslint-disable-next-line
     rgaTreeList.insert(fromJSONElement(pbRGANode.getElement()!));
   }
 
-  const arr = new JSONArray(
+  const arr = new ArrayInternal(
     fromTimeTicket(pbArray.getCreatedAt())!,
     rgaTreeList,
   );
@@ -958,7 +965,7 @@ function fromJSONPrimitive(
 /**
  * `fromJSONText` converts the given Protobuf format to model format.
  */
-function fromJSONText(pbText: PbJSONElement.Text): PlainText {
+function fromJSONText(pbText: PbJSONElement.Text): PlainTextInternal {
   const rgaTreeSplit = new RGATreeSplit<string>();
 
   let prev = rgaTreeSplit.getHead();
@@ -972,7 +979,7 @@ function fromJSONText(pbText: PbJSONElement.Text): PlainText {
     prev = current;
   }
 
-  const text = PlainText.create(
+  const text = PlainTextInternal.create(
     rgaTreeSplit,
     fromTimeTicket(pbText.getCreatedAt())!,
   );
@@ -984,7 +991,7 @@ function fromJSONText(pbText: PbJSONElement.Text): PlainText {
 /**
  * `fromJSONRichText` converts the given Protobuf format to model format.
  */
-function fromJSONRichText(pbText: PbJSONElement.RichText): RichText {
+function fromJSONRichText(pbText: PbJSONElement.RichText): RichTextInternal {
   const rgaTreeSplit = new RGATreeSplit<RichTextValue>();
 
   let prev = rgaTreeSplit.getHead();
@@ -998,7 +1005,7 @@ function fromJSONRichText(pbText: PbJSONElement.RichText): RichText {
     prev = current;
   }
 
-  const text = RichText.create(
+  const text = RichTextInternal.create(
     rgaTreeSplit,
     fromTimeTicket(pbText.getCreatedAt())!,
   );
@@ -1010,9 +1017,9 @@ function fromJSONRichText(pbText: PbJSONElement.RichText): RichText {
 /**
  * `fromCounter` converts the given Protobuf format to model format.
  */
-function fromCounter(pbCounter: PbJSONElement.Counter): Counter {
-  const counter = Counter.of(
-    Counter.valueFromBytes(
+function fromCounter(pbCounter: PbJSONElement.Counter): CounterInternal {
+  const counter = CounterInternal.of(
+    CounterInternal.valueFromBytes(
       fromCounterType(pbCounter.getType()),
       pbCounter.getValue_asU8(),
     ),
@@ -1050,9 +1057,9 @@ function fromJSONElement(pbJSONElement: PbJSONElement): JSONElement {
 /**
  * `bytesToObject` creates an JSONObject from the given byte array.
  */
-function bytesToObject(bytes?: Uint8Array): JSONObject {
+function bytesToObject(bytes?: Uint8Array): ObjectInternal {
   if (!bytes) {
-    return JSONObject.create(InitialTimeTicket);
+    return ObjectInternal.create(InitialTimeTicket);
   }
 
   const pbJSONElement = PbJSONElement.deserializeBinary(bytes);
@@ -1062,7 +1069,7 @@ function bytesToObject(bytes?: Uint8Array): JSONObject {
 /**
  * `objectToBytes` converts the given JSONObject to byte array.
  */
-function objectToBytes(obj: JSONObject): Uint8Array {
+function objectToBytes(obj: ObjectInternal): Uint8Array {
   return toJSONElement(obj).serializeBinary();
 }
 

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -34,14 +34,14 @@ import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
 import { converter } from '@yorkie-js-sdk/src/api/converter';
 import { ChangePack } from '@yorkie-js-sdk/src/document/change/change_pack';
 import { JSONRoot } from '@yorkie-js-sdk/src/document/json/root';
-import { JSONObject } from '@yorkie-js-sdk/src/document/json/object';
+import { ObjectInternal } from '@yorkie-js-sdk/src/document/json/object';
 import { createProxy } from '@yorkie-js-sdk/src/document/proxy/proxy';
 import {
   Checkpoint,
   InitialCheckpoint,
 } from '@yorkie-js-sdk/src/document/change/checkpoint';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { TObject } from './proxy/object_proxy';
+import { JSONObject } from './proxy/object_proxy';
 
 /**
  * `DocEventType` is document event types
@@ -181,7 +181,10 @@ export class DocumentReplica<T = Indexable> implements Observable<DocEvent> {
   /**
    * `update` executes the given updater to update this document.
    */
-  public update(updater: (root: TObject<T>) => void, message?: string): void {
+  public update(
+    updater: (root: JSONObject<T>) => void,
+    message?: string,
+  ): void {
     this.ensureClone();
     const context = ChangeContext.create(
       this.changeID.next(),
@@ -190,7 +193,10 @@ export class DocumentReplica<T = Indexable> implements Observable<DocEvent> {
     );
 
     try {
-      const proxy = createProxy<TObject<T>>(context, this.clone!.getObject());
+      const proxy = createProxy<JSONObject<T>>(
+        context,
+        this.clone!.getObject(),
+      );
       updater(proxy);
     } catch (err) {
       // drop clone because it is contaminated.
@@ -349,7 +355,7 @@ export class DocumentReplica<T = Indexable> implements Observable<DocEvent> {
    *
    * @internal
    */
-  public getClone(): JSONObject | undefined {
+  public getClone(): ObjectInternal | undefined {
     if (!this.clone) {
       return;
     }
@@ -384,7 +390,7 @@ export class DocumentReplica<T = Indexable> implements Observable<DocEvent> {
    *
    * @internal
    */
-  public getRootObject(): JSONObject {
+  public getRootObject(): ObjectInternal {
     return this.root.getObject();
   }
 

--- a/src/document/json/array.ts
+++ b/src/document/json/array.ts
@@ -22,11 +22,11 @@ import {
 import { RGATreeList } from '@yorkie-js-sdk/src/document/json/rga_tree_list';
 
 /**
- * `JSONArray` represents JSON array data structure including logical clock.
+ * `ArrayInternal` represents JSON array data structure including logical clock.
  *
  * @internal
  */
-export class JSONArray extends JSONContainer {
+export class ArrayInternal extends JSONContainer {
   private elements: RGATreeList;
 
   /** @hideconstructor */
@@ -38,8 +38,8 @@ export class JSONArray extends JSONContainer {
   /**
    * `create` creates a new instance of Array.
    */
-  public static create(createdAt: TimeTicket): JSONArray {
-    return new JSONArray(createdAt, RGATreeList.create());
+  public static create(createdAt: TimeTicket): ArrayInternal {
+    return new ArrayInternal(createdAt, RGATreeList.create());
   }
 
   /**
@@ -216,8 +216,8 @@ export class JSONArray extends JSONContainer {
   /**
    * `deepcopy` copies itself deeply.
    */
-  public deepcopy(): JSONArray {
-    const clone = JSONArray.create(this.getCreatedAt());
+  public deepcopy(): ArrayInternal {
+    const clone = ArrayInternal.create(this.getCreatedAt());
     for (const node of this.elements) {
       clone.elements.insertAfter(
         clone.getLastCreatedAt(),

--- a/src/document/json/counter.ts
+++ b/src/document/json/counter.ts
@@ -35,25 +35,28 @@ export enum CounterType {
 type CounterValue = number | Long;
 
 /**
- * `Counter` represents changeable number data type.
+ * `CounterInternal` represents changeable number data type.
  *
- * @public
+ * @internal
  */
-export class Counter extends JSONElement {
+export class CounterInternal extends JSONElement {
   private valueType?: CounterType;
   private value: CounterValue;
 
   constructor(value: CounterValue, createdAt: TimeTicket) {
     super(createdAt);
-    this.valueType = Counter.getCounterType(value);
+    this.valueType = CounterInternal.getCounterType(value);
     this.value = value;
   }
 
   /**
    * `of` creates a new instance of Counter.
    */
-  public static of(value: CounterValue, createdAt: TimeTicket): Counter {
-    return new Counter(value, createdAt);
+  public static of(
+    value: CounterValue,
+    createdAt: TimeTicket,
+  ): CounterInternal {
+    return new CounterInternal(value, createdAt);
   }
   /**
    * `valueFromBytes` parses the given bytes into value.
@@ -99,8 +102,8 @@ export class Counter extends JSONElement {
   /**
    * `deepcopy` copies itself deeply.
    */
-  public deepcopy(): Counter {
-    const counter = Counter.of(this.value, this.getCreatedAt());
+  public deepcopy(): CounterInternal {
+    const counter = CounterInternal.of(this.value, this.getCreatedAt());
     counter.setMovedAt(this.getMovedAt());
     return counter;
   }
@@ -131,7 +134,7 @@ export class Counter extends JSONElement {
    * `isSupport` check if there is a counter type of given value.
    */
   public static isSupport(value: CounterValue): boolean {
-    return !!Counter.getCounterType(value);
+    return !!CounterInternal.getCounterType(value);
   }
 
   /**
@@ -197,11 +200,11 @@ export class Counter extends JSONElement {
   /**
    * `increase` increases numeric data.
    */
-  public increase(v: JSONPrimitive): Counter {
+  public increase(v: JSONPrimitive): CounterInternal {
     /**
      * `checkNumericType` checks if the given target is a numeric type.
      */
-    function checkNumericType(target: JSONPrimitive | Counter): void {
+    function checkNumericType(target: JSONPrimitive | CounterInternal): void {
       if (!target.isNumericType()) {
         throw new TypeError(
           `Unsupported type of value: ${typeof target.getValue()}`,

--- a/src/document/json/object.ts
+++ b/src/document/json/object.ts
@@ -14,25 +14,20 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import {
   JSONContainer,
   JSONElement,
 } from '@yorkie-js-sdk/src/document/json/element';
 import { RHTPQMap } from '@yorkie-js-sdk/src/document/json/rht_pq_map';
-import { PlainText } from '@yorkie-js-sdk/src/document/json/plain_text';
-import { RichText } from '@yorkie-js-sdk/src/document/json/rich_text';
-import { CounterType } from '@yorkie-js-sdk/src/document/json/counter';
-import { CounterProxy } from '@yorkie-js-sdk/src/document/proxy/counter_proxy';
 
 /**
- * `JSONObject` represents a JSON object, but unlike regular JSON, it has time
+ * `ObjectInternal` represents a JSON object, but unlike regular JSON, it has time
  * tickets which is created by logical clock.
  *
  * @internal
  */
-export class JSONObject extends JSONContainer {
+export class ObjectInternal extends JSONContainer {
   private memberNodes: RHTPQMap;
 
   /** @hideconstructor */
@@ -44,30 +39,8 @@ export class JSONObject extends JSONContainer {
   /**
    * `create` creates a new instance of Object.
    */
-  public static create(createdAt: TimeTicket): JSONObject {
-    return new JSONObject(createdAt, RHTPQMap.create());
-  }
-
-  /**
-   * Don't use createText directly. Be sure to use it through a proxy.
-   * The reason for setting the PlainText type as the return value
-   * is to provide the PlainText interface to the user.
-   */
-  public createText(key: string): PlainText {
-    logger.fatal(`unsupported: this method should be called by proxy: ${key}`);
-    // @ts-ignore
-    return;
-  }
-
-  /**
-   * Don't use createRichText directly. Be sure to use it through a proxy.
-   * The reason for setting the RichText type as the return value
-   * is to provide the RichText interface to the user.
-   */
-  public createRichText(key: string): RichText {
-    logger.fatal(`unsupported: this method should be called by proxy: ${key}`);
-    // @ts-ignore
-    return;
+  public static create(createdAt: TimeTicket): ObjectInternal {
+    return new ObjectInternal(createdAt, RHTPQMap.create());
   }
 
   /**
@@ -82,21 +55,6 @@ export class JSONObject extends JSONContainer {
    */
   public purge(value: JSONElement): void {
     this.memberNodes.purge(value);
-  }
-
-  /**
-   * Don't use createCounter directly. Be sure to use it through a proxy.
-   * The reason for setting the CounterProxy type as the return value
-   * is to provide the CounterProxy interface to the user.
-   */
-  public createCounter(
-    key: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    value: CounterType,
-  ): CounterProxy {
-    logger.fatal(`unsupported: this method should be called by proxy: ${key}`);
-    // @ts-ignore
-    return;
   }
 
   /**
@@ -195,8 +153,8 @@ export class JSONObject extends JSONContainer {
   /**
    * `deepcopy` copies itself deeply.
    */
-  public deepcopy(): JSONObject {
-    const clone = JSONObject.create(this.getCreatedAt());
+  public deepcopy(): ObjectInternal {
+    const clone = ObjectInternal.create(this.getCreatedAt());
     for (const node of this.memberNodes) {
       clone.memberNodes.set(node.getStrKey(), node.getValue().deepcopy());
     }

--- a/src/document/json/plain_text.ts
+++ b/src/document/json/plain_text.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { TextElement } from '@yorkie-js-sdk/src/document/json/element';
 import {
@@ -26,12 +25,12 @@ import {
 } from '@yorkie-js-sdk/src/document/json/rga_tree_split';
 
 /**
- * `PlainText` represents plain text element
+ * `PlainTextInternal` represents plain text element
  * Text is an extended data type for the contents of a text editor
  *
  * @internal
  */
-export class PlainText extends TextElement {
+export class PlainTextInternal extends TextElement {
   private onChangesHandler?: (changes: Array<TextChange>) => void;
   private rgaTreeSplit: RGATreeSplit<string>;
   private selectionMap: Map<string, Selection>;
@@ -51,21 +50,8 @@ export class PlainText extends TextElement {
   public static create(
     rgaTreeSplit: RGATreeSplit<string>,
     createdAt: TimeTicket,
-  ): PlainText {
-    return new PlainText(rgaTreeSplit, createdAt);
-  }
-
-  /**
-   * Don't use edit directly. Be sure to use it through a proxy.
-   * The reason for setting the PlainText type as the return value
-   * is to provide the PlainText interface to the user.
-   */
-  public edit(fromIdx: number, toIdx: number, content: string): PlainText {
-    logger.fatal(
-      `unsupported: this method should be called by proxy, ${fromIdx}-${toIdx} ${content}`,
-    );
-    // @ts-ignore
-    return;
+  ): PlainTextInternal {
+    return new PlainTextInternal(rgaTreeSplit, createdAt);
   }
 
   /**
@@ -101,17 +87,6 @@ export class PlainText extends TextElement {
   }
 
   /**
-   * Don't use select directly. Be sure to use it through a proxy.
-   */
-  public select(fromIdx: number, toIdx: number): void {
-    logger.fatal(
-      `unsupported: this method should be called by proxy, ${fromIdx}-${toIdx}`,
-    );
-    // @ts-ignore
-    return;
-  }
-
-  /**
    * `selectInternal` updates selection info of the given selection range.
    *
    * @internal
@@ -140,7 +115,7 @@ export class PlainText extends TextElement {
   }
 
   /**
-   * onChanges registers a handler of onChanges event.
+   * `onChanges` registers a handler of onChanges event.
    */
   public onChanges(handler: (changes: Array<TextChange>) => void): void {
     this.onChangesHandler = handler;
@@ -214,8 +189,8 @@ export class PlainText extends TextElement {
   /**
    * `deepcopy` copies itself deeply.
    */
-  public deepcopy(): PlainText {
-    const text = PlainText.create(
+  public deepcopy(): PlainTextInternal {
+    const text = PlainTextInternal.create(
       this.rgaTreeSplit.deepcopy(),
       this.getCreatedAt(),
     );

--- a/src/document/json/rga_tree_split.ts
+++ b/src/document/json/rga_tree_split.ts
@@ -39,17 +39,15 @@ export enum TextChangeType {
 /**
  * `TextChange` is the value passed as an argument to `Text.onChanges()`.
  * `Text.onChanges()` is called when the `Text` is modified.
- *
- * @internal
  */
-export interface TextChange {
+export type TextChange = {
   type: TextChangeType;
   actor: ActorID;
   from: number;
   to: number;
   content?: string;
   attributes?: Record<string, string>;
-}
+};
 
 interface RGATreeSplitValue {
   length: number;

--- a/src/document/json/rich_text.ts
+++ b/src/document/json/rich_text.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { RHT } from '@yorkie-js-sdk/src/document/json/rht';
 import { TextElement } from '@yorkie-js-sdk/src/document/json/element';
@@ -109,11 +108,11 @@ export class RichTextValue {
 }
 
 /**
- *  `RichText` is an extended data type for the contents of a text editor.
+ *  `RichTextInternal` is an extended data type for the contents of a text editor.
  *
  * @internal
  */
-export class RichText extends TextElement {
+export class RichTextInternal extends TextElement {
   private onChangesHandler?: (changes: Array<TextChange>) => void;
   private rgaTreeSplit: RGATreeSplit<RichTextValue>;
   private selectionMap: Map<string, Selection>;
@@ -135,48 +134,11 @@ export class RichText extends TextElement {
   public static create(
     rgaTreeSplit: RGATreeSplit<RichTextValue>,
     createdAt: TimeTicket,
-  ): RichText {
-    const text = new RichText(rgaTreeSplit, createdAt);
+  ): RichTextInternal {
+    const text = new RichTextInternal(rgaTreeSplit, createdAt);
     const range = text.createRange(0, 0);
     text.editInternal(range, '\n', createdAt);
     return text;
-  }
-
-  /**
-   * Don't use edit directly. Be sure to use it through a proxy.
-   * The reason for setting the RichText type as the return value
-   * is to provide the RichText interface to the user.
-   */
-  public edit(
-    fromIdx: number,
-    toIdx: number,
-    content: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    attributes?: Record<string, string>,
-  ): RichText {
-    logger.fatal(
-      `unsupported: this method should be called by proxy, ${fromIdx}-${toIdx} ${content}`,
-    );
-    // @ts-ignore
-    return;
-  }
-
-  /**
-   * Don't use setStyle directly. Be sure to use it through a proxy.
-   * The reason for setting the RichText type as the return value
-   * is to provide the RichText interface to the user.
-   */
-  public setStyle(
-    fromIdx: number,
-    toIdx: number,
-    key: string,
-    value: string,
-  ): RichText {
-    logger.fatal(
-      `unsupported: this method should be called by proxy, ${fromIdx}-${toIdx} ${key} ${value}`,
-    );
-    // @ts-ignore
-    return;
   }
 
   /**
@@ -274,17 +236,6 @@ export class RichText extends TextElement {
       this.onChangesHandler(changes);
       this.remoteChangeLock = false;
     }
-  }
-
-  /**
-   * Don't use select directly. Be sure to use it through a proxy.
-   */
-  public select(fromIdx: number, toIdx: number): void {
-    logger.fatal(
-      `unsupported: this method should be called by proxy, ${fromIdx}-${toIdx}`,
-    );
-    // @ts-ignore
-    return;
   }
 
   /**
@@ -411,8 +362,8 @@ export class RichText extends TextElement {
   /**
    * `deepcopy` copies itself deeply.
    */
-  public deepcopy(): RichText {
-    const text = new RichText(
+  public deepcopy(): RichTextInternal {
+    const text = new RichTextInternal(
       this.rgaTreeSplit.deepcopy(),
       this.getCreatedAt(),
     );

--- a/src/document/json/root.ts
+++ b/src/document/json/root.ts
@@ -24,7 +24,7 @@ import {
   JSONElement,
   TextElement,
 } from '@yorkie-js-sdk/src/document/json/element';
-import { JSONObject } from '@yorkie-js-sdk/src/document/json/object';
+import { ObjectInternal } from '@yorkie-js-sdk/src/document/json/object';
 
 interface JSONElementPair {
   element: JSONElement;
@@ -40,12 +40,12 @@ interface JSONElementPair {
  * a particular element.
  */
 export class JSONRoot {
-  private rootObject: JSONObject;
+  private rootObject: ObjectInternal;
   private elementPairMapByCreatedAt: Map<string, JSONElementPair>;
   private removedElementSetByCreatedAt: Set<string>;
   private textWithGarbageSetByCreatedAt: Set<string>;
 
-  constructor(rootObject: JSONObject) {
+  constructor(rootObject: ObjectInternal) {
     this.rootObject = rootObject;
     this.elementPairMapByCreatedAt = new Map();
     this.removedElementSetByCreatedAt = new Set();
@@ -68,7 +68,7 @@ export class JSONRoot {
    * `create` creates a new instance of Root.
    */
   public static create(): JSONRoot {
-    return new JSONRoot(JSONObject.create(InitialTimeTicket));
+    return new JSONRoot(ObjectInternal.create(InitialTimeTicket));
   }
 
   /**
@@ -163,7 +163,7 @@ export class JSONRoot {
   /**
    * `getObject` returns root object.
    */
-  public getObject(): JSONObject {
+  public getObject(): ObjectInternal {
     return this.rootObject;
   }
 

--- a/src/document/operation/add_operation.ts
+++ b/src/document/operation/add_operation.ts
@@ -18,7 +18,7 @@ import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { JSONElement } from '@yorkie-js-sdk/src/document/json/element';
 import { JSONRoot } from '@yorkie-js-sdk/src/document/json/root';
-import { JSONArray } from '@yorkie-js-sdk/src/document/json/array';
+import { ArrayInternal } from '@yorkie-js-sdk/src/document/json/array';
 import { Operation } from '@yorkie-js-sdk/src/document/operation/operation';
 
 /**
@@ -56,8 +56,8 @@ export class AddOperation extends Operation {
    */
   public execute(root: JSONRoot): void {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
-    if (parentObject instanceof JSONArray) {
-      const array = parentObject as JSONArray;
+    if (parentObject instanceof ArrayInternal) {
+      const array = parentObject as ArrayInternal;
       const value = this.value.deepcopy();
       array.insertAfter(this.prevCreatedAt, value);
       root.registerElement(value, array);

--- a/src/document/operation/edit_operation.ts
+++ b/src/document/operation/edit_operation.ts
@@ -18,7 +18,7 @@ import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { JSONRoot } from '@yorkie-js-sdk/src/document/json/root';
 import { RGATreeSplitNodePos } from '@yorkie-js-sdk/src/document/json/rga_tree_split';
-import { PlainText } from '@yorkie-js-sdk/src/document/json/plain_text';
+import { PlainTextInternal } from '@yorkie-js-sdk/src/document/json/plain_text';
 import { Operation } from '@yorkie-js-sdk/src/document/operation/operation';
 
 /**
@@ -71,8 +71,8 @@ export class EditOperation extends Operation {
    */
   public execute(root: JSONRoot): void {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
-    if (parentObject instanceof PlainText) {
-      const text = parentObject as PlainText;
+    if (parentObject instanceof PlainTextInternal) {
+      const text = parentObject as PlainTextInternal;
       text.editInternal(
         [this.fromPos, this.toPos],
         this.content,

--- a/src/document/operation/increase_operation.ts
+++ b/src/document/operation/increase_operation.ts
@@ -20,7 +20,7 @@ import { JSONElement } from '@yorkie-js-sdk/src/document/json/element';
 import { JSONRoot } from '@yorkie-js-sdk/src/document/json/root';
 import { JSONPrimitive } from '@yorkie-js-sdk/src/document/json/primitive';
 import { logger } from '@yorkie-js-sdk/src/util/logger';
-import { Counter } from '@yorkie-js-sdk/src/document/json/counter';
+import { CounterInternal } from '@yorkie-js-sdk/src/document/json/counter';
 
 /**
  * `IncreaseOperation` represents an operation that increments a numeric value to Counter.
@@ -54,8 +54,8 @@ export class IncreaseOperation extends Operation {
    */
   public execute(root: JSONRoot): void {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
-    if (parentObject instanceof Counter) {
-      const counter = parentObject as Counter;
+    if (parentObject instanceof CounterInternal) {
+      const counter = parentObject as CounterInternal;
       const value = this.value.deepcopy() as JSONPrimitive;
       counter.increase(value);
     } else {

--- a/src/document/operation/move_operation.ts
+++ b/src/document/operation/move_operation.ts
@@ -17,7 +17,7 @@
 import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { JSONRoot } from '@yorkie-js-sdk/src/document/json/root';
-import { JSONArray } from '@yorkie-js-sdk/src/document/json/array';
+import { ArrayInternal } from '@yorkie-js-sdk/src/document/json/array';
 import { Operation } from '@yorkie-js-sdk/src/document/operation/operation';
 
 /**
@@ -60,8 +60,8 @@ export class MoveOperation extends Operation {
    */
   public execute(root: JSONRoot): void {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
-    if (parentObject instanceof JSONArray) {
-      const array = parentObject as JSONArray;
+    if (parentObject instanceof ArrayInternal) {
+      const array = parentObject as ArrayInternal;
       array.moveAfter(
         this.prevCreatedAt!,
         this.createdAt,

--- a/src/document/operation/rich_edit_operation.ts
+++ b/src/document/operation/rich_edit_operation.ts
@@ -18,7 +18,7 @@ import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { JSONRoot } from '@yorkie-js-sdk/src/document/json/root';
 import { RGATreeSplitNodePos } from '@yorkie-js-sdk/src/document/json/rga_tree_split';
-import { RichText } from '@yorkie-js-sdk/src/document/json/rich_text';
+import { RichTextInternal } from '@yorkie-js-sdk/src/document/json/rich_text';
 import { Operation } from '@yorkie-js-sdk/src/document/operation/operation';
 
 /**
@@ -77,8 +77,8 @@ export class RichEditOperation extends Operation {
    */
   public execute(root: JSONRoot): void {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
-    if (parentObject instanceof RichText) {
-      const text = parentObject as RichText;
+    if (parentObject instanceof RichTextInternal) {
+      const text = parentObject as RichTextInternal;
       text.editInternal(
         [this.fromPos, this.toPos],
         this.content,

--- a/src/document/operation/select_operation.ts
+++ b/src/document/operation/select_operation.ts
@@ -18,8 +18,8 @@ import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { JSONRoot } from '@yorkie-js-sdk/src/document/json/root';
 import { RGATreeSplitNodePos } from '@yorkie-js-sdk/src/document/json/rga_tree_split';
-import { PlainText } from '@yorkie-js-sdk/src/document/json/plain_text';
-import { RichText } from '@yorkie-js-sdk/src/document/json/rich_text';
+import { PlainTextInternal } from '@yorkie-js-sdk/src/document/json/plain_text';
+import { RichTextInternal } from '@yorkie-js-sdk/src/document/json/rich_text';
 import { Operation } from '@yorkie-js-sdk/src/document/operation/operation';
 
 /**
@@ -57,11 +57,11 @@ export class SelectOperation extends Operation {
    */
   public execute(root: JSONRoot): void {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
-    if (parentObject instanceof PlainText) {
-      const text = parentObject as PlainText;
+    if (parentObject instanceof PlainTextInternal) {
+      const text = parentObject as PlainTextInternal;
       text.selectInternal([this.fromPos, this.toPos], this.getExecutedAt());
-    } else if (parentObject instanceof RichText) {
-      const text = parentObject as RichText;
+    } else if (parentObject instanceof RichTextInternal) {
+      const text = parentObject as RichTextInternal;
       text.selectInternal([this.fromPos, this.toPos], this.getExecutedAt());
     } else {
       if (!parentObject) {

--- a/src/document/operation/set_operation.ts
+++ b/src/document/operation/set_operation.ts
@@ -18,7 +18,7 @@ import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { JSONElement } from '@yorkie-js-sdk/src/document/json/element';
 import { JSONRoot } from '@yorkie-js-sdk/src/document/json/root';
-import { JSONObject } from '@yorkie-js-sdk/src/document/json/object';
+import { ObjectInternal } from '@yorkie-js-sdk/src/document/json/object';
 import { Operation } from '@yorkie-js-sdk/src/document/operation/operation';
 
 /**
@@ -57,8 +57,8 @@ export class SetOperation extends Operation {
    */
   public execute(root: JSONRoot): void {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
-    if (parentObject instanceof JSONObject) {
-      const obj = parentObject as JSONObject;
+    if (parentObject instanceof ObjectInternal) {
+      const obj = parentObject as ObjectInternal;
       const value = this.value.deepcopy();
       obj.set(this.key, value);
       root.registerElement(value, obj);

--- a/src/document/operation/style_operation.ts
+++ b/src/document/operation/style_operation.ts
@@ -18,7 +18,7 @@ import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { JSONRoot } from '@yorkie-js-sdk/src/document/json/root';
 import { RGATreeSplitNodePos } from '@yorkie-js-sdk/src/document/json/rga_tree_split';
-import { RichText } from '@yorkie-js-sdk/src/document/json/rich_text';
+import { RichTextInternal } from '@yorkie-js-sdk/src/document/json/rich_text';
 import { Operation } from '@yorkie-js-sdk/src/document/operation/operation';
 
 /**
@@ -66,8 +66,8 @@ export class StyleOperation extends Operation {
    */
   public execute(root: JSONRoot): void {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
-    if (parentObject instanceof RichText) {
-      const text = parentObject as RichText;
+    if (parentObject instanceof RichTextInternal) {
+      const text = parentObject as RichTextInternal;
       text.setStyleInternal(
         [this.fromPos, this.toPos],
         this.attributes ? Object.fromEntries(this.attributes) : {},

--- a/src/document/proxy/proxy.ts
+++ b/src/document/proxy/proxy.ts
@@ -16,26 +16,26 @@
 
 import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
 import { JSONElement } from '@yorkie-js-sdk/src/document/json/element';
-import { JSONObject } from '@yorkie-js-sdk/src/document/json/object';
-import { JSONArray } from '@yorkie-js-sdk/src/document/json/array';
+import { ObjectInternal } from '@yorkie-js-sdk/src/document/json/object';
+import { ArrayInternal } from '@yorkie-js-sdk/src/document/json/array';
 import { JSONPrimitive } from '@yorkie-js-sdk/src/document/json/primitive';
-import { RichText } from '@yorkie-js-sdk/src/document/json/rich_text';
-import { PlainText } from '@yorkie-js-sdk/src/document/json/plain_text';
+import { RichTextInternal } from '@yorkie-js-sdk/src/document/json/rich_text';
+import { PlainTextInternal } from '@yorkie-js-sdk/src/document/json/plain_text';
 import { ObjectProxy } from '@yorkie-js-sdk/src/document/proxy/object_proxy';
 import { ArrayProxy } from '@yorkie-js-sdk/src/document/proxy/array_proxy';
 import { TextProxy } from '@yorkie-js-sdk/src/document/proxy/text_proxy';
 import { RichTextProxy } from '@yorkie-js-sdk/src/document/proxy/rich_text_proxy';
 import { CounterProxy } from '@yorkie-js-sdk/src/document/proxy/counter_proxy';
-import { Counter } from '@yorkie-js-sdk/src/document/json/counter';
+import { CounterInternal } from '@yorkie-js-sdk/src/document/json/counter';
 
 /**
  * `createProxy` create a new instance of ObjectProxy.
  */
 export function createProxy<T>(
   context: ChangeContext,
-  target: JSONObject,
-): T & JSONObject {
-  return ObjectProxy.create(context, target) as T & JSONObject;
+  target: ObjectInternal,
+): T & ObjectInternal {
+  return ObjectProxy.create(context, target) as T & ObjectInternal;
 }
 
 /**
@@ -45,20 +45,20 @@ export function toProxy(context: ChangeContext, elem?: JSONElement): any {
   if (elem instanceof JSONPrimitive) {
     const primitive = elem as JSONPrimitive;
     return primitive.getValue();
-  } else if (elem instanceof JSONObject) {
-    const obj = elem as JSONObject;
+  } else if (elem instanceof ObjectInternal) {
+    const obj = elem as ObjectInternal;
     return ObjectProxy.create(context, obj);
-  } else if (elem instanceof JSONArray) {
-    const array = elem as JSONArray;
+  } else if (elem instanceof ArrayInternal) {
+    const array = elem as ArrayInternal;
     return ArrayProxy.create(context, array);
-  } else if (elem instanceof PlainText) {
-    const text = elem as PlainText;
+  } else if (elem instanceof PlainTextInternal) {
+    const text = elem as PlainTextInternal;
     return TextProxy.create(context, text);
-  } else if (elem instanceof RichText) {
-    const text = elem as RichText;
+  } else if (elem instanceof RichTextInternal) {
+    const text = elem as RichTextInternal;
     return RichTextProxy.create(context, text);
-  } else if (elem instanceof Counter) {
-    const counter = elem as Counter;
+  } else if (elem instanceof CounterInternal) {
+    const counter = elem as CounterInternal;
     return CounterProxy.create(context, counter);
   } else if (!elem) {
     return;

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -59,11 +59,11 @@ export {
   TextChangeType,
 } from '@yorkie-js-sdk/src/document/json/rga_tree_split';
 export { JSONElement } from '@yorkie-js-sdk/src/document/json/element';
-export { TArray } from '@yorkie-js-sdk/src/document/proxy/array_proxy';
-export { TCounter } from '@yorkie-js-sdk/src/document/proxy/counter_proxy';
-export { TObject } from '@yorkie-js-sdk/src/document/proxy/object_proxy';
-export { TRichText } from '@yorkie-js-sdk/src/document/proxy/rich_text_proxy';
-export { TText } from '@yorkie-js-sdk/src/document/proxy/text_proxy';
+export { JSONArray } from '@yorkie-js-sdk/src/document/proxy/array_proxy';
+export { Counter } from '@yorkie-js-sdk/src/document/proxy/counter_proxy';
+export { JSONObject } from '@yorkie-js-sdk/src/document/proxy/object_proxy';
+export { RichText } from '@yorkie-js-sdk/src/document/proxy/rich_text_proxy';
+export { PlainText } from '@yorkie-js-sdk/src/document/proxy/text_proxy';
 
 /**
  * `createClient` creates a new instance of `Client`.

--- a/test/integration/array_test.ts
+++ b/test/integration/array_test.ts
@@ -1,15 +1,13 @@
 import { assert } from 'chai';
 import { DocumentReplica } from '@yorkie-js-sdk/src/document/document';
-import { JSONElement } from '@yorkie-js-sdk/src/document/json/element';
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { MaxTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 
 import { withTwoClientsAndDocuments } from '@yorkie-js-sdk/test/integration/integration_helper';
-import { TArray } from '@yorkie-js-sdk/src/yorkie';
+import { JSONArray, JSONElement, TimeTicket } from '@yorkie-js-sdk/src/yorkie';
 
 describe('Array', function () {
   it('should handle delete operations', function () {
-    const doc = DocumentReplica.create<{ k1: TArray<string> }>('test-doc');
+    const doc = DocumentReplica.create<{ k1: JSONArray<string> }>('test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
     doc.update((root) => {
@@ -26,7 +24,7 @@ describe('Array', function () {
 
   it('can push array element after delete operation', function () {
     const doc =
-      DocumentReplica.create<{ k1: TArray<string | Array<number>> }>(
+      DocumentReplica.create<{ k1: JSONArray<string | Array<number>> }>(
         'test-doc',
       );
     assert.equal('{}', doc.toSortedJSON());
@@ -51,7 +49,7 @@ describe('Array', function () {
 
   it('can push object element after delete operation', function () {
     const doc = DocumentReplica.create<{
-      k1: TArray<string | { a: string; b: string }>;
+      k1: JSONArray<string | { a: string; b: string }>;
     }>('test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
@@ -88,7 +86,7 @@ describe('Array', function () {
   });
 
   it('can push element then delete it by ID in array', function () {
-    const doc = DocumentReplica.create<{ list: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ list: JSONArray<number> }>('test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
     let toDelete: JSONElement;
@@ -115,7 +113,7 @@ describe('Array', function () {
   });
 
   it('can insert an element after the given element in array', function () {
-    const doc = DocumentReplica.create<{ list: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ list: JSONArray<number> }>('test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
     let prev: JSONElement;
@@ -152,7 +150,7 @@ describe('Array', function () {
   });
 
   it('can move an element before the given element in array', function () {
-    const doc = DocumentReplica.create<{ list: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ list: JSONArray<number> }>('test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
     doc.update((root) => {
@@ -175,7 +173,7 @@ describe('Array', function () {
   });
 
   it('can move an element after the given element in array', function () {
-    const doc = DocumentReplica.create<{ list: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ list: JSONArray<number> }>('test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
     doc.update((root) => {
@@ -198,7 +196,7 @@ describe('Array', function () {
   });
 
   it('can insert an element at the first of array', function () {
-    const doc = DocumentReplica.create<{ list: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ list: JSONArray<number> }>('test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
     doc.update((root) => {
@@ -225,7 +223,7 @@ describe('Array', function () {
   });
 
   it('can move an element at the last of array', function () {
-    const doc = DocumentReplica.create<{ list: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ list: JSONArray<number> }>('test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
     doc.update((root) => {
@@ -252,7 +250,7 @@ describe('Array', function () {
   });
 
   it('Can handle concurrent insertAfter operations', async function () {
-    type TestDoc = { k1: TArray<number> };
+    type TestDoc = { k1: JSONArray<number> };
     await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
       let prev: JSONElement;
       d1.update((root) => {
@@ -295,7 +293,7 @@ describe('Array', function () {
   });
 
   it('Can handle concurrent moveBefore operations with the same position', async function () {
-    type TestDoc = { k1: TArray<number> };
+    type TestDoc = { k1: JSONArray<number> };
     await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root['k1'] = [0, 1, 2];
@@ -341,7 +339,7 @@ describe('Array', function () {
   });
 
   it('Can handle concurrent moveBefore operations from the different position', async function () {
-    type TestDoc = { k1: TArray<number> };
+    type TestDoc = { k1: JSONArray<number> };
     await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root['k1'] = [0, 1, 2];
@@ -373,7 +371,7 @@ describe('Array', function () {
   });
 
   it('Can handle concurrent moveFront operations with the item which has the different index', async function () {
-    type TestDoc = { k1: TArray<number> };
+    type TestDoc = { k1: JSONArray<number> };
     await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root['k1'] = [0, 1, 2];
@@ -415,7 +413,7 @@ describe('Array', function () {
   });
 
   it('Can handle concurrent moveFront operations with the item which has the same index', async function () {
-    type TestDoc = { k1: TArray<number> };
+    type TestDoc = { k1: JSONArray<number> };
     await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root['k1'] = [0, 1, 2];
@@ -445,7 +443,7 @@ describe('Array', function () {
   });
 
   it('Can handle concurrent moveAfter operations', async function () {
-    type TestDoc = { k1: TArray<number> };
+    type TestDoc = { k1: JSONArray<number> };
     await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root['k1'] = [0, 1, 2];
@@ -475,7 +473,7 @@ describe('Array', function () {
   });
 
   it('Can handle concurrent insertAfter and moveBefore operations', async function () {
-    type TestDoc = { k1: TArray<number> };
+    type TestDoc = { k1: JSONArray<number> };
     await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
       let prev: JSONElement;
       d1.update((root) => {
@@ -521,7 +519,7 @@ describe('Array', function () {
   });
 
   it('Can handle concurrent moveAfter', async function () {
-    type TestDoc = { k1: TArray<number> };
+    type TestDoc = { k1: JSONArray<number> };
     await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root['k1'] = [0, 1, 2];
@@ -576,7 +574,7 @@ describe('Array', function () {
   });
 
   it('Can handle concurrent delete operations', async function () {
-    type TestDoc = { k1: TArray<number> };
+    type TestDoc = { k1: JSONArray<number> };
     await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
       let prev: JSONElement;
       d1.update((root) => {
@@ -606,7 +604,7 @@ describe('Array', function () {
   });
 
   it('Can handle concurrent insertBefore and delete operations', async function () {
-    type TestDoc = { k1: TArray<number> };
+    type TestDoc = { k1: JSONArray<number> };
     await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
       let prev: JSONElement;
 
@@ -640,7 +638,7 @@ describe('Array', function () {
   });
 
   it('Can handle complex concurrent insertBefore and delete operations', async function () {
-    type TestDoc = { k1: TArray<number> };
+    type TestDoc = { k1: JSONArray<number> };
     await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
       let prev: JSONElement;
 
@@ -694,7 +692,7 @@ describe('Array', function () {
   });
 
   it('Returns undefined when looking up an element that doesnt exist after GC', function () {
-    const doc = DocumentReplica.create<{ list: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ list: JSONArray<number> }>('test-doc');
     let targetID: TimeTicket;
 
     doc.update((root) => {
@@ -716,7 +714,7 @@ describe('Array', function () {
   });
 
   it('Returns undefined when looking up an element that doesnt exist', function () {
-    const doc = DocumentReplica.create<{ list: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ list: JSONArray<number> }>('test-doc');
     let targetID: TimeTicket;
 
     doc.update((root) => {

--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -1,11 +1,10 @@
 import { assert } from 'chai';
 import * as sinon from 'sinon';
-import yorkie from '@yorkie-js-sdk/src/yorkie';
-import { DocEventType } from '@yorkie-js-sdk/src/document/document';
-import {
+import yorkie, {
+  DocEventType,
   ClientEventType,
   DocumentSyncResultType,
-} from '@yorkie-js-sdk/src/core/client';
+} from '@yorkie-js-sdk/src/yorkie';
 import {
   createEmitterAndSpy,
   waitFor,

--- a/test/integration/counter_test.ts
+++ b/test/integration/counter_test.ts
@@ -1,12 +1,12 @@
 import { assert } from 'chai';
 import { DocumentReplica } from '@yorkie-js-sdk/src/document/document';
 import { withTwoClientsAndDocuments } from '@yorkie-js-sdk/test/integration/integration_helper';
-import { TObject, TCounter } from '@yorkie-js-sdk/src/yorkie';
+import { JSONObject, Counter } from '@yorkie-js-sdk/src/yorkie';
 
 describe('Counter', function () {
   it('can be increased by Counter type', function () {
     const doc = DocumentReplica.create<{
-      k1: TObject<{ age?: TCounter; length?: TCounter }>;
+      k1: JSONObject<{ age?: Counter; length?: Counter }>;
     }>('test-doc');
 
     doc.update((root) => {
@@ -35,7 +35,7 @@ describe('Counter', function () {
   });
 
   it('Can handle increase operation', async function () {
-    type TestDoc = { age: TCounter };
+    type TestDoc = { age: Counter };
     await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root.createCounter!('age', 0);
@@ -53,9 +53,9 @@ describe('Counter', function () {
 
   it('Can handle concurrent increase operation', async function () {
     await withTwoClientsAndDocuments<{
-      age: TCounter;
-      width: TCounter;
-      height: TCounter;
+      age: Counter;
+      width: Counter;
+      height: Counter;
     }>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root.createCounter!('age', 0);

--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -1,6 +1,5 @@
 import { assert } from 'chai';
-import yorkie from '@yorkie-js-sdk/src/yorkie';
-import { DocEventType } from '@yorkie-js-sdk/src/document/document';
+import yorkie, { DocEventType } from '@yorkie-js-sdk/src/yorkie';
 import { testRPCAddr } from '@yorkie-js-sdk/test/integration/integration_helper';
 import {
   createEmitterAndSpy,

--- a/test/integration/gc_test.ts
+++ b/test/integration/gc_test.ts
@@ -1,11 +1,10 @@
 import { assert } from 'chai';
 import { DocumentReplica } from '@yorkie-js-sdk/src/document/document';
-import { PlainText } from '@yorkie-js-sdk/src/document/json/plain_text';
 import { MaxTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { JSONArray } from '@yorkie-js-sdk/src/document/json/array';
+import { ArrayInternal } from '@yorkie-js-sdk/src/document/json/array';
 import yorkie from '@yorkie-js-sdk/src/yorkie';
 import { testRPCAddr } from '@yorkie-js-sdk/test/integration/integration_helper';
-import { TText, TRichText } from '@yorkie-js-sdk/src/yorkie';
+import { PlainText, RichText } from '@yorkie-js-sdk/src/yorkie';
 
 describe('Garbage Collection', function () {
   it('garbage collection test', function () {
@@ -64,10 +63,10 @@ describe('Garbage Collection', function () {
     assert.equal(1, doc.garbageCollect(MaxTimeTicket));
     assert.equal(0, doc.getGarbageLen());
 
-    const root = (doc.getRootObject().get('list') as JSONArray)
+    const root = (doc.getRootObject().get('list') as ArrayInternal)
       .getElements()
       .getAnnotatedString();
-    const clone = (doc.getClone()!.get('list') as JSONArray)
+    const clone = (doc.getClone()!.get('list') as ArrayInternal)
       .getElements()
       .getAnnotatedString();
 
@@ -103,7 +102,7 @@ describe('Garbage Collection', function () {
   });
 
   it('garbage collection test for text', function () {
-    const doc = DocumentReplica.create<{ k1: TText }>('test-doc');
+    const doc = DocumentReplica.create<{ k1: PlainText }>('test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
     let expected_msg = '{"k1":"Hello mario"}';
@@ -136,7 +135,7 @@ describe('Garbage Collection', function () {
   });
 
   it('garbage collection test for rich text', function () {
-    const doc = DocumentReplica.create<{ k1: TRichText }>('test-doc');
+    const doc = DocumentReplica.create<{ k1: RichText }>('test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
     let expected_msg =
@@ -239,7 +238,7 @@ describe('Garbage Collection', function () {
   });
 
   it('Can handle garbage collection for text type', async function () {
-    type TestDoc = { text: TRichText; richText: TRichText };
+    type TestDoc = { text: RichText; richText: RichText };
     const docKey = `${this.test!.title}-${new Date().getTime()}`;
     const doc1 = yorkie.createDocument<TestDoc>(docKey);
     const doc2 = yorkie.createDocument<TestDoc>(docKey);
@@ -314,8 +313,8 @@ describe('Garbage Collection', function () {
       1: number;
       2?: Array<number>;
       3: number;
-      4: TText;
-      5: TRichText;
+      4: PlainText;
+      5: RichText;
     };
     const docKey = `${this.test!.title}-${new Date().getTime()}`;
     const doc1 = yorkie.createDocument<TestDoc>(docKey);

--- a/test/integration/rich_text_test.ts
+++ b/test/integration/rich_text_test.ts
@@ -1,11 +1,13 @@
 import { assert } from 'chai';
-import { DocumentReplica } from '@yorkie-js-sdk/src/document/document';
-import { TextChangeType } from '@yorkie-js-sdk/src/document/json/rga_tree_split';
-import { TRichText } from '@yorkie-js-sdk/src/yorkie';
+import {
+  DocumentReplica,
+  RichText,
+  TextChangeType,
+} from '@yorkie-js-sdk/src/yorkie';
 
 describe('RichText', function () {
   it('should handle rich text edit operations', function () {
-    const doc = DocumentReplica.create<{ k1: TRichText }>('test-doc');
+    const doc = DocumentReplica.create<{ k1: RichText }>('test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
     doc.update((root) => {
@@ -28,7 +30,7 @@ describe('RichText', function () {
   });
 
   it('should handle select operations', async function () {
-    const doc = DocumentReplica.create<{ k1: TRichText }>('test-doc');
+    const doc = DocumentReplica.create<{ k1: RichText }>('test-doc');
 
     doc.update((root) => {
       root.createRichText!('k1');

--- a/test/stress/document_stress_test.ts
+++ b/test/stress/document_stress_test.ts
@@ -1,12 +1,12 @@
 import { assert } from 'chai';
 import { DocumentReplica } from '@yorkie-js-sdk/src/document/document';
 import { MaxTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { TText } from '@yorkie-js-sdk/src/yorkie';
+import { PlainText } from '@yorkie-js-sdk/src/yorkie';
 
 describe('Document stress', function () {
   it('garbage collection test for large size text 1', function () {
     const size = 100;
-    const doc = DocumentReplica.create<{ k1: TText }>('test-doc');
+    const doc = DocumentReplica.create<{ k1: PlainText }>('test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
     // 01. initial
@@ -35,7 +35,7 @@ describe('Document stress', function () {
 
   it('garbage collection test for large size text 2', function () {
     const size = 100;
-    const doc = DocumentReplica.create<{ k1: TText }>('test-doc');
+    const doc = DocumentReplica.create<{ k1: PlainText }>('test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
     // 01. long text by one node

--- a/test/unit/api/converter_test.ts
+++ b/test/unit/api/converter_test.ts
@@ -17,7 +17,7 @@
 import { assert } from 'chai';
 import { DocumentReplica } from '@yorkie-js-sdk/src/document/document';
 import { converter } from '@yorkie-js-sdk/src/api/converter';
-import { TCounter, TText } from '@yorkie-js-sdk/src/yorkie';
+import { Counter, PlainText } from '@yorkie-js-sdk/src/yorkie';
 
 describe('Converter', function () {
   it('should encode/decode bytes', function () {
@@ -28,8 +28,8 @@ describe('Converter', function () {
         ['k1.5']: string;
       };
       k2: Array<boolean | number | string>;
-      k3: TText;
-      k4: TCounter;
+      k3: PlainText;
+      k4: Counter;
     }>('test-doc');
 
     doc.update((root) => {

--- a/test/unit/document/document_test.ts
+++ b/test/unit/document/document_test.ts
@@ -20,7 +20,7 @@ import {
   DocumentReplica,
   DocEventType,
 } from '@yorkie-js-sdk/src/document/document';
-import { TArray } from '@yorkie-js-sdk/src/yorkie';
+import { JSONArray } from '@yorkie-js-sdk/src/yorkie';
 
 describe('DocumentReplica', function () {
   it('doesnt return error when trying to delete a missing key', function () {
@@ -110,7 +110,7 @@ describe('DocumentReplica', function () {
   });
 
   it('move elements before a specific node of array', function () {
-    const doc = DocumentReplica.create<{ data: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ data: JSONArray<number> }>('test-doc');
     doc.update((root) => {
       root.data = [0, 1, 2];
     });
@@ -137,7 +137,7 @@ describe('DocumentReplica', function () {
   });
 
   it('simple move elements before a specific node of array', function () {
-    const doc = DocumentReplica.create<{ data: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ data: JSONArray<number> }>('test-doc');
     doc.update((root) => {
       root.data = [0, 1, 2];
     });
@@ -156,7 +156,7 @@ describe('DocumentReplica', function () {
   });
 
   it('move elements after a specific node of array', function () {
-    const doc = DocumentReplica.create<{ data: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ data: JSONArray<number> }>('test-doc');
     doc.update((root) => {
       root.data = [0, 1, 2];
     });
@@ -183,7 +183,7 @@ describe('DocumentReplica', function () {
   });
 
   it('simple move elements after a specific node of array', function () {
-    const doc = DocumentReplica.create<{ data: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ data: JSONArray<number> }>('test-doc');
     doc.update((root) => {
       root.data = [0, 1, 2];
     });
@@ -202,7 +202,7 @@ describe('DocumentReplica', function () {
   });
 
   it('move elements at the first of array', function () {
-    const doc = DocumentReplica.create<{ data: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ data: JSONArray<number> }>('test-doc');
     doc.update((root) => {
       root.data = [0, 1, 2];
     });
@@ -227,7 +227,7 @@ describe('DocumentReplica', function () {
   });
 
   it('simple move elements at the first of array', function () {
-    const doc = DocumentReplica.create<{ data: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ data: JSONArray<number> }>('test-doc');
     doc.update((root) => {
       root.data = [0, 1, 2];
     });
@@ -245,7 +245,7 @@ describe('DocumentReplica', function () {
   });
 
   it('move elements at the last of array', function () {
-    const doc = DocumentReplica.create<{ data: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ data: JSONArray<number> }>('test-doc');
     doc.update((root) => {
       root.data = [0, 1, 2];
     });
@@ -270,7 +270,7 @@ describe('DocumentReplica', function () {
   });
 
   it('simple move elements at the last of array', function () {
-    const doc = DocumentReplica.create<{ data: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ data: JSONArray<number> }>('test-doc');
     doc.update((root) => {
       root.data = [0, 1, 2];
     });
@@ -417,7 +417,7 @@ describe('DocumentReplica', function () {
   });
 
   it('insert elements before a specific node of array', function () {
-    const doc = DocumentReplica.create<{ data: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ data: JSONArray<number> }>('test-doc');
     doc.update((root) => {
       root.data = [0, 1, 2];
     });
@@ -447,7 +447,7 @@ describe('DocumentReplica', function () {
   });
 
   it('can insert an element before specific position after delete operation', function () {
-    const doc = DocumentReplica.create<{ data: TArray<number> }>('test-doc');
+    const doc = DocumentReplica.create<{ data: JSONArray<number> }>('test-doc');
     doc.update((root) => {
       root.data = [0, 1, 2];
     });

--- a/test/unit/document/json/counter_test.ts
+++ b/test/unit/document/json/counter_test.ts
@@ -17,13 +17,13 @@
 import { assert } from 'chai';
 import { InitialTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import Long from 'long';
-import { Counter } from '@yorkie-js-sdk/src/document/json/counter';
+import { CounterInternal } from '@yorkie-js-sdk/src/document/json/counter';
 import { JSONPrimitive } from '@yorkie-js-sdk/src/document/json/primitive';
 
 describe('Counter', function () {
   it('Can increase numeric data of Counter', function () {
-    const double = Counter.of(10, InitialTimeTicket);
-    const long = Counter.of(Long.fromString('100'), InitialTimeTicket);
+    const double = CounterInternal.of(10, InitialTimeTicket);
+    const long = CounterInternal.of(Long.fromString('100'), InitialTimeTicket);
 
     const doubleOperand = JSONPrimitive.of(10, InitialTimeTicket);
     const longOperand = JSONPrimitive.of(
@@ -40,7 +40,7 @@ describe('Counter', function () {
     assert.equal((long.getValue() as Long).toNumber(), 210);
 
     // error process test
-    function errorTest(counter: Counter, operand: JSONPrimitive): void {
+    function errorTest(counter: CounterInternal, operand: JSONPrimitive): void {
       const errValue = !counter.isNumericType()
         ? counter.getValue()
         : operand.getValue();

--- a/test/unit/document/json/root_test.ts
+++ b/test/unit/document/json/root_test.ts
@@ -1,7 +1,7 @@
 import { assert } from 'chai';
 import { InitialChangeID } from '@yorkie-js-sdk/src/document/change/change_id';
 import { JSONRoot } from '@yorkie-js-sdk/src/document/json/root';
-import { JSONObject } from '@yorkie-js-sdk/src/document/json/object';
+import { ObjectInternal } from '@yorkie-js-sdk/src/document/json/object';
 import { RHTPQMap } from '@yorkie-js-sdk/src/document/json/rht_pq_map';
 import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
 import { ObjectProxy } from '@yorkie-js-sdk/src/document/proxy/object_proxy';
@@ -10,12 +10,12 @@ import { InitialTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { MaxTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { RGATreeList } from '@yorkie-js-sdk/src/document/json/rga_tree_list';
 import { JSONPrimitive } from '@yorkie-js-sdk/src/document/json/primitive';
-import { JSONArray } from '@yorkie-js-sdk/src/document/json/array';
+import { ArrayInternal } from '@yorkie-js-sdk/src/document/json/array';
 
 describe('ROOT', function () {
   it('basic test', function () {
     const root = new JSONRoot(
-      new JSONObject(InitialTimeTicket, RHTPQMap.create()),
+      new ObjectInternal(InitialTimeTicket, RHTPQMap.create()),
     );
     const cc = ChangeContext.create(InitialChangeID, root);
     assert.isUndefined(root.findByCreatedAt(MaxTimeTicket));
@@ -37,7 +37,7 @@ describe('ROOT', function () {
     assert.isUndefined(root.findByCreatedAt(k1.getCreatedAt()));
 
     // set '$.k2'
-    const k2 = JSONObject.create(cc.issueTimeTicket());
+    const k2 = ObjectInternal.create(cc.issueTimeTicket());
     root.getObject().set('k2', k2);
     root.registerElement(k2, root.getObject());
     assert.equal(root.getElementMapSize(), 2);
@@ -47,7 +47,7 @@ describe('ROOT', function () {
     assert.equal(Object.keys(k2.toJS()).length, 0);
 
     // set '$.k2.1'
-    const k2_1 = JSONArray.create(cc.issueTimeTicket());
+    const k2_1 = ArrayInternal.create(cc.issueTimeTicket());
     k2.set('1', k2_1);
     root.registerElement(k2_1, k2);
     assert.equal(root.getElementMapSize(), 3);
@@ -73,9 +73,9 @@ describe('ROOT', function () {
 
   it('garbage collection test for array', function () {
     const root = new JSONRoot(
-      new JSONObject(InitialTimeTicket, RHTPQMap.create()),
+      new ObjectInternal(InitialTimeTicket, RHTPQMap.create()),
     );
-    const arr = new JSONArray(InitialTimeTicket, RGATreeList.create());
+    const arr = new ArrayInternal(InitialTimeTicket, RGATreeList.create());
     const change = ChangeContext.create(InitialChangeID, root);
 
     ArrayProxy.pushInternal(change, arr, 0);
@@ -104,9 +104,9 @@ describe('ROOT', function () {
 
   it('garbage collection test for text', function () {
     const root = new JSONRoot(
-      new JSONObject(InitialTimeTicket, RHTPQMap.create()),
+      new ObjectInternal(InitialTimeTicket, RHTPQMap.create()),
     );
-    const obj = new JSONObject(InitialTimeTicket, RHTPQMap.create());
+    const obj = new ObjectInternal(InitialTimeTicket, RHTPQMap.create());
     const change = ChangeContext.create(InitialChangeID, root);
     const text = ObjectProxy.createText(change, obj, 'k1');
 
@@ -126,9 +126,9 @@ describe('ROOT', function () {
 
   it('garbage collection test for rich text', function () {
     const root = new JSONRoot(
-      new JSONObject(InitialTimeTicket, RHTPQMap.create()),
+      new ObjectInternal(InitialTimeTicket, RHTPQMap.create()),
     );
-    const obj = new JSONObject(InitialTimeTicket, RHTPQMap.create());
+    const obj = new ObjectInternal(InitialTimeTicket, RHTPQMap.create());
     const change = ChangeContext.create(InitialChangeID, root);
     const text = ObjectProxy.createRichText(change, obj, 'k1');
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Rename TXXX to JSONXXX

This commit renames the types exposed to the user to a more generic name.

#### Any background context you want to provide?

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

This is a follow-up to https://github.com/yorkie-team/yorkie-js-sdk/pull/289.

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
