### PR TITLE
Remove redundant create functions in ObjectProxy

### DIFF
--- a/src/document/json/object.ts
+++ b/src/document/json/object.ts
@@ -31,11 +31,7 @@ import { CRDTText } from '@yorkie-js-sdk/src/document/crdt/text';
 import { ArrayProxy } from '@yorkie-js-sdk/src/document/json/array';
 import { Text } from '@yorkie-js-sdk/src/document/json/text';
 import { toJSONElement } from '@yorkie-js-sdk/src/document/json/element';
-import {
-  CounterType,
-  CounterValue,
-  CRDTCounter,
-} from '@yorkie-js-sdk/src/document/crdt/counter';
+import { CRDTCounter } from '@yorkie-js-sdk/src/document/crdt/counter';
 import { Counter } from '@yorkie-js-sdk/src/document/json/counter';
 
 /**
@@ -215,54 +211,6 @@ export class ObjectProxy {
     } else {
       logger.fatal(`unsupported type of value: ${typeof value}`);
     }
-  }
-
-  /**
-   * `createText` creates a new Text for the given key.
-   */
-  public static createText<A>(
-    context: ChangeContext,
-    target: CRDTObject,
-    key: string,
-  ): Text<A> {
-    const ticket = context.issueTimeTicket();
-    const text = CRDTText.create<A>(RGATreeSplit.create(), ticket);
-    target.set(key, text);
-    context.registerElement(text, target);
-    context.push(
-      SetOperation.create(key, text.deepcopy(), target.getCreatedAt(), ticket),
-    );
-    return new Text(context, text);
-  }
-
-  /**
-   * `createCounter` a new Counter for the given key.
-   */
-  public static createCounter(
-    context: ChangeContext,
-    target: CRDTObject,
-    key: string,
-    value: CounterValue,
-  ): Counter {
-    const ticket = context.issueTimeTicket();
-    const counterInternal = CRDTCounter.of(
-      CRDTCounter.getCounterType(value)!,
-      value,
-      ticket,
-    );
-    target.set(key, counterInternal);
-    context.registerElement(counterInternal, target);
-    context.push(
-      SetOperation.create(
-        key,
-        counterInternal.deepcopy(),
-        target.getCreatedAt(),
-        ticket,
-      ),
-    );
-    const counter = new Counter(CounterType.IntegerCnt, 0);
-    counter.initialize(context, counterInternal);
-    return counter;
   }
 
   /**

--- a/test/unit/document/json/root_test.ts
+++ b/test/unit/document/json/root_test.ts
@@ -4,13 +4,15 @@ import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import { CRDTObject } from '@yorkie-js-sdk/src/document/crdt/object';
 import { RHTPQMap } from '@yorkie-js-sdk/src/document/crdt/rht_pq_map';
 import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
-import { ObjectProxy } from '@yorkie-js-sdk/src/document/json/object';
 import { ArrayProxy } from '@yorkie-js-sdk/src/document/json/array';
 import { InitialTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { MaxTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { RGATreeList } from '@yorkie-js-sdk/src/document/crdt/rga_tree_list';
 import { Primitive } from '@yorkie-js-sdk/src/document/crdt/primitive';
 import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';
+import { CRDTText } from '@yorkie-js-sdk/src/document/crdt/text';
+import { RGATreeSplit } from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';
+import { Text } from '@yorkie-js-sdk/src/yorkie';
 
 describe('ROOT', function () {
   it('basic test', function () {
@@ -108,7 +110,13 @@ describe('ROOT', function () {
     );
     const obj = new CRDTObject(InitialTimeTicket, RHTPQMap.create());
     const change = ChangeContext.create(InitialChangeID, root);
-    const text = ObjectProxy.createText(change, obj, 'k1');
+    const crdtText = CRDTText.create(
+      RGATreeSplit.create(),
+      change.issueTimeTicket(),
+    );
+    obj.set('k1', crdtText);
+    change.registerElement(crdtText, obj);
+    const text = new Text(change, crdtText);
 
     text.edit(0, 0, 'Hello World');
     assert.equal(


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Since `createText`, `createRichText`, and `createCounter` is not used and their roles are duplicated with `ObjectProxy.setInternal`, they should be removed.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
