### PR TITLE
fix incorrect cursor position

### DIFF
--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -888,16 +888,10 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
           from: fromIdx,
           to: toIdx,
         });
-        console.log('change', {
-          type: TextChangeType.Content,
-          actor: editedAt.getActorID()!,
-          from: fromIdx,
-          to: toIdx,
-        });
       }
       fromIdx = temp;
     }
-    
+
     return changes.reverse();
   }
 

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -198,7 +198,7 @@ export type RGATreeSplitNodeRange = [RGATreeSplitNodePos, RGATreeSplitNodePos];
  */
 export class RGATreeSplitNode<
   T extends RGATreeSplitValue,
-  > extends SplayNode<T> {
+> extends SplayNode<T> {
   private id: RGATreeSplitNodeID;
   private removedAt?: TimeTicket;
 
@@ -546,7 +546,9 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
   /**
    * `findIndexesFromOuterRange` finds indexes based on range.
    */
-  public findIndexesFromOuterRange(range: RGATreeSplitNodeRange): [number, number] {
+  public findIndexesFromOuterRange(
+    range: RGATreeSplitNodeRange,
+  ): [number, number] {
     const [fromPos, toPos] = range;
     return [
       this.findIdxFromNodePos(fromPos, true),
@@ -579,7 +581,10 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
         return this.treeByIndex.indexOf(indexNode) + indexNode.getLength();
       }
       const [indexNode, isNext] = this.findLivingNodePreferToNext(node);
-      return this.treeByIndex.indexOf(indexNode) + (isNext ? 0 : indexNode.getLength());
+      return (
+        this.treeByIndex.indexOf(indexNode) +
+        (isNext ? 0 : indexNode.getLength())
+      );
     }
 
     const index = this.treeByIndex.indexOf(node);
@@ -587,14 +592,18 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
     return index + offset;
   }
 
-  private findPreviousLivingNode(node: RGATreeSplitNode<T>): RGATreeSplitNode<T> {
+  private findPreviousLivingNode(
+    node: RGATreeSplitNode<T>,
+  ): RGATreeSplitNode<T> {
     while (node.isRemoved()) {
       node = node.getPrev()!;
     }
     return node;
   }
 
-  private findLivingNodePreferToNext(node: RGATreeSplitNode<T>): [RGATreeSplitNode<T>, boolean] {
+  private findLivingNodePreferToNext(
+    node: RGATreeSplitNode<T>,
+  ): [RGATreeSplitNode<T>, boolean] {
     let current: RGATreeSplitNode<T> | undefined = node;
     while (current && current.isRemoved()) {
       current = current.getNext();
@@ -815,10 +824,10 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
     editedAt: TimeTicket,
     latestCreatedAtMapByActor?: Map<string, TimeTicket>,
   ): [
-      Array<TextChange>,
-      Map<string, TimeTicket>,
-      Map<string, RGATreeSplitNode<T>>,
-    ] {
+    Array<TextChange>,
+    Map<string, TimeTicket>,
+    Map<string, RGATreeSplitNode<T>>,
+  ] {
     if (!candidates.length) {
       return [[], new Map(), new Map()];
     }

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -559,7 +559,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
       logger.fatal(
         `the node of the given id should be found: ${absoluteID.getAnnotatedString()}`,
       );
-    } 
+    }
     let index: number, offset: number;
     if (node!.isRemoved()) {
       const indexNode = this.findNearLivingNode(node!);
@@ -891,7 +891,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
           actor: editedAt.getActorID()!,
           from: fromIdx,
           to: toIdx,
-        })
+        });
       }
       fromIdx = temp;
     }

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -838,6 +838,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
       node.remove(editedAt);
     }
     this.deleteIndexNodes(nodesToKeep);
+
     return [changes, createdAtMapByActor, removedNodeMap];
   }
 
@@ -877,6 +878,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
       } else {
         toIdx = this.treeByIndex.length;
       }
+
       // NOTE: filtering meaningless change where fromIdx equals toIdx
       // when 2 boundary nodes are continuous.
       if (fromIdx < toIdx) {
@@ -895,6 +897,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
       }
       fromIdx = temp;
     }
+    
     return changes.reverse();
   }
 

--- a/src/document/crdt/rich_text.ts
+++ b/src/document/crdt/rich_text.ts
@@ -386,6 +386,7 @@ export class CRDTRichText extends CRDTTextElement {
         updatedAt.getActorID()!,
         Selection.of(range, updatedAt),
       );
