### PR TITLE
Fix incorrect index for nodes newly created then concurrently removed

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -117,7 +117,7 @@
     async function main() {
       try {
         // 01. create client with RPCAddr(envoy) then activate it.
-        const client = new yorkie.Client('http://14.53.253.179:8080');
+        const client = new yorkie.Client('http://localhost:8080');
         client.subscribe(network.statusListener(statusHolder));
         await client.activate();
 

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -801,7 +801,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
     // There are 2 types of nodes in `candidates`: should delete, should not delete.
     // `nodesToKeep` contains nodes should not delete,
     // then is used to find the boundary of the range to be deleted.
-    const [nodesToDelete, nodesToKeep, nodesAlreadyDeleted] = this.filterNodes(
+    const [nodesToDelete, nodesToKeep] = this.filterNodes(
       candidates,
       editedAt,
       latestCreatedAtMapByActor,
@@ -822,10 +822,6 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
       }
       removedNodeMap.set(node.getID().getAnnotatedString(), node);
       node.remove(editedAt);
-      node.initWeight();
-    }
-    for (const node of nodesAlreadyDeleted) {
-      node.initWeight();
     }
     // Finally remove index nodes of tombstones.
     this.deleteIndexNodes(nodesToKeep);
@@ -840,12 +836,10 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
   ): [
     Array<RGATreeSplitNode<T>>,
     Array<RGATreeSplitNode<T> | undefined>,
-    Array<RGATreeSplitNode<T>>,
   ] {
     const isRemote = !!latestCreatedAtMapByActor;
     const nodesToDelete: Array<RGATreeSplitNode<T>> = [];
     const nodesToKeep: Array<RGATreeSplitNode<T> | undefined> = [];
-    const nodesAlreadyDeleted: Array<RGATreeSplitNode<T>> = [];
 
     const [leftEdge, rightEdge] = this.findEdgesOfCandidates(candidates);
     nodesToKeep.push(leftEdge);
@@ -863,13 +857,11 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
         nodesToDelete.push(node);
       } else if (!node.isRemoved()) {
         nodesToKeep.push(node);
-      } else {
-        nodesAlreadyDeleted.push(node);
       }
     }
     nodesToKeep.push(rightEdge);
 
