### PR TITLE
Fix mismatch of applying snapshot of rich text

### DIFF
--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -663,7 +663,7 @@ function fromElementSimple(pbElementSimple: PbJSONElementSimple): CRDTElement {
         fromTimeTicket(pbElementSimple.getCreatedAt())!,
       );
     case PbValueType.VALUE_TYPE_RICH_TEXT:
-      return CRDTRichText.create(
+      return new CRDTRichText(
         RGATreeSplit.create(),
         fromTimeTicket(pbElementSimple.getCreatedAt())!,
       );
@@ -741,9 +741,18 @@ function fromTextNode(pbTextNode: PbTextNode): RGATreeSplitNode<string> {
 function fromRichTextNode(
   pbTextNode: PbRichTextNode,
 ): RGATreeSplitNode<RichTextValue> {
+  const richTextValue = RichTextValue.create(pbTextNode.getValue());
+  pbTextNode.getAttributesMap().forEach((value) => {
+    richTextValue.setAttr(
+      value.getKey(),
+      value.getValue(),
+      fromTimeTicket(value.getUpdatedAt())!,
+    );
+  });
+
   const textNode = RGATreeSplitNode.create(
     fromTextNodeID(pbTextNode.getId()!),
-    RichTextValue.create(pbTextNode.getValue()),
+    richTextValue,
   );
   textNode.remove(fromTimeTicket(pbTextNode.getRemovedAt()));
   return textNode;
@@ -994,8 +1003,7 @@ function fromRichText(pbText: PbJSONElement.RichText): CRDTRichText {
     }
     prev = current;
   }
-
-  const text = CRDTRichText.create(
+  const text = new CRDTRichText(
     rgaTreeSplit,
     fromTimeTicket(pbText.getCreatedAt())!,
   );

--- a/test/integration/snapshot_test.ts
+++ b/test/integration/snapshot_test.ts
@@ -1,6 +1,6 @@
 import { assert } from 'chai';
 import { withTwoClientsAndDocuments } from '@yorkie-js-sdk/test/integration/integration_helper';
-import { Text } from '@yorkie-js-sdk/src/yorkie';
+import { RichText, Text } from '@yorkie-js-sdk/src/yorkie';
 
 describe('Snapshot', function () {
   it('should handle snapshot', async function () {
@@ -56,5 +56,30 @@ describe('Snapshot', function () {
 
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
     }, this.test!.title);
+  });
+
+  it('should handle snapshot for rich text object', async function () {
+    await withTwoClientsAndDocuments<{ k1: RichText }>(
+      async (c1, d1, c2, d2) => {
+        d1.update((root) => {
+          root.k1 = new RichText();
+          root.k1.edit(0, 0, 'a');
+        }, 'set new doc by c1');
+        await c1.sync();
+        await c2.sync();
+
+        // 01. Updates 700 changes over snapshot threshold by c1.
+        for (let idx = 0; idx < 700; idx++) {
+          d1.update((root) => {
+            root.k1.setStyle(0, 1, { bold: 'true' });
+          });
+        }
+        await c1.sync();
+        await c2.sync();
+
+        assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+      },
+      this.test!.title,
+    );
   });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

There was a bug where attributes was lost and a new line(\n) was
added when a rich text document applied snapshot from the server.
This commit fixes the bug by correcting missing process in converter.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
