### PR TITLE
Fix the problem local changes were applied twice

### DIFF
--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -416,10 +416,6 @@ export class Document<T> implements Observable<DocEvent> {
   private applySnapshot(serverSeq: Long, snapshot?: Uint8Array): void {
     const obj = converter.bytesToObject(snapshot);
     this.root = new CRDTRoot(obj);
-
-    for (const change of this.localChanges) {
-      change.execute(this.root);
-    }
     this.changeID = this.changeID.syncLamport(serverSeq);
 
     // drop clone because it is contaminated.

--- a/test/integration/snapshot_test.ts
+++ b/test/integration/snapshot_test.ts
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
 import { withTwoClientsAndDocuments } from '@yorkie-js-sdk/test/integration/integration_helper';
+import { Text } from '@yorkie-js-sdk/src/yorkie';
 
 describe('Snapshot', function () {
   it('should handle snapshot', async function () {
@@ -23,6 +24,37 @@ describe('Snapshot', function () {
       await c1.sync();
       await c2.sync();
       await c1.sync();
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, this.test!.title);
+  });
+
+  it('should handle snapshot for text object', async function () {
+    await withTwoClientsAndDocuments<{ k1: Text }>(async (c1, d1, c2, d2) => {
+      
+      for (let idx = 0; idx < 700; idx++) {
+        d1.update((root) => {
+          root.k1 = new Text();
+        }, 'set new doc by c1');
+      }
+      await c1.sync();
+      await c2.sync();
+
+      // 01. Updates 700 changes over snapshot threshold by c1.
+      for (let idx = 0; idx < 700; idx++) {
+        d1.update((root) => {
+          root.k1.edit(idx, idx, 'x');
+        });
+      }
+
+      // 02. Makes local change by c2.
+      d2.update((root) => {
+        root.k1.edit(0, 0, 'o');
+      });
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
     }, this.test!.title);
   });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

When a client receives a remote snapshot, the concurrent local changes
were apllied twice.
`client.syncInternal` first sends local changes to server, and then
receives remote `ChangePack`. So the snapshot in given `ChangePack`
is of the time when the local changes were already applied.

By deleting `change.execute` in `applySnapshot`, fix above problem.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
