### PR TITLE
rebuild : applying split tree range isolation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yorkie-js-sdk",
-  "version": "0.2.8",
+  "version": "0.2.9",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "yorkie-js-sdk",
-      "version": "0.2.8",
+      "version": "0.2.9",
       "license": "Apache-2.0",
       "dependencies": {
         "@types/google-protobuf": "^3.15.5",

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -869,7 +869,18 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
     boundaries: Array<RGATreeSplitNode<T> | undefined>,
   ): void {
     for (let i = 0; i < boundaries.length - 1; i++) {
-      this.treeByIndex.cutOffRange(boundaries[i], boundaries[i + 1]);
+      const leftBoundary = boundaries[i]
+      const rightBoundary = boundaries[i+1]
+      if (leftBoundary!.getNext() == rightBoundary) {
+        // If there is no node to delete between boundaries, do notting.
+        return;
+      }
+      if (leftBoundary!.getNext() && leftBoundary!.getNext()!.getNext() == rightBoundary) {
+        // TODO(Eithea): If there is one node to delete between boundaries, delete that.
+        // this.treeByIndex.delete(leftBoundary!.getNext()!);
+        return;
+      }
+      this.treeByIndex.cutOffRange(leftBoundary, rightBoundary);
     }
   }
 

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -844,7 +844,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
 
     for (const node of nodesToDelete) {
       node.remove(editedAt);
-      this.treeByIndex.splayNode(node);
+      this.treeByIndex.freeWeight(node);
     }
     this.deleteIndexNodes(nodesToKeep);
 
@@ -869,18 +869,13 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
     boundaries: Array<RGATreeSplitNode<T> | undefined>,
   ): void {
     for (let i = 0; i < boundaries.length - 1; i++) {
-      const leftBoundary = boundaries[i]
-      const rightBoundary = boundaries[i+1]
+      const leftBoundary = boundaries[i];
+      const rightBoundary = boundaries[i + 1];
       if (leftBoundary!.getNext() == rightBoundary) {
         // If there is no node to delete between boundaries, do notting.
-        continue;
+      } else {
+        this.treeByIndex.cutOffRange(leftBoundary, rightBoundary);
       }
-      if (leftBoundary!.getNext() && leftBoundary!.getNext()!.getNext() == rightBoundary) {
-        // TODO(Eithea): If there is one node to delete between boundaries, delete that.
-        // this.treeByIndex.delete(leftBoundary!.getNext()!);
-        continue;
-      }
-      this.treeByIndex.cutOffRange(leftBoundary, rightBoundary);
     }
   }
 

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -873,12 +873,12 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
       const rightBoundary = boundaries[i+1]
       if (leftBoundary!.getNext() == rightBoundary) {
         // If there is no node to delete between boundaries, do notting.
-        return;
+        continue;
       }
       if (leftBoundary!.getNext() && leftBoundary!.getNext()!.getNext() == rightBoundary) {
         // TODO(Eithea): If there is one node to delete between boundaries, delete that.
         // this.treeByIndex.delete(leftBoundary!.getNext()!);
-        return;
+        continue;
       }
       this.treeByIndex.cutOffRange(leftBoundary, rightBoundary);
     }

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -296,6 +296,16 @@ export class SplayTree<V> {
   }
 
   /**
+   * `freeWeight` set the weiht is 0. This function only uses in range deletion.
+   */
+  public freeWeight(node: SplayNode<V>): void {
+    node.initWeight();
+    if (node.getWeight()) {
+      logger.fatal("node is not removed");
+    }
+  }
+
+  /**
    * `splayNode` moves the given node to the root.
    */
   public splayNode(node: SplayNode<V> | undefined): void {

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -242,8 +242,8 @@ export class SplayTree<V> {
   /**
    * `getRoot` returns root of this tree.
    */
-  public getRoot(): SplayNode<V> {
-    return this.root!;
+  public getRoot(): SplayNode<V> | undefined {
+    return this.root;
   }
 
   /**
@@ -370,6 +370,60 @@ export class SplayTree<V> {
     node.unlink();
     if (this.root) {
       this.updateWeight(this.root);
+    }
+  }
+
+  /**
+   * `cutOffRange` cuts the range between given 2 boundaries from this Tree.
+   * This function separates the range as a subtree
+   * by splaying outer nodes (then cuts the subtree but not yet implemented).
+   * leftBoundary, rightBoundary are not included in the range to cut,
+   * and they could be nil, meaning to delete to the end of the tree.
+   */
+  public cutOffRange(
+    leftBoundary: SplayNode<V> | undefined,
+    rightBoundary: SplayNode<V> | undefined,
+  ): void {
+    if (!leftBoundary && !rightBoundary) {
+      // Absence of both boundaries means the deletion of the entire.
+      this.root = undefined;
+      return;
+    }
+
+    if (!leftBoundary) {
+      // Absence of leftBoundary means the deletion
+      // from start of the tree to rightBoundary.
+      this.splayNode(rightBoundary);
+      return;
+    }
+
+    if (!rightBoundary) {
+      // Absence of rightBoundary means the deletion
+      // from leftBoundary to the end of the tree.
+      this.splayNode(leftBoundary);
+      return;
+    }
+    // The other cases, separate range as a subtree to splay 2 boundaries.
+    this.splayNode(rightBoundary);
+    this.splayNode(leftBoundary);
+    this.checkRangeSeparation(leftBoundary, rightBoundary);
+  }
+
+  private checkRangeSeparation(
+    leftBoundary: SplayNode<V>,
+    rightBoundary: SplayNode<V>,
+  ) {
+    // leftBoundary must be root
+    if (this.root != leftBoundary) {
+      logger.fatal('Invalid argument for Boundary');
+    }
+    // rightBoundary must be root.right or root.right.right
+    if (
+      !this.root!.getRight() ||
+      (this.root!.getRight() != rightBoundary &&
+        this.root!.getRight()!.getRight() != rightBoundary)
+    ) {
+      logger.fatal('Invalid argument for Boundary');
     }
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

From the stable version, range isolation in splay tree is applied.
By not applying node deletion yet, it is expected that removed
nodes return correct index.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
