### PR TITLE
Support quill embeds type to example project

### DIFF
--- a/examples/quill.html
+++ b/examples/quill.html
@@ -36,23 +36,23 @@
       textLogHolder.innerText = doc.getRoot().content.getAnnotatedString();
     }
 
-    function embedAttributeToContent(val) {
-      const { embed, ...attributes } = val.attributes ?? {};
+    function toDelta(change) {
+      const { embed, ...attributes } = change.attributes ?? {};
 
       const delta = embed
         ? { insert: JSON.parse(embed), attributes } :
         {
-          insert: val.content || ' ',
-          attributes: val.attributes,
+          insert: change.content || ' ',
+          attributes: change.attributes,
         };
       return delta;
     }
 
-    function toDelta(doc) {
+    function toDeltaList(doc) {
       const obj = doc.getRoot();
       const deltas = [];
       for (const val of obj.content.values()) {
-        deltas.push(embedAttributeToContent(val));
+        deltas.push(toDelta(val));
       }
       return deltas;
     }
@@ -215,8 +215,7 @@
             const retainFrom = from - prevTo;
             const retainTo = to - from;
 
-            const deltaOp = { insert: change.insert, attributes: change.attributes }
-            const { insert: content, attributes } = embedAttributeToContent(deltaOp);
+            const { insert: content, attributes } = toDelta(change);
             if (change.type === 'content') {
               console.log(
                 `%c remote: ${from}-${to}: ${content}`,
@@ -274,7 +273,7 @@
         // 05. set initial value.
         displayLog(doc);
         quill.setContents({
-          ops: toDelta(doc)
+          ops: toDeltaList(doc)
         }, 'yorkie');
       } catch (e) {
         console.error(e);

--- a/examples/quill.html
+++ b/examples/quill.html
@@ -36,14 +36,23 @@
       textLogHolder.innerText = doc.getRoot().content.getAnnotatedString();
     }
 
+    function embedAttributeToContent(val) {
+      const { embed, ...attributes } = val.attributes ?? {};
+
+      const delta = embed
+        ? { insert: JSON.parse(embed), attributes } :
+        {
+          insert: val.content || ' ',
+          attributes: val.attributes,
+        };
+      return delta;
+    }
+
     function toDelta(doc) {
       const obj = doc.getRoot();
       const deltas = [];
       for (const val of obj.content.values()) {
-        deltas.push({
-          insert: val.content,
-          attributes: val.attributes,
-        });
+        deltas.push(embedAttributeToContent(val));
       }
       return deltas;
     }
@@ -122,6 +131,7 @@
               [{ 'color': [] }, { 'background': [] }],
               [{ 'font': [] }],
               [{ 'align': [] }],
+              ['image', 'video'],
               ['clean']
             ],
             cursors: true
@@ -155,7 +165,12 @@
                   if (to < from) {
                     to = from;
                   }
-                  root.content.edit(from, to, op.insert, toAttributes(op.attributes));
+
+                  if (typeof op.insert === 'object') {
+                    root.content.edit(from, to, ' ', { embed: JSON.stringify(op.insert), ...toAttributes(op.attributes) })
+                  } else {
+                    root.content.edit(from, to, op.insert, toAttributes(op.attributes))
+                  }
                   from = to + op.insert.length;
                 }
               }, `update style by ${client.getID()}`);
@@ -199,8 +214,10 @@
             const to = change.to;
             const retainFrom = from - prevTo;
             const retainTo = to - from;
+
+            const deltaOp = { insert: change.insert, attributes: change.attributes }
+            const { insert: content, attributes } = embedAttributeToContent(deltaOp);
             if (change.type === 'content') {
-              const content = change.content || '';
               console.log(
                 `%c remote: ${from}-${to}: ${content}`,
                 'color: skyblue'
@@ -214,22 +231,22 @@
               }
               if (content) {
                 const op = { insert: content };
-                if (change.attributes) {
-                  op.attributes = change.attributes;
+                if (attributes) {
+                  op.attributes = attributes;
                 }
                 delta.push(op);
               }
             } else if (change.type === 'style') {
               console.log(
-                `%c remote: ${from}-${to}: ${JSON.stringify(change.attributes)}`,
+                `%c remote: ${from}-${to}: ${JSON.stringify(attributes)}`,
                 'color: skyblue'
               );
 
               if (retainFrom) {
                 delta.push({ retain: retainFrom });
               }
-              if (change.attributes) {
-                const op = { attributes: change.attributes };
+              if (attributes) {
+                const op = { attributes };
                 if (retainTo) {
                   op.retain = retainTo;
                 }

--- a/examples/style.css
+++ b/examples/style.css
@@ -6,3 +6,9 @@
 }
 .green { background-color: green }
 .red { background-color: red; }
+
+.ql-editor {
+  min-height: 300px;
+  overflow-y: auto;
+  resize: vertical;
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

## What this PR does / why we need it?

I implement it following the previous comment about using the RichText attributes field to manage the quill embed data:

> Conversation with @hackerwins Embed data (video, image ..) has a size of 1 like space bar in content and decided to use `attributes` field.
>
> https://github.com/yorkie-team/yorkie-js-sdk/issues/32#issuecomment-674779963

## Any background context you want to provide?

When the user insert embed type, the quill embed object is serialized as a string and inserted into the `embed` field in RichText's `attributes`.

Increase `min-height` and add `resize: vertical` style to quill edit area. There has an issue with the video insert tooltip displayed in the edit area being hidden (Please refer to the below demo video):

<img width="521" alt="Screen Shot 2022-07-23 at 9 42 58 PM" src="https://user-images.githubusercontent.com/5278201/180605397-ed70281b-e869-4199-b4c5-d80b64bb256b.png">

### Unresolved problem 🐛

I often get index range error logs from js-sdk.

> YORKIE E: Error: YORKIE F: out of index range: pos: 3 > node.length: 0

Please also refer to the below demo video:

https://user-images.githubusercontent.com/5278201/180604526-561a1480-3915-4fa3-b0e3-f99b4e0eea58.mp4


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

WIP #32

### Checklist
- [x] Added relevant tests or not required
- [ ] Didn't break anything: 🤔
