### PR TITLE
reduce bundle size for production

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -17,7 +17,6 @@
 const path = require('path');
 const webpack = require('webpack');
 const pkg = require('../package.json');
-const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 const CopyPlugin = require('copy-webpack-plugin');
 
 const date = new Date().toISOString().replace(/:\d+\.\d+Z$/, 'Z');
@@ -44,8 +43,8 @@ limitations under the License.
 
 module.exports = {
   entry: './src/yorkie',
-  devtool: 'inline-source-map',
-  mode: 'development',
+  devtool: 'source-map',
+  mode: 'production',
   module: {
     rules: [
       {
@@ -78,15 +77,20 @@ module.exports = {
     new webpack.BannerPlugin({
       banner,
     }),
-    new NodePolyfillPlugin(),
     // TODO(chacha912): When we exposed the converter, the resources_pb.d.ts
     // was not in the lib, so we got a compile error. For now, we bypass it by
     // directly copying the file. Let's delete this later when we know a more correct fix.
     new CopyPlugin({
       patterns: [
         {
-          from: path.resolve(__dirname, '../src/api/yorkie/v1/resources_pb.d.ts'),
-          to: path.resolve(__dirname, '../lib/src/api/yorkie/v1/resources_pb.d.ts'),
+          from: path.resolve(
+            __dirname,
+            '../src/api/yorkie/v1/resources_pb.d.ts',
+          ),
+          to: path.resolve(
+            __dirname,
+            '../lib/src/api/yorkie/v1/resources_pb.d.ts',
+          ),
         },
       ],
     }),

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -15,8 +15,6 @@
  */
 
 const path = require('path');
-const webpack = require('webpack');
-const NodePolyfillPlugin = require('node-polyfill-webpack-plugin')
 const WebpackBundleAnalyzer = require('webpack-bundle-analyzer');
 
 module.exports = {
@@ -73,8 +71,5 @@ module.exports = {
       },
     },
   },
-  plugins: [
-    new WebpackBundleAnalyzer.BundleAnalyzerPlugin(),
-    new NodePolyfillPlugin(),
-  ],
+  plugins: [new WebpackBundleAnalyzer.BundleAnalyzerPlugin()],
 };

--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -15,6 +15,8 @@
  */
 
 const path = require('path');
+const webpack = require('webpack');
+const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 const WebpackBundleAnalyzer = require('webpack-bundle-analyzer');
 
 module.exports = {
@@ -71,5 +73,8 @@ module.exports = {
       },
     },
   },
-  plugins: [new WebpackBundleAnalyzer.BundleAnalyzerPlugin()],
+  plugins: [
+    new WebpackBundleAnalyzer.BundleAnalyzerPlugin(),
+    new NodePolyfillPlugin(),
+  ],
 };

--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -994,17 +994,39 @@ function objectToBytes(obj: CRDTObject): Uint8Array {
 }
 
 /**
+ * `bytesToHex` creates an hex string from the given byte array.
+ */
+function bytesToHex(bytes?: Uint8Array): string {
+  if (!bytes) {
+    return '';
+  }
+
+  return Array.from(bytes)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+
+/**
  * `toHexString` converts the given byte array to hex string.
  */
 function toHexString(bytes: Uint8Array): string {
-  return Buffer.from(bytes).toString('hex');
+  return bytesToHex(bytes);
+}
+
+/**
+ * `hexToBytes` converts the given hex string to byte array.
+ */
+function hexToBytes(hex: string): Uint8Array {
+  return new Uint8Array(
+    hex.match(/.{1,2}/g)!.map((byte) => parseInt(byte, 16)),
+  );
 }
 
 /**
  * `toUnit8Array` converts the given hex string to byte array.
  */
 function toUint8Array(hex: string): Uint8Array {
-  return Uint8Array.from(Buffer.from(hex, 'hex'));
+  return hexToBytes(hex);
 }
 
 /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Reduce bundle size for production 

#### Any background context you want to provide?


Change the webpack build configuration to reduce the bundle size.

Modify all 3 settings.

1. Separate the source-map to the outside.
2. Build in production mode and minify it.
3. Delete unnecessary packages by removing NodePolyFillPlugin. Buffer used inside is replaced with inline code.

old version bundle

<img width="979" alt="스크린샷 2023-02-07 오후 8 26 12" src="https://user-images.githubusercontent.com/591983/217232512-4bbabcd2-4247-4d9b-bb91-b80722bcb00f.png">


new version bundle

<img width="976" alt="스크린샷 2023-02-07 오후 8 23 56" src="https://user-images.githubusercontent.com/591983/217232625-6a5b91ad-ab14-4a20-9180-c491c5ee3646.png">

| target | old bundle size | new bundle size(minified) | reduce |
|---|---|---|---|
| stat size | 2.11MB | `1.02MB` | -51% | 
| parsed size | 4.36MB | `544.35KB` | -87% | 
| gzipped size | 800.65KB | `95.35KB` | -88% | 

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #434

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
