### PR TITLE
Export counter type

### DIFF
--- a/public/counter.html
+++ b/public/counter.html
@@ -53,7 +53,7 @@
           // 03. initialize document properties
           doc.update((root) => {
             if (!root.counter) {
-              root.counter = new yorkie.Counter(0, 0);
+              root.counter = new yorkie.Counter(yorkie.IntType, 0);
             }
           }, 'create counter if not exists');
 
@@ -71,7 +71,6 @@
 
           // 05. subscribe to document changes
           doc.subscribe((event) => {
-            console.log(event, doc.getRoot().counter);
             displayCount();
           });
 

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -18,6 +18,7 @@ import { Client } from '@yorkie-js-sdk/src/core/client';
 import { Document } from '@yorkie-js-sdk/src/document/document';
 import { Text } from '@yorkie-js-sdk/src/document/json/text';
 import { Counter } from '@yorkie-js-sdk/src/document/json/counter';
+import { CounterType } from '@yorkie-js-sdk/src/document/crdt/counter';
 
 export {
   Client,
@@ -87,6 +88,8 @@ const yorkie = {
   Document,
   Text,
   Counter,
+  IntType: CounterType.IntegerCnt,
+  LongType: CounterType.LongCnt,
 };
 
 export default yorkie;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

In this PR, I exported the type for the counter first.
Later, we can apply the default type if necessary.

- as-is
```js
// yorkie-js-sdk
export enum CounterType {
    IntegerCnt,
    LongCnt,
}

// counter example
root.counter = new yorkie.Counter(0, 0); // IntegerCnt(0), initial value
```
- to-be 
```js
// counter example
import yorkie from 'yorkie-js-sdk';

root.counter = new yorkie.Counter(yorkie.IntType, 0);
```

#### Any background context you want to provide?

Is it better to change the order of the arguments for the default type?

```js
// as-is
root.counter = new yorkie.Counter(yorkie.LongType, 0);

// to-be
root.counter = new yorkie.Counter(0, yorkie.LongType);
root.counter = new yorkie.Counter(0); // Default is `long`
```

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #439

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
