### PR TITLE
Add editorconfig file to set editor default style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,5 @@
+root = true 
+
+[*]
+indent_size = 2
+indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,12 @@
-root = true 
+# EditorConfig is awesome: http://EditorConfig.org
 
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
 [*]
-indent_size = 2
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
 indent_style = space
+indent_size = 2

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,5 +3,4 @@ module.exports = {
   singleQuote: true,
   trailingComma: 'all',
   printWidth: 80,
-  tabWidth: 2,
 };


### PR DESCRIPTION
#### What this PR does / why we need it?
Set same indent style in various editors and IDEs.
> EditorConfig helps maintain consistent coding styles for multiple developers working on the same project across various editors and IDEs. 


#### Any background context you want to provide?
A plugin is required for the EditorConfig file to work. Some editors and IDEs have plugins built in. If not, you need to install plugins. To check if it's built-in, see [here](https://editorconfig.org/#download).

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #341

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