+      
       const [from, to] = this.rgaTreeSplit.findIndexesFromRange(range);
       return {
         type: TextChangeType.Selection,

--- a/src/document/crdt/rich_text.ts
+++ b/src/document/crdt/rich_text.ts
@@ -386,7 +386,6 @@ export class CRDTRichText extends CRDTTextElement {
         updatedAt.getActorID()!,
         Selection.of(range, updatedAt),
       );
-
       const [from, to] = this.rgaTreeSplit.findIndexesFromRange(range);
       return {
         type: TextChangeType.Selection,

--- a/src/document/crdt/rich_text.ts
+++ b/src/document/crdt/rich_text.ts
@@ -386,7 +386,7 @@ export class CRDTRichText extends CRDTTextElement {
         updatedAt.getActorID()!,
         Selection.of(range, updatedAt),
       );
-      
+
       const [from, to] = this.rgaTreeSplit.findIndexesFromRange(range);
       return {
         type: TextChangeType.Selection,

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -191,7 +191,7 @@ export class SplayTree<V> {
     }
 
     let node = this.root;
-    for (; ;) {
+    for (;;) {
       if (node.hasLeft() && pos <= node.getLeftWeight()) {
         node = node.getLeft()!;
       } else if (
@@ -222,7 +222,7 @@ export class SplayTree<V> {
   public indexOf(node: SplayNode<V>): number {
     if (!node.hasLinks()) {
       if (node == this.root) {
-        return 0
+        return 0;
       }
       return -1;
     }
@@ -342,7 +342,7 @@ export class SplayTree<V> {
       return;
     }
 
-    for (; ;) {
+    for (;;) {
       if (this.isLeftChild(node.getParent()) && this.isRightChild(node)) {
         // zig-zag
         this.rotateLeft(node);
@@ -432,14 +432,14 @@ export class SplayTree<V> {
     // from start of the tree to rightBoundary.
     if (!leftBoundary) {
       this.splayNode(rightBoundary);
-      //this.cutOffLeft(rightBoundary!);
+      this.cutOffLeft(rightBoundary!);
       return;
     }
     // Absence of rightBoundary means the deletion
     // from leftBoundary to the end of the tree.
     if (!rightBoundary) {
       this.splayNode(leftBoundary);
-      //this.cutOffRight(leftBoundary);
+      this.cutOffRight(leftBoundary);
       return;
     }
     // The other cases, separate range as a subtree to splay 2 boundaries.
@@ -447,8 +447,8 @@ export class SplayTree<V> {
     this.splayNode(leftBoundary);
     //this.cutOffLeft(rightBoundary);
     if (leftBoundary.getRight() != rightBoundary) {
-      //this.cutOffLeft(leftBoundary.getRight()!);
-      //this.delete(leftBoundary.getRight()!);
+      this.cutOffLeft(leftBoundary.getRight()!);
+      this.delete(leftBoundary.getRight()!);
     }
   }
 

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -191,7 +191,7 @@ export class SplayTree<V> {
     }
 
     let node = this.root;
-    for (;;) {
+    for (; ;) {
       if (node.hasLeft() && pos <= node.getLeftWeight()) {
         node = node.getLeft()!;
       } else if (
@@ -220,7 +220,10 @@ export class SplayTree<V> {
    * @returns the index of given node
    */
   public indexOf(node: SplayNode<V>): number {
-    if (!node || !node.hasLinks()) {
+    if (!node.hasLinks()) {
+      if (node == this.root) {
+        return 0
+      }
       return -1;
     }
 
@@ -339,7 +342,7 @@ export class SplayTree<V> {
       return;
     }
 
-    for (;;) {
+    for (; ;) {
       if (this.isLeftChild(node.getParent()) && this.isRightChild(node)) {
         // zig-zag
         this.rotateLeft(node);
@@ -429,23 +432,23 @@ export class SplayTree<V> {
     // from start of the tree to rightBoundary.
     if (!leftBoundary) {
       this.splayNode(rightBoundary);
-      this.cutOffLeft(rightBoundary!);
+      //this.cutOffLeft(rightBoundary!);
       return;
     }
     // Absence of rightBoundary means the deletion
     // from leftBoundary to the end of the tree.
     if (!rightBoundary) {
       this.splayNode(leftBoundary);
-      this.cutOffRight(leftBoundary);
+      //this.cutOffRight(leftBoundary);
       return;
     }
     // The other cases, separate range as a subtree to splay 2 boundaries.
     this.splayNode(rightBoundary);
     this.splayNode(leftBoundary);
-    this.cutOffLeft(rightBoundary);
+    //this.cutOffLeft(rightBoundary);
     if (leftBoundary.getRight() != rightBoundary) {
-      this.cutOffLeft(leftBoundary.getRight()!);
-      this.delete(leftBoundary.getRight()!);
+      //this.cutOffLeft(leftBoundary.getRight()!);
+      //this.delete(leftBoundary.getRight()!);
     }
   }
 

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -445,7 +445,7 @@ export class SplayTree<V> {
     // The other cases, separate range as a subtree to splay 2 boundaries.
     this.splayNode(rightBoundary);
     this.splayNode(leftBoundary);
-    //this.cutOffLeft(rightBoundary);
+    this.cutOffLeft(rightBoundary);
     if (leftBoundary.getRight() != rightBoundary) {
       this.cutOffLeft(leftBoundary.getRight()!);
       this.delete(leftBoundary.getRight()!);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

There was a bug where the cursor of remote peer went to the wrong
position after deletion from remote. This commit solve that
to fix the problem that index of deleted node is 0.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
