### PR TITLE
Change lamport from uint64 to int64

### DIFF
--- a/src/document/time/ticket.ts
+++ b/src/document/time/ticket.ts
@@ -151,11 +151,11 @@ export class TimeTicket {
 }
 
 export const InitialDelimiter = 0;
-export const MaxDelemiter = 4294967295;
-export const MaxLamport = Long.fromString('18446744073709551615', true);
+export const MaxDelemiter = 4294967295; // UInt32 MAX_VALUE
+export const MaxLamport = Long.MAX_VALUE;
 
 export const InitialTimeTicket = new TimeTicket(
-  Long.fromNumber(0, true),
+  Long.fromNumber(0),
   InitialDelimiter,
   InitialActorID,
 );

--- a/test/integration/primitive_test.ts
+++ b/test/integration/primitive_test.ts
@@ -59,7 +59,7 @@ describe('Primitive', function () {
         root['k0'] = null;
         root['k1'] = true;
         root['k2'] = 2147483647;
-        root['k3'] = Long.fromString('9223372036854775807');
+        root['k3'] = Long.MAX_VALUE,
         root['k4'] = 1.79;
         root['k5'] = '4';
         root['k6'] = new Uint8Array([65, 66]);

--- a/test/unit/document/json/primitive_test.ts
+++ b/test/unit/document/json/primitive_test.ts
@@ -46,7 +46,7 @@ describe('Primitive', function () {
     },
     {
       type: PrimitiveType.Long,
-      value: Long.fromString('9223372036854775807'),
+      value: Long.MAX_VALUE,
     },
     {
       type: PrimitiveType.Bytes,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Change `lamport` from uint64 to int64

Since `lamport` is inserted directly into the DB, you need to change it from uint64 to int64.

https://github.com/yorkie-team/yorkie/pull/379

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
