### PR TITLE
fix: change global object name of webpack build output

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -71,6 +71,7 @@ module.exports = {
     library: 'yorkie',
     libraryTarget: 'umd',
     filename: 'yorkie-js-sdk.js',
+    globalObject: 'this',
     path: path.resolve(__dirname, '../dist'),
   },
   plugins: [


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Compatible with non-web-like environments(e.g. server side rendering -- node)


#### Any background context you want to provide?
We are using UMD as a build target format.
If the build target is UMD, Webpack uses the default value of the global object's name as `self`.
Change Webpack setting `output.globalObject` to `this` can solve this problem.

ref: [webpack configuration document](https://webpack.js.org/configuration/output/#outputglobalobject)

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #373 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
