### PR TITLE
Add `delete` and `empty` method to `Text` data type

### DIFF
--- a/src/document/json/text.ts
+++ b/src/document/json/text.ts
@@ -112,6 +112,20 @@ export class Text<A = Indexable> {
   }
 
   /**
+   * `delete` delete text in the given range.
+   */
+  delete(fromIdx: number, toIdx: number): boolean {
+    return this.edit(fromIdx, toIdx, '');
+  }
+
+  /**
+   * `empty` make text empty.
+   */
+  empty(): boolean {
+    return this.edit(0, this.length, '');
+  }
+
+  /**
    * `setStyle` styles this text with the given attributes.
    */
   setStyle(fromIdx: number, toIdx: number, attributes: A): boolean {

--- a/src/document/json/text.ts
+++ b/src/document/json/text.ts
@@ -112,14 +112,14 @@ export class Text<A = Indexable> {
   }
 
   /**
-   * `delete` delete text in the given range.
+   * `delete` deletes the text in the given range.
    */
   delete(fromIdx: number, toIdx: number): boolean {
     return this.edit(fromIdx, toIdx, '');
   }
 
   /**
-   * `empty` make text empty.
+   * `empty` makes the text empty.
    */
   empty(): boolean {
     return this.edit(0, this.length, '');

--- a/test/integration/text_test.ts
+++ b/test/integration/text_test.ts
@@ -228,6 +228,34 @@ describe('Text', function () {
     );
   });
 
+  it('should handle text delete operations', function () {
+    const doc = Document.create<{ k1: Text }>('test-doc');
+    doc.update((root) => {
+      root.k1 = new Text();
+      root.k1.edit(0, 0, 'ABCD');
+    }, 'set ABCD');
+    assert.equal(doc.getRoot().k1.toString(), `ABCD`);
+
+    doc.update((root) => {
+      root.k1.delete(1, 3);
+    }, 'delete BC');
+    assert.equal(doc.getRoot().k1.toString(), `AD`);
+  });
+
+  it('should handle text empty operations', function () {
+    const doc = Document.create<{ k1: Text }>('test-doc');
+    doc.update((root) => {
+      root.k1 = new Text();
+      root.k1.edit(0, 0, 'ABCD');
+    }, 'set ABCD');
+    assert.equal(doc.getRoot().k1.toString(), `ABCD`);
+
+    doc.update((root) => {
+      root.k1.empty();
+    }, 'empty');
+    assert.equal(doc.getRoot().k1.toString(), ``);
+  });
+
   it('should handle concurrent edit operations', async function () {
     await withTwoClientsAndDocuments<{ k1: Text }>(async (c1, d1, c2, d2) => {
       d1.update((root) => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Until now, user called `edit(from, to, '')` to delete content in `Text`; since it is not intuitive, `delete` and `empty` are added to `Text` data type.
```ts
root.content.delete(from, to) // delete range
root.content.empty() // delete all 
```

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #450

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
