### PR TITLE
Rename `keyOf` to `subPathOf`

### DIFF
--- a/src/document/crdt/array.ts
+++ b/src/document/crdt/array.ts
@@ -43,10 +43,10 @@ export class CRDTArray extends CRDTContainer {
   }
 
   /**
-   * `keyof` returns key of the given `createdAt` element.
+   * `subPathOf` returns the sub path of the given element.
    */
-  public keyOf(createdAt: TimeTicket): string | undefined {
-    return this.elements.keyOf(createdAt);
+  public subPathOf(createdAt: TimeTicket): string | undefined {
+    return this.elements.subPathOf(createdAt);
   }
 
   /**

--- a/src/document/crdt/element.ts
+++ b/src/document/crdt/element.ts
@@ -115,7 +115,10 @@ export abstract class CRDTContainer extends CRDTElement {
     super(createdAt);
   }
 
-  abstract keyOf(createdAt: TimeTicket): string | undefined;
+  /**
+   * `subPathOf` returns the sub path of the given element.
+   */
+  abstract subPathOf(createdAt: TimeTicket): string | undefined;
 
   abstract purge(element: CRDTElement): void;
 

--- a/src/document/crdt/object.ts
+++ b/src/document/crdt/object.ts
@@ -44,10 +44,10 @@ export class CRDTObject extends CRDTContainer {
   }
 
   /**
-   * `keyOf` returns a key of RHTPQMap based on the given creation time.
+   * `subPathOf` returns the sub path of the given element.
    */
-  public keyOf(createdAt: TimeTicket): string | undefined {
-    return this.memberNodes.keyOf(createdAt);
+  public subPathOf(createdAt: TimeTicket): string | undefined {
+    return this.memberNodes.subPathOf(createdAt);
   }
 
   /**

--- a/src/document/crdt/rga_tree_list.ts
+++ b/src/document/crdt/rga_tree_list.ts
@@ -275,9 +275,9 @@ export class RGATreeList {
   }
 
   /**
-   * `keyOf` key based on the creation time of the node.
+   * `subPathOf` returns the sub path of the given element.
    */
-  public keyOf(createdAt: TimeTicket): string | undefined {
+  public subPathOf(createdAt: TimeTicket): string | undefined {
     const node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
     if (!node) {
       return;

--- a/src/document/crdt/rht_pq_map.ts
+++ b/src/document/crdt/rht_pq_map.ts
@@ -127,9 +127,9 @@ export class RHTPQMap {
   }
 
   /**
-   * `keyOf` returns a key of node based on creation time
+   * `subPathOf` returns the sub path of the given element.
    */
-  public keyOf(createdAt: TimeTicket): string | undefined {
+  public subPathOf(createdAt: TimeTicket): string | undefined {
     const node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
     if (!node) {
       return;

--- a/src/document/crdt/root.ts
+++ b/src/document/crdt/root.ts
@@ -84,39 +84,39 @@ export class CRDTRoot {
   }
 
   /**
-   * `createPathArray` creates path of the given element.
+   * `createSubPaths` creates an array of the sub paths for the given element.
    */
-  public createPathArray(createdAt: TimeTicket): Array<string> {
+  public createSubPaths(createdAt: TimeTicket): Array<string> {
     let pair = this.elementPairMapByCreatedAt.get(createdAt.toIDString());
     if (!pair) {
       return [];
     }
 
-    const keys: Array<string> = [];
+    const subPaths: Array<string> = [];
     while (pair.parent) {
       const createdAt = pair.element.getCreatedAt();
-      let key = pair.parent.keyOf(createdAt);
-      if (key === undefined) {
+      let subPath = pair.parent.subPathOf(createdAt);
+      if (subPath === undefined) {
         logger.fatal(`cant find the given element: ${createdAt.toIDString()}`);
       } else {
-        key = key.replace(/[$.]/g, '\\$&');
+        subPath = subPath.replace(/[$.]/g, '\\$&');
       }
 
-      keys.unshift(key!);
+      subPaths.unshift(subPath!);
       pair = this.elementPairMapByCreatedAt.get(
         pair.parent.getCreatedAt().toIDString(),
       )!;
     }
 
-    keys.unshift('$');
-    return keys;
+    subPaths.unshift('$');
+    return subPaths;
   }
 
   /**
    * `createPath` creates path of the given element.
    */
   public createPath(createdAt: TimeTicket): string {
-    return this.createPathArray(createdAt).join('.');
+    return this.createSubPaths(createdAt).join('.');
   }
 
   /**

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -493,9 +493,9 @@ export class Document<T> implements Observable<DocEvent> {
     for (const op of change.getOperations()) {
       const createdAt = op.getEffectedCreatedAt();
       if (createdAt) {
-        const pathArray = this.root.createPathArray(createdAt)!;
-        pathArray.shift();
-        pathTrie.insert(pathArray);
+        const subPaths = this.root.createSubPaths(createdAt)!;
+        subPaths.shift();
+        pathTrie.insert(subPaths);
       }
     }
     return pathTrie.findPrefixes().map((element) => element.join('.'));


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Rename `keyOf` to `subPathOf`

`keyOf` means a sub-path of JSONPath. But it does not reveal its usage properly. So, this commit changes the name to something a little more meaningful.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to https://github.com/yorkie-team/yorkie-android-sdk/pull/9#issue-1382588534

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
