### PR TITLE
Remove unused nodeMapByCreatedAt in RHT

### DIFF
--- a/src/document/crdt/rht.ts
+++ b/src/document/crdt/rht.ts
@@ -66,11 +66,9 @@ export class RHTNode {
  */
 export class RHT {
   private nodeMapByKey: Map<string, RHTNode>;
-  private nodeMapByCreatedAt: Map<string, RHTNode>;
 
   constructor() {
     this.nodeMapByKey = new Map();
-    this.nodeMapByCreatedAt = new Map();
   }
 
   /**
@@ -89,7 +87,6 @@ export class RHT {
     if (prev === undefined || executedAt.after(prev.getUpdatedAt())) {
       const node = RHTNode.of(key, value, executedAt);
       this.nodeMapByKey.set(key, node);
-      this.nodeMapByCreatedAt.set(executedAt.toIDString(), node);
     }
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Remove unused nodeMapByCreatedAt in RHT

In `RHT`, `nodeMapByCreatedAt` is required for remote deletion. However, `RHT` for representing attributes in `RichText`, doesn't currently need delete method, so this commit removes `nodeMapByCreatedAt`.

CC) @skhugh

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
