### PR TITLE
Add snapshot event observer to codemirror example

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,6 +27,10 @@ services:
     command: [
       'server',
       '--enable-pprof',
+      '--backend-snapshot-threshold',
+      '2',
+      '--backend-snapshot-interval',
+      '2',
     ]
     restart: always
     ports:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -27,10 +27,6 @@ services:
     command: [
       'server',
       '--enable-pprof',
-      '--backend-snapshot-threshold',
-      '2',
-      '--backend-snapshot-interval',
-      '2',
     ]
     restart: always
     ports:

--- a/examples/index.html
+++ b/examples/index.html
@@ -121,22 +121,28 @@
         client.subscribe(network.statusListener(statusHolder));
         await client.activate();
 
-        // 02. create a document then attach it into the client.
-        const doc = new yorkie.Document('codemirror');
-        await client.attach(doc);
-
+        // 01-2. subscribe client event.
         client.subscribe((event) => {
           if (event.type === 'peers-changed') {
             displayPeers(event.value[doc.getKey()], client.getID());
           }
         });
 
+        // 02. create a document then attach it into the client.
+        const doc = new yorkie.Document('codemirror');
+        await client.attach(doc);
+
         doc.update((root) => {
           if (!root.content) {
             root.content = new yorkie.Text();
           }
         }, 'create content if not exists');
+
+        // 02-2. subscribe document event.
         doc.subscribe((event) => {
+          if (event.type === 'snapshot') {
+            syncText();
+          }
           displayLog(doc, codemirror);
         });
         await client.sync();
@@ -147,7 +153,7 @@
         });
 
         // 04. bind the document with the codemirror.
-        // 04-1. codemirror to document(local).
+        // 04-1. codemirror to document(applying local).
         codemirror.on('beforeChange', (cm, change) => {
           if (change.origin === 'yorkie' || change.origin === 'setValue') {
             return;
@@ -180,9 +186,8 @@
           }, `update selection by ${client.getID()}`);
         });
 
-        // 04-2. document to codemirror(remote).
-        const text = doc.getRoot().content;
-        text.onChanges((changes) => {
+        // 04-2. document to codemirror(applying remote).
+        function changeEventHandler(changes) {
           for (const change of changes) {
             if (change.type === 'content') {
               const actor = change.actor;
@@ -203,11 +208,17 @@
               }
             }
           }
-        });
+        }
 
-        // 05. set initial value.
+        // 05. synchronize text of document and codemirror.
+        function syncText() {
+          const text = doc.getRoot().content;
+          text.onChanges(changeEventHandler);
+          codemirror.setValue(text.toString());
+        }
+        syncText();
+        
         displayLog(doc, codemirror);
-        codemirror.setValue(text.toString());
       } catch (e) {
         console.error(e);
       }

--- a/examples/index.html
+++ b/examples/index.html
@@ -141,6 +141,7 @@
         // 02-2. subscribe document event.
         doc.subscribe((event) => {
           if (event.type === 'snapshot') {
+            // The text is replaced to snapshot and must be re-synced.
             syncText();
           }
           displayLog(doc, codemirror);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

When a client receives a snapshot, doc.root is replaced by the snapshot.
It is not detected by the remote change obsever, causing problems with
synchronization.

By adding snapshot event observer to document, value of the editor is
synced and the onChange handler re-setted for the replaced new root.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/yorkie-js-sdk/issues/347

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
