### PR TITLE
Omit attributes if they don't exist when outputting `toJSON`

### DIFF
--- a/src/document/crdt/text.ts
+++ b/src/document/crdt/text.ts
@@ -107,6 +107,9 @@ export class CRDTTextValue {
       attrs.push(item);
     }
     attrs.sort();
+    if (attrs.length === 0) {
+      return `{"val":"${content}"}`;
+    }
     return `{"attrs":{${attrs.join(',')}},"val":"${content}"}`;
   }
 

--- a/test/integration/gc_test.ts
+++ b/test/integration/gc_test.ts
@@ -104,8 +104,7 @@ describe('Garbage Collection', function () {
     const doc = new yorkie.Document<{ k1: Text }>('test-doc');
     assert.equal('{}', doc.toSortedJSON());
 
-    let expected_msg =
-      '{"k1":[{"attrs":{},"val":"Hello "},{"attrs":{},"val":"mario"}]}';
+    let expected_msg = '{"k1":[{"val":"Hello "},{"val":"mario"}]}';
     doc.update((root) => {
       root.k1 = new Text();
       root.k1.edit(0, 0, 'Hello world');
@@ -116,7 +115,7 @@ describe('Garbage Collection', function () {
     assert.equal(1, doc.getGarbageLen());
 
     expected_msg =
-      '{"k1":[{"attrs":{},"val":"Hi"},{"attrs":{},"val":" "},{"attrs":{},"val":"j"},{"attrs":{},"val":"ane"}]}';
+      '{"k1":[{"val":"Hi"},{"val":" "},{"val":"j"},{"val":"ane"}]}';
 
     doc.update((root) => {
       const text = root['k1'];
@@ -140,7 +139,7 @@ describe('Garbage Collection', function () {
     assert.equal('{}', doc.toSortedJSON());
 
     let expected_msg =
-      '{"k1":[{"attrs":{"b":"1"},"val":"Hello "},{"attrs":{},"val":"mario"}]}';
+      '{"k1":[{"attrs":{"b":"1"},"val":"Hello "},{"val":"mario"}]}';
 
     doc.update((root) => {
       root.k1 = new Text();
@@ -152,7 +151,7 @@ describe('Garbage Collection', function () {
     assert.equal(1, doc.getGarbageLen());
 
     expected_msg =
-      '{"k1":[{"attrs":{"b":"1"},"val":"Hi"},{"attrs":{"b":"1"},"val":" "},{"attrs":{},"val":"j"},{"attrs":{"b":"1"},"val":"ane"}]}';
+      '{"k1":[{"attrs":{"b":"1"},"val":"Hi"},{"attrs":{"b":"1"},"val":" "},{"val":"j"},{"attrs":{"b":"1"},"val":"ane"}]}';
 
     doc.update((root) => {
       const text = root['k1'];

--- a/test/integration/text_test.ts
+++ b/test/integration/text_test.ts
@@ -45,7 +45,7 @@ describe('Text', function () {
     });
 
     assert.equal(
-      '{"k1":[{"attrs":{},"val":"A"},{"attrs":{},"val":"12"},{"attrs":{},"val":"D"}]}',
+      '{"k1":[{"val":"A"},{"val":"12"},{"val":"D"}]}',
       doc.toSortedJSON(),
     );
   });
@@ -71,7 +71,7 @@ describe('Text', function () {
     });
 
     assert.equal(
-      '{"k1":[{"attrs":{},"val":"ABC"},{"attrs":{},"val":"\\n"},{"attrs":{},"val":"D"}]}',
+      '{"k1":[{"val":"ABC"},{"val":"\\n"},{"val":"D"}]}',
       doc.toSortedJSON(),
     );
   });
@@ -90,10 +90,7 @@ describe('Text', function () {
       root.k1.edit(1, 2, '늘');
     }, 'set {"k1":"하늘"}');
 
-    assert.equal(
-      '{"k1":[{"attrs":{},"val":"하"},{"attrs":{},"val":"늘"}]}',
-      doc.toSortedJSON(),
-    );
+    assert.equal('{"k1":[{"val":"하"},{"val":"늘"}]}', doc.toSortedJSON());
   });
 
   it('should handle deletion of nested nodes', function () {
@@ -193,7 +190,7 @@ describe('Text', function () {
       }, 'set new text by c1');
       await c1.sync();
       await c2.sync();
-      assert.equal(d1.toSortedJSON(), `{"k1":[{"attrs":{},"val":"ABCD"}]}`);
+      assert.equal(d1.toSortedJSON(), `{"k1":[{"val":"ABCD"}]}`);
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
       d1.update((root) => {
@@ -203,7 +200,7 @@ describe('Text', function () {
       await c1.sync();
       await c2.sync();
       await c1.sync();
-      assert.equal(d1.toSortedJSON(), `{"k1":[{"attrs":{},"val":"1234"}]}`);
+      assert.equal(d1.toSortedJSON(), `{"k1":[{"val":"1234"}]}`);
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
     }, this.test!.title);
   });
@@ -226,7 +223,7 @@ describe('Text', function () {
     });
 
     assert.equal(
-      '{"k1":[{"attrs":{"b":"1"},"val":"ABC"},{"attrs":{},"val":"\\n"},{"attrs":{"b":"1"},"val":"D"}]}',
+      '{"k1":[{"attrs":{"b":"1"},"val":"ABC"},{"val":"\\n"},{"attrs":{"b":"1"},"val":"D"}]}',
       doc.toSortedJSON(),
     );
   });
@@ -244,11 +241,11 @@ describe('Text', function () {
       d1.update((root) => {
         root['k1'].edit(0, 0, 'ABCD');
       }, 'edit 0,0 ABCD by c1');
-      assert.equal(d1.toSortedJSON(), `{"k1":[{"attrs":{},"val":"ABCD"}]}`);
+      assert.equal(d1.toSortedJSON(), `{"k1":[{"val":"ABCD"}]}`);
       d2.update((root) => {
         root['k1'].edit(0, 0, '1234');
       }, 'edit 0,0 1234 by c2');
-      assert.equal(d2.toSortedJSON(), `{"k1":[{"attrs":{},"val":"1234"}]}`);
+      assert.equal(d2.toSortedJSON(), `{"k1":[{"val":"1234"}]}`);
       await c1.sync();
       await c2.sync();
       await c1.sync();
@@ -291,7 +288,7 @@ describe('Text', function () {
       await c2.sync();
       assert.equal(
         d1.toSortedJSON(),
-        `{"k1":[{"attrs":{},"val":"123"},{"attrs":{},"val":"456"},{"attrs":{},"val":"789"}]}`,
+        `{"k1":[{"val":"123"},{"val":"456"},{"val":"789"}]}`,
       );
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
@@ -301,17 +298,14 @@ describe('Text', function () {
       d1.update((root) => {
         root.k1.edit(1, 7, '');
       });
-      assert.equal(
-        d1.toSortedJSON(),
-        `{"k1":[{"attrs":{},"val":"1"},{"attrs":{},"val":"89"}]}`,
-      );
+      assert.equal(d1.toSortedJSON(), `{"k1":[{"val":"1"},{"val":"89"}]}`);
 
       d2.update((root) => {
         root.k1.edit(2, 5, '');
       });
       assert.equal(
         d2.toSortedJSON(),
-        `{"k1":[{"attrs":{},"val":"12"},{"attrs":{},"val":"6"},{"attrs":{},"val":"789"}]}`,
+        `{"k1":[{"val":"12"},{"val":"6"},{"val":"789"}]}`,
       );
 
       await c1.sync();

--- a/test/unit/document/document_test.ts
+++ b/test/unit/document/document_test.ts
@@ -1163,10 +1163,7 @@ describe('Document', function () {
       root.text = new Text();
       root.text.edit(0, 0, '"hello"');
     });
-    assert.equal(
-      '{"text":[{"attrs":{},"val":"\\"hello\\""}]}',
-      doc.toSortedJSON(),
-    );
+    assert.equal('{"text":[{"val":"\\"hello\\""}]}', doc.toSortedJSON());
   });
 
   it('escapes string for text with Attributes', function () {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Attributes that are not present should not be included in the output.
It can be too lengthy for users who only use plain text.

```js
// as-is 
{ "contents": [{"attrs": {}, "val": "hello"}, {"attrs": {}, "val": "world"}] }

// to-be
{ "contents": ["val": "hello"}, {"val": "world"}] }`
```

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address https://github.com/yorkie-team/yorkie/issues/435#issuecomment-1371732400

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
