### PR TITLE
Fix example/react-todomvc's unexpected routing in iframe conditions

### DIFF
--- a/examples/react-todomvc/src/App.css
+++ b/examples/react-todomvc/src/App.css
@@ -11,3 +11,20 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.filters li button {
+  color: inherit;
+  margin: 0px 3px 0px 3px;
+  padding: 0px 3px 0px 3px;
+  text-decoration: none;
+  border: 1px solid transparent;
+  border-radius: 3px;
+}
+
+.filters li button:hover {
+  border-color: #DB7676;
+}
+
+.filters li button.selected {
+  border-color: #CE4646;
+}

--- a/examples/react-todomvc/src/Footer.tsx
+++ b/examples/react-todomvc/src/Footer.tsx
@@ -36,14 +36,14 @@ export default function Footer(props: FooterProps) {
         {
           ['SHOW_ALL', 'SHOW_ACTIVE', 'SHOW_COMPLETED'].map((filter) => (
             <li key={filter}>
-              <a
-                href="/#"
+              <button
+                type="button"
                 className={classnames({ selected: filter === selectedFilter })}
                 style={{ cursor: 'pointer' }}
                 onClick={() => onShow(filter)}
               >
                 {FILTER_TITLES[filter]}
-              </a>
+              </button>
             </li>
           ))
         }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Modified anchor `<a>` component with button `<button>` and added some CSS values to fit previous appearance.

~~Add `e.preventDefault()` in ` example/react-todomvc`'s `<a>` tag.~~
~~This is hard-coded solution, I recommend using button tag instead of anchor tag.~~

#### Any background context you want to provide?

`<a href="/#" ...>` is causing unexpected behavior in iframe's conditions.
In https://yorkie.dev/examples/todomvc example, when you click filtering options (All, Active, Completed), you will be redirected to iframe's parent url, which is https://yorkie.dev/#.

Also, using <a> tag for button that is not performing redirection is not recommended in sematic web. I recommend using button tag instead of anchor tag.

#### What are the relevant tickets?
None

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
