### PR TITLE
Fix bugs in text deletion

### DIFF
--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -813,8 +813,6 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
         deletionBoundaries.push(node);
       }
     }
-    // When editing the end of a document, the last elememt of
-    // deletionBoundaries can be undefined.
     deletionBoundaries.push(rightEdge);
 
     // NOTE: We need to collect indexes for change first then delete the nodes.
@@ -835,6 +833,9 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
     return [changes, createdAtMapByActor, removedNodeMap];
   }
 
+  // Find the outermost 2 boundaries that surrounds `candidates`.
+  // which has not already been deleted, or be nil.
+  // nil means `candidates` contains the edge of text.
   private findDeletionBoundariesEdges(
     leftEdge: RGATreeSplitNode<T> | undefined,
     rightEdge: RGATreeSplitNode<T> | undefined,

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -832,8 +832,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
 
   // Find the 2 edges outside `candidates`,
   // which has not already been deleted, or be undefined.
-  // left, right edge is undefined means `candidates` contains
-  // end of text in that direction.
+  // right edge is undefined means `candidates` contains the end of text.
   private findEdgesOfCandidates(
     candidates: Array<RGATreeSplitNode<T>>,
   ): [RGATreeSplitNode<T>, RGATreeSplitNode<T> | undefined] {
@@ -861,7 +860,9 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
     [, fromIdx] = this.findIndexesFromRange(nodesToKeep[0]!.createRange());
     for (let i = 1; i < nodesToKeep.length; i++) {
       if (nodesToKeep[i]) {
-        [toIdx, temp] = this.findIndexesFromRange(nodesToKeep[i]!.createRange());
+        [toIdx, temp] = this.findIndexesFromRange(
+          nodesToKeep[i]!.createRange(),
+        );
       } else {
         toIdx = this.treeByIndex.length;
       }

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -247,11 +247,8 @@ export class SplayTree<V> {
       return this.root;
     }
     let node = this.root;
-    for (;;) {
-      if (!node.hasLeft()) {
-        break;
-      }
-      node = node.getLeft()!;
+    while (node.hasLeft()) {
+      node = node.getLeft()!;  
     }
     return node;
   }
@@ -264,11 +261,8 @@ export class SplayTree<V> {
       return this.root;
     }
     let node = this.root;
-    for (;;) {
-      if (!node!.hasRight()) {
-        break;
-      }
-      node = node!.getRight()!;
+    while (node.hasRight()) {
+      node = node.getRight()!;  
     }
     return node;
   }

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -265,10 +265,10 @@ export class SplayTree<V> {
     }
     let node = this.root;
     for (;;) {
-      if (!node.hasRight()) {
+      if (!node!.hasRight()) {
         break;
       }
-      node = node.getRight()!;
+      node = node!.getRight()!;
     }
     return node;
   }
@@ -416,43 +416,43 @@ export class SplayTree<V> {
   }
 
   /**
-   * `cutOffRange` cuts the given range from this Tree.
-   * This function separates the range from `fromInner` to `toInner` as a subtree
-   * by splaying outer nodes then cuts the subtree. 'xxxOuter' could be nil and
-   * means to delete the entire subtree in that direction.
-   *
-   * CAUTION: This function does not filter out invalid argument inputs,
-   * such as non-consecutive indices in fromOuter and fromInner.
+   * `cutOffRange` cuts the range between given 2 boundaries from this Tree.
+   * This function separates the range as a subtree
+   * by splaying outer nodes then cuts the subtree.
+   * leftBoundary, rightBoundary are not included in the range to cut,
+   * and they could be nil, meaning to delete to the end of the tree.
    */
   public cutOffRange(
-    fromOuter: SplayNode<V> | undefined,
-    fromInner: SplayNode<V> | undefined,
-    toInner: SplayNode<V> | undefined,
-    toOuter: SplayNode<V> | undefined,
+    leftBoundary: SplayNode<V> | undefined,
+    rightBoundary: SplayNode<V> | undefined,
   ): void {
-    this.splayNode(toInner);
-    this.splayNode(fromInner);
-
-    if (!fromOuter && !toOuter) {
+    // Absence of both boundaries means the deletion of the entire.
+    if (!leftBoundary && !rightBoundary) {
       this.root = undefined;
       return;
     }
-
-    if (!fromOuter) {
-      this.splayNode(toOuter);
-      this.cutOffLeft(toOuter!);
+    // Absence of leftBoundary means the deletion
+    // from start of the tree to rightBoundary.
+    if (!leftBoundary) {
+      this.splayNode(rightBoundary);
+      this.cutOffLeft(rightBoundary!);
       return;
     }
-
-    if (!toOuter) {
-      this.splayNode(toOuter);
-      this.cutOffRight(fromOuter);
+    // Absence of rightBoundary means the deletion
+    // from leftBoundary to the end of the tree.
+    if (!rightBoundary) {
+      this.splayNode(leftBoundary);
+      this.cutOffRight(leftBoundary);
       return;
     }
-
-    this.splayNode(toOuter);
-    this.splayNode(fromOuter);
-    this.cutOffLeft(toOuter);
+    // The other cases, separate range as a subtree to splay 2 boundaries.
+    this.splayNode(rightBoundary);
+    this.splayNode(leftBoundary);
+    this.cutOffLeft(rightBoundary);
+    if (leftBoundary.getRight() != rightBoundary) {
+      this.cutOffLeft(leftBoundary.getRight()!);
+      this.delete(leftBoundary.getRight()!);
+    }
   }
 
   /**

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -248,7 +248,7 @@ export class SplayTree<V> {
     }
     let node = this.root;
     while (node.hasLeft()) {
-      node = node.getLeft()!;  
+      node = node.getLeft()!;
     }
     return node;
   }
@@ -262,7 +262,7 @@ export class SplayTree<V> {
     }
     let node = this.root;
     while (node.hasRight()) {
-      node = node.getRight()!;  
+      node = node.getRight()!;
     }
     return node;
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

There were some bugs in text deletion after applying range deletion.

1. Deletion is intermittently not applied in remote peers.
2. In typing in Korean, intermediate traces remain.
3. Index error when editing end of document
4. Randomly occurring runtime errors

Most of the bugs were solved by fixing the code added in #312 and #316.
Bug 4 was caused by collision with GC, so the GC was modified a little.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
