### PR TITLE
set value to counter initialize

### DIFF
--- a/src/document/json/counter.ts
+++ b/src/document/json/counter.ts
@@ -41,6 +41,7 @@ export class Counter {
   public initialize(context: ChangeContext, counter: CRDTCounter): void {
     this.context = context;
     this.counter = counter;
+    this.value = counter.getValue();
   }
 
   /**

--- a/test/unit/document/document_test.ts
+++ b/test/unit/document/document_test.ts
@@ -1186,4 +1186,12 @@ describe('Document', function () {
       doc.toSortedJSON(),
     );
   });
+
+  it('Get the value of the counter', function () {
+    const doc = Document.create<{ counter: Counter }>('test-doc');
+    doc.update((root) => {
+      root.counter = new Counter(155);
+    });
+    assert.equal(155, doc.getRoot().counter.getValue());
+  });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
After creating the counter object
An issue where the constructor is executed every time the counter object is called and the value is initialized to 0.

#### Any background context you want to provide?
```
call construct value =  155              counter.ts:25
call construct value =  0                  (index):136 
call1 counter object value =  155    counter.ts:25 
call construct value =  0                  (index):137 
call2 counter object value =  155    counter.ts:25 
call construct value =  0                  (index):138 
call3 counter object value =  155
```

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #325 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
