### PR TITLE
Add the `toJS` method to the ObjectProxy's handler

### DIFF
--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -401,14 +401,14 @@ export class Document<T> implements Observable<DocEvent> {
   }
 
   /**
-   * `toJSON` returns the JSON encoding of this array.
+   * `toJSON` returns the JSON encoding of this document.
    */
   public toJSON(): string {
     return this.root.toJSON();
   }
 
   /**
-   * `toJSON` returns the sorted JSON encoding of this array.
+   * `toSortedJSON` returns the sorted JSON encoding of this document.
    */
   public toSortedJSON(): string {
     return this.root.toSortedJSON();

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -363,7 +363,7 @@ export class Document<T> implements Observable<DocEvent> {
   /**
    * `getRoot` returns a new proxy of cloned root.
    */
-  public getRoot(): T {
+  public getRoot(): JSONObject<T> {
     this.ensureClone();
 
     const context = ChangeContext.create(this.changeID.next(), this.clone!);

--- a/src/document/json/object.ts
+++ b/src/document/json/object.ts
@@ -48,6 +48,11 @@ export type JSONObject<T> = {
    * `toJSON` returns the JSON encoding of this object.
    */
   toJSON?(): string;
+
+  /**
+   * `toJS` returns the JSON object of this object.
+   */
+  toJS?(): T;
 } & T;
 
 /**

--- a/src/document/json/object.ts
+++ b/src/document/json/object.ts
@@ -96,6 +96,10 @@ export class ObjectProxy {
           return (): string => {
             return target.toJSON();
           };
+        } else if (keyOrMethod === 'toJS') {
+          return (): object => {
+            return target.toJS();
+          };
         }
 
         return toJSONElement(context, target.get(keyOrMethod));

--- a/test/integration/object_test.ts
+++ b/test/integration/object_test.ts
@@ -1,4 +1,5 @@
 import { assert } from 'chai';
+import { JSONObject } from '@yorkie-js-sdk/src/yorkie';
 import { DocEventType, Document } from '@yorkie-js-sdk/src/document/document';
 import { withTwoClientsAndDocuments } from '@yorkie-js-sdk/test/integration/integration_helper';
 
@@ -74,6 +75,22 @@ describe('Object', function () {
       root['k1']['k1-3'] = 'v4';
     }, 'set {"k1":{"k1-2":"v2"}}');
     assert.equal('{"k1":{"k1-2":"v2","k1-3":"v4"}}', doc.toSortedJSON());
+  });
+
+  it('should support toJS and toJSON methods', function () {
+    const doc = Document.create<{
+      content: JSONObject<{ a: number; b: number; c: number }>;
+    }>('test-doc');
+    doc.update((root) => {
+      root.content = { a: 1, b: 2, c: 3 };
+    }, 'set a, b, c');
+    assert.equal(doc.toSortedJSON(), '{"content":{"a":1,"b":2,"c":3}}');
+
+    const root = doc.getRoot();
+    assert.equal(root.toJSON!(), '{"content":{"a":1,"b":2,"c":3}}');
+    assert.deepEqual(root.toJS!(), { content: { a: 1, b: 2, c: 3 } });
+    assert.equal(root.content.toJSON!(), '{"a":1,"b":2,"c":3}');
+    assert.deepEqual(root.content.toJS!(), { a: 1, b: 2, c: 3 });
   });
 
   it('Object.keys, Object.values and Object.entries test', function () {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Add the `toJS` method to the ObjectProxy's handler.
Previously, `toJSON` returns a JSON string. 
It requires an extra step of `JSON.parse` to use JSON object.
After this PR, it is easier to use the JSON object with `toJS` method.

```js
doc.subscribe((event) => {
  // as-is
  const rootObject = JSON.parse(doc.getRoot().toJSON());

  // to-be
  const rootObject = doc.getRoot().toJS();
});
```

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #444

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