-    return [nodesToDelete, nodesToKeep, nodesAlreadyDeleted];
+    return [nodesToDelete, nodesToKeep];
   }
 
   /**

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -863,7 +863,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
         nodesToDelete.push(node);
       } else if (!node.isRemoved()) {
         nodesToKeep.push(node);
-        console.log(nodesToKeep)
+        console.log(nodesToKeep);
       } else {
         nodesAlreadyDeleted.push(node);
       }

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -837,7 +837,11 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
     candidates: Array<RGATreeSplitNode<T>>,
     editedAt: TimeTicket,
     latestCreatedAtMapByActor?: Map<string, TimeTicket>,
-  ): [Array<RGATreeSplitNode<T>>, Array<RGATreeSplitNode<T> | undefined>, Array<RGATreeSplitNode<T>>] {
+  ): [
+    Array<RGATreeSplitNode<T>>,
+    Array<RGATreeSplitNode<T> | undefined>,
+    Array<RGATreeSplitNode<T>>,
+  ] {
     const isRemote = !!latestCreatedAtMapByActor;
     const nodesToDelete: Array<RGATreeSplitNode<T>> = [];
     const nodesToKeep: Array<RGATreeSplitNode<T> | undefined> = [];
@@ -859,6 +863,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
         nodesToDelete.push(node);
       } else if (!node.isRemoved()) {
         nodesToKeep.push(node);
+        console.log(nodesToKeep)
       } else {
         nodesAlreadyDeleted.push(node);
       }

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -863,7 +863,6 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
         nodesToDelete.push(node);
       } else if (!node.isRemoved()) {
         nodesToKeep.push(node);
-        console.log(nodesToKeep);
       } else {
         nodesAlreadyDeleted.push(node);
       }

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -801,7 +801,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
     // There are 2 types of nodes in `candidates`: should delete, should not delete.
     // `nodesToKeep` contains nodes should not delete,
     // then is used to find the boundary of the range to be deleted.
-    const [nodesToDelete, nodesToKeep] = this.filterNodes(
+    const [nodesToDelete, nodesToKeep, nodesAlreadyDeleted] = this.filterNodes(
       candidates,
       editedAt,
       latestCreatedAtMapByActor,
@@ -822,6 +822,10 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
       }
       removedNodeMap.set(node.getID().getAnnotatedString(), node);
       node.remove(editedAt);
+      node.initWeight();
+    }
+    for (const node of nodesAlreadyDeleted) {
+      node.initWeight();
     }
     // Finally remove index nodes of tombstones.
     this.deleteIndexNodes(nodesToKeep);
@@ -833,10 +837,11 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
     candidates: Array<RGATreeSplitNode<T>>,
     editedAt: TimeTicket,
     latestCreatedAtMapByActor?: Map<string, TimeTicket>,
-  ): [Array<RGATreeSplitNode<T>>, Array<RGATreeSplitNode<T> | undefined>] {
+  ): [Array<RGATreeSplitNode<T>>, Array<RGATreeSplitNode<T> | undefined>, Array<RGATreeSplitNode<T>>] {
     const isRemote = !!latestCreatedAtMapByActor;
     const nodesToDelete: Array<RGATreeSplitNode<T>> = [];
     const nodesToKeep: Array<RGATreeSplitNode<T> | undefined> = [];
+    const nodesAlreadyDeleted: Array<RGATreeSplitNode<T>> = [];
 
     const [leftEdge, rightEdge] = this.findEdgesOfCandidates(candidates);
     nodesToKeep.push(leftEdge);
@@ -854,11 +859,13 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
         nodesToDelete.push(node);
       } else if (!node.isRemoved()) {
         nodesToKeep.push(node);
+      } else {
+        nodesAlreadyDeleted.push(node);
       }
     }
     nodesToKeep.push(rightEdge);
 
-    return [nodesToDelete, nodesToKeep];
+    return [nodesToDelete, nodesToKeep, nodesAlreadyDeleted];
   }
 
   /**

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -590,6 +590,14 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
   }
 
   /**
+   * `checkWeight` returns false when there is an incorrect weight node.
+   * for debugging purpose.
+   */
+  public checkWeight(): boolean {
+    return this.treeByIndex.checkWeight();
+  }
+
+  /**
    * `toJSON` returns the JSON encoding of this Array.
    */
   public toJSON(): string {
@@ -833,10 +841,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
     candidates: Array<RGATreeSplitNode<T>>,
     editedAt: TimeTicket,
     latestCreatedAtMapByActor?: Map<string, TimeTicket>,
-  ): [
-    Array<RGATreeSplitNode<T>>,
-    Array<RGATreeSplitNode<T> | undefined>,
-  ] {
+  ): [Array<RGATreeSplitNode<T>>, Array<RGATreeSplitNode<T> | undefined>] {
     const isRemote = !!latestCreatedAtMapByActor;
     const nodesToDelete: Array<RGATreeSplitNode<T>> = [];
     const nodesToKeep: Array<RGATreeSplitNode<T> | undefined> = [];

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -855,7 +855,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
 
       if (node.canDelete(editedAt, latestCreatedAt!)) {
         nodesToDelete.push(node);
-      } else if (!node.isRemoved()) {
+      } else {
         nodesToKeep.push(node);
       }
     }

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -822,7 +822,6 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
       }
       removedNodeMap.set(node.getID().getAnnotatedString(), node);
       node.remove(editedAt);
-      node.initWeight();
     }
     // Finally remove index nodes of tombstones.
     this.deleteIndexNodes(nodesToKeep);

