### PR TITLE
move peerPresenceMap into Document and add DocEvent about presence

### DIFF
--- a/examples/react-todomvc/vite.config.ts
+++ b/examples/react-todomvc/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite';
-import react from '@vitejs/plugin-react';
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-});
+})

--- a/examples/react-todomvc/vite.config.ts
+++ b/examples/react-todomvc/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [react()],
-})
+});

--- a/examples/react-todomvc/vite.config.ts
+++ b/examples/react-todomvc/vite.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()]
-})
+  plugins: [react()],
+});

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -638,7 +638,7 @@ export class Client<P = Indexable> implements Observable<ClientEvent<P>> {
   public getPeers(key: string): Record<string, P> {
     const peers: Record<string, P> = {};
     const attachment = this.attachmentMap.get(key);
-    for (const [key, value] of attachment!.peerPresenceMap!) {
+    for (const [key, value] of attachment!.doc.getPresenceMap()) {
       peers[key] = value.data;
     }
     return peers;

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -653,7 +653,7 @@ export class Client<P = Indexable> implements Observable<ClientEvent<P>> {
   ): Record<string, Record<string, P>> => {
     const attachment = this.attachmentMap.get(key);
     const peers: Record<string, P> = {};
-    for (const [key, value] of attachment!.peerPresenceMap!) {
+    for (const [key, value] of attachment!.doc.getPresenceMap()) {
       peers[key] = value.data;
     }
     peersMap[key] = peers;

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -530,4 +530,11 @@ export class Document<T, P = any> implements Observable<DocEvent> {
   public getPresenceOf(actorID: ActorID): PresenceInfo<P> | undefined {
     return this.actorPresenceMap.get(actorID);
   }
+
+  /**
+   * `getPresenceMap` gets the presence map of this document.
+   */
+  public getPresenceMap(): Map<string, PresenceInfo<P>> {
+    return this.actorPresenceMap;
+  }
 }

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -43,6 +43,7 @@ import {
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { JSONObject } from './json/object';
 import { Trie } from '../util/trie';
+import { PresenceInfo } from '@yorkie-js-sdk/src/core/client';
 
 /**
  * `DocEventType` is document event types
@@ -150,7 +151,7 @@ export type Indexable = Record<string, any>;
  *
  * @public
  */
-export class Document<T> implements Observable<DocEvent> {
+export class Document<T, P = any> implements Observable<DocEvent> {
   private key: string;
   private root: CRDTRoot;
   private clone?: CRDTRoot;
@@ -159,6 +160,7 @@ export class Document<T> implements Observable<DocEvent> {
   private localChanges: Array<Change>;
   private eventStream: Observable<DocEvent>;
   private eventStreamObserver!: Observer<DocEvent>;
+  private actorPresenceMap: Map<string, PresenceInfo<P>>;
 
   constructor(key: string) {
     this.key = key;
@@ -169,13 +171,14 @@ export class Document<T> implements Observable<DocEvent> {
     this.eventStream = createObservable<DocEvent>((observer) => {
       this.eventStreamObserver = observer;
     });
+    this.actorPresenceMap = new Map();
   }
 
   /**
    * `create` creates a new instance of Document.
    */
-  public static create<T>(key: string): Document<T> {
-    return new Document<T>(key);
+  public static create<T, P = any>(key: string): Document<T, P> {
+    return new Document<T, P>(key);
   }
 
   /**

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -160,6 +160,7 @@ export class Document<T, P = any> implements Observable<DocEvent> {
   private localChanges: Array<Change>;
   private eventStream: Observable<DocEvent>;
   private eventStreamObserver!: Observer<DocEvent>;
+  private localActor: ActorID;
   private actorPresenceMap: Map<string, PresenceInfo<P>>;
 
   constructor(key: string) {
@@ -171,6 +172,7 @@ export class Document<T, P = any> implements Observable<DocEvent> {
     this.eventStream = createObservable<DocEvent>((observer) => {
       this.eventStreamObserver = observer;
     });
+    this.localActor = '';
     this.actorPresenceMap = new Map();
   }
 
@@ -333,6 +335,7 @@ export class Document<T, P = any> implements Observable<DocEvent> {
    * @internal
    */
   public setActor(actorID: ActorID): void {
+    this.localActor = actorID;
     for (const change of this.localChanges) {
       change.setActor(actorID);
     }
@@ -502,5 +505,29 @@ export class Document<T, P = any> implements Observable<DocEvent> {
       }
     }
     return pathTrie.findPrefixes().map((element) => element.join('.'));
+  }
+
+  /**
+   * `updatePresenceOf` updates the presence of given actor.
+   */
+  public updatePresenceOf(
+    actorID: ActorID,
+    presenceInfo: PresenceInfo<P>,
+  ): void {
+    this.actorPresenceMap.set(actorID, presenceInfo);
+  }
+
+  /**
+   * `removePresenceOf` removes the presence of given actor.
+   */
+  public removePresenceOf(actorID: ActorID): void {
+    this.actorPresenceMap.delete(actorID);
+  }
+
+  /**
+   * `getPresenceOf` gets the presence of given actor.
+   */
+  public getPresenceOf(actorID: ActorID): PresenceInfo<P> | undefined {
+    return this.actorPresenceMap.get(actorID);
   }
 }

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -62,6 +62,10 @@ export enum DocEventType {
    * remote document change event type
    */
   RemoteChange = 'remote-change',
+  /**
+   * presence event type
+   */
+  Presence = 'presence',
 }
 
 /**
@@ -70,7 +74,7 @@ export enum DocEventType {
  *
  * @public
  */
-export type DocEvent = SnapshotEvent | LocalChangeEvent | RemoteChangeEvent;
+export type DocEvent = SnapshotEvent | LocalChangeEvent | RemoteChangeEvent | PresenceEvent;
 
 /**
  * @internal
@@ -137,6 +141,22 @@ export interface RemoteChangeEvent extends BaseDocEvent {
    * RemoteChangeEvent type
    */
   value: Array<ChangeInfo>;
+}
+
+/**
+ * `PresenceEvent` is an event that occurs when some actor's presence is updated.
+ *
+ * @public
+ */
+export interface PresenceEvent extends BaseDocEvent {
+  /**
+   * enum {@link DocEventType}.Presence
+   */
+  type: DocEventType.Presence;
+  /**
+   * PresenceEvent type
+   */
+  value: string; // temporary type before applying generics
 }
 
 /**
@@ -515,6 +535,13 @@ export class Document<T, P = any> implements Observable<DocEvent> {
     presenceInfo: PresenceInfo<P>,
   ): void {
     this.actorPresenceMap.set(actorID, presenceInfo);
+
+    if (this.eventStreamObserver) {
+      this.eventStreamObserver.next({
+        type: DocEventType.Presence,
+        value: 'for test: update',
+      });
+    }
   }
 
   /**
@@ -522,6 +549,13 @@ export class Document<T, P = any> implements Observable<DocEvent> {
    */
   public removePresenceOf(actorID: ActorID): void {
     this.actorPresenceMap.delete(actorID);
+
+    if (this.eventStreamObserver) {
+      this.eventStreamObserver.next({
+        type: DocEventType.Presence,
+        value: 'for test: remove',
+      });
+    }
   }
 
   /**

--- a/src/document/json/array.ts
+++ b/src/document/json/array.ts
@@ -614,7 +614,8 @@ export class ArrayProxy {
 
     for (let i = from; i < length; i++) {
       if (
-        target.getByIndex(i)?.getID() === (searchElement as WrappedElement).getID!()
+        target.getByIndex(i)?.getID() ===
+        (searchElement as WrappedElement).getID!()
       ) {
         return true;
       }
@@ -650,7 +651,8 @@ export class ArrayProxy {
 
     for (let i = from; i < length; i++) {
       if (
-        target.getByIndex(i)?.getID() === (searchElement as WrappedElement).getID!()
+        target.getByIndex(i)?.getID() ===
+        (searchElement as WrappedElement).getID!()
       ) {
         return i;
       }
@@ -686,7 +688,8 @@ export class ArrayProxy {
 
     for (let i = from; i > 0; i--) {
       if (
-        target.getByIndex(i)?.getID() === (searchElement as WrappedElement).getID!()
+        target.getByIndex(i)?.getID() ===
+        (searchElement as WrappedElement).getID!()
       ) {
         return i;
       }

--- a/src/util/heap.ts
+++ b/src/util/heap.ts
@@ -80,13 +80,17 @@ export class Heap<K, V> {
    * `release` deletes the given value from this Heap.
    */
   public release(node: HeapNode<K, V>): void {
-    let lastIndexBeforeRelease = this.nodes.length - 1;
+    const lastIndexBeforeRelease = this.nodes.length - 1;
     const targetIndex = this.nodes.findIndex(
       (_node) => _node.getValue() === node.getValue(),
     );
     const lastNode = this.nodes.pop()!;
 
-    if (targetIndex < 0 || !this.len() || targetIndex === lastIndexBeforeRelease) {
+    if (
+      targetIndex < 0 ||
+      !this.len() ||
+      targetIndex === lastIndexBeforeRelease
+    ) {
       return;
     }
 

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -40,6 +40,7 @@ export {
   SnapshotEvent,
   LocalChangeEvent,
   RemoteChangeEvent,
+  PresenceEvent,
   Indexable,
   DocEvent,
   Document,

--- a/test/bench/toonie_test.ts
+++ b/test/bench/toonie_test.ts
@@ -12,20 +12,23 @@ function stringToUint(string: string) {
   return new Uint8Array(uintArray);
 }
 
-const tests = [{
-  name: 'Toonie#hello',
-  run: (): void => {
-    const snapshot = stringToUint(helloBuffer);
-    const root = new CRDTRoot(converter.bytesToObject(snapshot));
-    root.deepcopy();
-  }
-}, {
-  name: 'Toonie#nXIQ0KX',
-  run: (): void => {
-    const snapshot = stringToUint(nXIQ0KXbuffer);
-    const root = new CRDTRoot(converter.bytesToObject(snapshot));
-    root.deepcopy();
-  }
-}];
+const tests = [
+  {
+    name: 'Toonie#hello',
+    run: (): void => {
+      const snapshot = stringToUint(helloBuffer);
+      const root = new CRDTRoot(converter.bytesToObject(snapshot));
+      root.deepcopy();
+    },
+  },
+  {
+    name: 'Toonie#nXIQ0KX',
+    run: (): void => {
+      const snapshot = stringToUint(nXIQ0KXbuffer);
+      const root = new CRDTRoot(converter.bytesToObject(snapshot));
+      root.deepcopy();
+    },
+  },
+];
 
 export default tests;

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -47,13 +47,13 @@ export function delay(timeout: number): Promise<void> {
   });
 }
 
-export function createEmitterAndSpy(
-  fn?: (event: ClientEvent | DocEvent) => string,
-): [EventEmitter, NextFn<ClientEvent | DocEvent>] {
+export function createEmitterAndSpy<P = Indexable>(
+  fn?: (event: ClientEvent | DocEvent<P>) => string,
+): [EventEmitter, NextFn<ClientEvent | DocEvent<P>>] {
   const emitter = new EventEmitter();
   return [
     emitter,
-    (event: ClientEvent | DocEvent) =>
+    (event: ClientEvent | DocEvent<P>) =>
       emitter.emit(fn ? fn(event) : event.type),
   ];
 }

--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -217,8 +217,8 @@ describe('Client', function () {
     await c1.activate();
     await c2.activate();
 
-    const [emitter1, spy1] = createEmitterAndSpy();
-    const [emitter2, spy2] = createEmitterAndSpy();
+    const [emitter1, spy1] = createEmitterAndSpy<PresenceType>();
+    const [emitter2, spy2] = createEmitterAndSpy<PresenceType>();
 
     const docKey = `${this.test!.title}-${new Date().getTime()}`;
     const d1 = new yorkie.Document<unknown, PresenceType>(docKey);
@@ -278,8 +278,8 @@ describe('Client', function () {
     await c1.activate();
     await c2.activate();
 
-    const [emitter1, spy1] = createEmitterAndSpy();
-    const [emitter2, spy2] = createEmitterAndSpy();
+    const [emitter1, spy1] = createEmitterAndSpy<PresenceType>();
+    const [emitter2, spy2] = createEmitterAndSpy<PresenceType>();
 
     const docKey = `${this.test!.title}-${new Date().getTime()}`;
     const d1 = new yorkie.Document<unknown, PresenceType>(docKey);

--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -221,8 +221,8 @@ describe('Client', function () {
     const [emitter2, spy2] = createEmitterAndSpy();
 
     const docKey = `${this.test!.title}-${new Date().getTime()}`;
-    const d1 = new yorkie.Document(docKey);
-    const d2 = new yorkie.Document(docKey);
+    const d1 = new yorkie.Document<unknown, PresenceType>(docKey);
+    const d2 = new yorkie.Document<unknown, PresenceType>(docKey);
 
     await c1.attach(d1);
     await c2.attach(d2);
@@ -282,8 +282,8 @@ describe('Client', function () {
     const [emitter2, spy2] = createEmitterAndSpy();
 
     const docKey = `${this.test!.title}-${new Date().getTime()}`;
-    const d1 = new yorkie.Document(docKey);
-    const d2 = new yorkie.Document(docKey);
+    const d1 = new yorkie.Document<unknown, PresenceType>(docKey);
+    const d2 = new yorkie.Document<unknown, PresenceType>(docKey);
 
     await c1.attach(d1);
     await c2.attach(d2);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Presence map (that is the presence data of document's actors) exists only
on the client. It may make not good userbility.
This commit moves the presence map from client to document and add
doc event about presence.
After applying, user can get presence change from doc event, and get
presence map form doc method.

- [x] extend Document for generic presence and add empty `actorPresenceMap`
- [x] sync `Doc.actorPresenceMap` with `peerPresenceMap` of Client
- [x] replace source of methods that returns peer data to `Doc.actorPresenceMap`
- [x] create empty `PresenceEvent` and add observers
- [x] extend `DocEvent` for generic presence and fill the value of `PresenceEvent`
- [ ] create export doc methods about presence
- [ ] add test and update example

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #302

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
