### PR TITLE
Fix a bug when deleting blocks concurrently

### DIFF
--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -380,7 +380,11 @@ export class RGATreeSplitNode<
    * `split` creates a new split node of the given offset.
    */
   public split(offset: number): RGATreeSplitNode<T> {
-    return new RGATreeSplitNode(this.id.split(offset), this.splitValue(offset));
+    return new RGATreeSplitNode(
+      this.id.split(offset),
+      this.splitValue(offset),
+      this.removedAt,
+    );
   }
 
   /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fix a bug when deleting blocks concurrently

When splitting a removed node, the value came alive because the
tombstone was missing in the new node.

This commit passes the tombstone when splitting.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