--- a/src/document/crdt/text.ts
+++ b/src/document/crdt/text.ts
@@ -137,6 +137,14 @@ export class CRDTText extends CRDTTextElement {
   public get length(): number {
     return this.rgaTreeSplit.length;
   }
+  
+/**
+   * `checkWeight` returns false when there is an incorrect weight node.
+   * for debugging purpose.
+   */
+  public checkWeight(): boolean {
+    return this.rgaTreeSplit.checkWeight();
+  }
 
   /**
    * `toJSON` returns the JSON encoding of this text.

--- a/src/document/crdt/text.ts
+++ b/src/document/crdt/text.ts
@@ -137,8 +137,8 @@ export class CRDTText extends CRDTTextElement {
   public get length(): number {
     return this.rgaTreeSplit.length;
   }
-  
-/**
+
+  /**
    * `checkWeight` returns false when there is an incorrect weight node.
    * for debugging purpose.
    */

--- a/src/document/json/text.ts
+++ b/src/document/json/text.ts
@@ -140,6 +140,14 @@ export class Text {
   }
 
   /**
+   * `checkWeight` returns false when there is an incorrect weight node.
+   * for debugging purpose.
+   */
+  public checkWeight(): boolean {
+    return this.text!.checkWeight();
+  }
+
+  /**
    * `toString` returns the string representation of this text.
    */
   toString(): string {

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -381,7 +381,7 @@ export class SplayTree<V> {
   }
 
   /**
-   * DeleteRange separates the range between given 2 boundaries from this Tree.
+   * `deleteRange` separates the range between given 2 boundaries from this Tree.
    * This function separates the range to delete as a subtree
    * by splaying outer boundary nodes.
    * leftBoundary must exist because of 0-indexed initial dummy node of tree,

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -434,7 +434,10 @@ export class SplayTree<V> {
     const nodes: Array<SplayNode<V>> = [];
     this.traverseInorder(this.root!, nodes);
     for (const node of nodes) {
-      if (node.getWeight() != node.getLength() + node.getLeftWeight() + node.getRightWeight()) {
+      if (
+        node.getWeight() !=
+        node.getLength() + node.getLeftWeight() + node.getRightWeight()
+      ) {
         return false;
       }
     }

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -405,12 +405,7 @@ export class SplayTree<V> {
     this.cutOffRight(leftBoundary);
   }
 
-  private cutOffRight(node: SplayNode<V>): void {   
-    const nodesToFree: Array<SplayNode<V>> = [];
-    this.traversePostorder(node.getRight(), nodesToFree);
-    for (const nod of nodesToFree) {
-      this.updateWeight(nod);
-    }
+  private cutOffRight(node: SplayNode<V>): void {
     // TODO(Eithea): The node to delete is not actually disconnected from the tree yet.
     this.updateTreeWeight(node);
   }
@@ -446,19 +441,6 @@ export class SplayTree<V> {
     this.traverseInorder(node.getLeft(), stack);
     stack.push(node);
     this.traverseInorder(node.getRight(), stack);
-  }
-
-  private traversePostorder(
-    node: SplayNode<V> | undefined,
-    stack: Array<SplayNode<V>>,
-  ): void {
-    if (!node) {
-      return;
-    }
-
-    this.traversePostorder(node.getLeft(), stack);
-    this.traversePostorder(node.getRight(), stack);
-    stack.push(node);
   }
 
   private rotateLeft(pivot: SplayNode<V>): void {
@@ -524,5 +506,4 @@ export class SplayTree<V> {
     }
     return false;
   }
-
 }

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -426,6 +426,21 @@ export class SplayTree<V> {
       .join('');
   }
 
+  /**
+   * `checkWeight` returns false when there is an incorrect weight node.
+   * for debugging purpose.
+   */
+  public checkWeight(): boolean {
+    const nodes: Array<SplayNode<V>> = [];
+    this.traverseInorder(this.root!, nodes);
+    for (const node of nodes) {
+      if (node.getWeight() != node.getLength() + node.getLeftWeight() + node.getRightWeight()) {
+        return false;
+      }
+    }
+    return true;
+  }
+
   private getMaximum(): SplayNode<V> {
     let node = this.root!;
     while (node.hasRight()) {

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -411,7 +411,6 @@ export class SplayTree<V> {
     for (const node of nodesToFreeWeight) {
       node.initWeight();
     }
-    // TODO(Eithea): The node to delete is not actually disconnected from the tree yet.
     this.updateTreeWeight(root);
   }
 

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -405,9 +405,14 @@ export class SplayTree<V> {
     this.cutOffRight(leftBoundary);
   }
 
-  private cutOffRight(node: SplayNode<V>): void {
+  private cutOffRight(root: SplayNode<V>): void {
+    const nodesToFreeWeight: Array<SplayNode<V>> = [];
+    this.traversePostorder(root.getRight(), nodesToFreeWeight);
+    for (const node of nodesToFreeWeight) {
+      node.initWeight();
+    }
     // TODO(Eithea): The node to delete is not actually disconnected from the tree yet.
-    this.updateTreeWeight(node);
+    this.updateTreeWeight(root);
   }
 
   /**
@@ -441,6 +446,19 @@ export class SplayTree<V> {
     this.traverseInorder(node.getLeft(), stack);
     stack.push(node);
     this.traverseInorder(node.getRight(), stack);
+  }
+
+  private traversePostorder(
+    node: SplayNode<V> | undefined,
+    stack: Array<SplayNode<V>>,
+  ): void {
+    if (!node) {
+      return;
+    }
+
+    this.traversePostorder(node.getLeft(), stack);
+    stack.push(node);
+    this.traversePostorder(node.getRight(), stack);
   }
 
   private rotateLeft(pivot: SplayNode<V>): void {

--- a/test/integration/text_test.ts
+++ b/test/integration/text_test.ts
@@ -279,7 +279,7 @@ describe('Text', function () {
     }, this.test!.title);
   });
 
-  it.only('should maintain the correct weight for nodes concurrently edited then removed', async function () {
+  it('should maintain the correct weight for nodes concurrently edited then removed', async function () {
     await withTwoClientsAndDocuments<{ k1: Text }>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root.k1 = new Text();
@@ -304,14 +304,12 @@ describe('Text', function () {
         root.k1.edit(0, 3, 'N');
       });
 
-
       await c1.sync();
       await c2.sync();
       await c1.sync();
 
       assert.equal(d1.getRoot().k1.checkWeight(), true);
       assert.equal(d2.getRoot().k1.checkWeight(), true);
-
     }, this.test!.title);
   });
 });

--- a/test/integration/text_test.ts
+++ b/test/integration/text_test.ts
@@ -279,7 +279,7 @@ describe('Text', function () {
     }, this.test!.title);
   });
 
-  it('should maintain the correct weight for nodes concurrently edited then removed', async function () {
+  it('should maintain the correct weight for nodes newly created then concurrently removed', async function () {
     await withTwoClientsAndDocuments<{ k1: Text }>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root.k1 = new Text();

--- a/test/integration/text_test.ts
+++ b/test/integration/text_test.ts
@@ -308,8 +308,8 @@ describe('Text', function () {
       await c2.sync();
       await c1.sync();
 
-      assert.equal(d1.getRoot().k1.checkWeight(), true);
-      assert.equal(d2.getRoot().k1.checkWeight(), true);
+      assert.isOk(d1.getRoot().k1.checkWeight());
+      assert.isOk(d2.getRoot().k1.checkWeight());
     }, this.test!.title);
   });
 });

--- a/test/unit/util/splay_tree_test.ts
+++ b/test/unit/util/splay_tree_test.ts
@@ -56,7 +56,6 @@ function makeSampleTree(): [SplayTree<string>, Array<StringNode>] {
 function removeNodes(nodes: Array<StringNode>, from: number, to: number): void {
   for (let i = from; i <= to; i++) {
     nodes[i].removed = true;
-    nodes[i].initWeight();
   }
 }
 

--- a/test/unit/util/splay_tree_test.ts
+++ b/test/unit/util/splay_tree_test.ts
@@ -136,10 +136,10 @@ describe('SplayTree', function () {
     // check the case 1 of rangeDelete
     removeNodes(nodes, 3, 6);
     tree.deleteRange(nodes[2], nodes[7]);
-    assert.equal(nodes[2], tree.getRoot());
-    assert.equal(nodes[7], tree.getRoot().getRight());
-    assert.equal(nodes[2].getWeight(), 9);
-    assert.equal(nodes[7].getWeight(), 3);
+    assert.equal(nodes[7], tree.getRoot());
+    assert.equal(nodes[2], tree.getRoot().getLeft());
+    assert.equal(nodes[7].getWeight(), 9);
+    assert.equal(nodes[2].getWeight(), 6);
     assert.equal(sumOfWeight(nodes, 3, 6), 0);
 
     [tree, nodes] = makeSampleTree();
@@ -148,10 +148,10 @@ describe('SplayTree', function () {
     // check the case 2 of rangeDelete
     removeNodes(nodes, 3, 7);
     tree.deleteRange(nodes[2], nodes[8]);
-    assert.equal(nodes[2], tree.getRoot());
-    assert.equal(nodes[8], tree.getRoot()!.getRight());
-    assert.equal(nodes[2].getWeight(), 7);
-    assert.equal(nodes[8].getWeight(), 1);
+    assert.equal(nodes[8], tree.getRoot());
+    assert.equal(nodes[2], tree.getRoot()!.getLeft());
+    assert.equal(nodes[8].getWeight(), 7);
+    assert.equal(nodes[2].getWeight(), 6);
     assert.equal(sumOfWeight(nodes, 3, 7), 0);
   });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Nodes newly created then concurrently removed in the range to be deleted
had incorrect `weight` since they were not included in either `nodesToKeep`
or `nodesToDelete`. This problem causes incorrect indexing, and this commit
fixes that missing weight updates.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #331

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
