### PR TITLE
remove engines field in package.json when client sdk is bundled

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -16,7 +16,7 @@ jobs:
         cache-dependency-path: package-lock.json
         registry-url: 'https://registry.npmjs.org'
     - run: npm install
-    - run: npm run build
-    - run: npm publish
+    - run: npm run build && npm run publish:prepare
+    - run: cd bundle && npm publish
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -118,6 +118,7 @@ tags
 
 # Dist files
 dist/
+bundle/
 
 # Docs files
 docs/

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "test:watch": "karma start ./config/karma.conf.js",
     "lint": "eslint . --fix --max-warnings=0 --ext .ts",
     "prepare": "ts-patch install && npm run build",
-    "benchmark": "ts-node-script ./test/bench"
+    "benchmark": "ts-node-script ./test/bench",
+    "publish:prepare": "mkdir -p bundle && cp -r dist package.json README.md LICENSE CHANGELOG.md bundle && cp package.publish.json bundle/package.json"
   },
   "engines": {
     "node": ">=16.0.0",

--- a/package.publish.json
+++ b/package.publish.json
@@ -1,0 +1,30 @@
+{
+  "name": "yorkie-js-sdk",
+  "version": "0.2.20",
+  "description": "Yorkie JS SDK",
+  "main": "./dist/yorkie-js-sdk.js",
+  "typings": "./dist/yorkie-js-sdk.d.ts",
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/yorkie-team/yorkie-js-sdk.git"
+  },
+  "author": {
+    "name": "hackerwins",
+    "email": "<susukang98@gmail.com>"
+  },
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/yorkie-team/yorkie-js-sdk/issues"
+  },
+  "homepage": "https://github.com/yorkie-team/yorkie-js-sdk#readme",
+  "dependencies": {
+    "@types/google-protobuf": "^3.15.5",
+    "@types/long": "^4.0.1",
+    "google-protobuf": "^3.19.4",
+    "grpc-web": "^1.3.1",
+    "long": "^5.2.0"
+  }
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

It remove engines field in package.json when client sdk is bundled.


#### Any background context you want to provide?

Bundle files that are installed as pure clients do not require nodejs engine version.
This prevents nodejs version conflicts with other libraries.
Before publishing to npm, package.json is newly configured for publish only.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #432