### PR TITLE
Fix invalid indexOf SplayTree with single node

### DIFF
--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -220,7 +220,7 @@ export class SplayTree<V> {
    * @returns the index of given node
    */
   public indexOf(node: SplayNode<V>): number {
-    if (!node || !node.hasLinks()) {
+    if (!node || (node !== this.root && !node.hasLinks())) {
       return -1;
     }
 

--- a/test/unit/util/splay_tree_test.ts
+++ b/test/unit/util/splay_tree_test.ts
@@ -153,4 +153,12 @@ describe('SplayTree', function () {
     assert.equal(nodes[2].getWeight(), 6);
     assert.equal(sumOfWeight(nodes, 3, 7), 0);
   });
+
+  it('should handle indexOf correctly with single node', function () {
+    const tree = new SplayTree<string>();
+    const nodeA = tree.insert(StringNode.create('A'));
+    assert.equal(tree.indexOf(nodeA), 0);
+    tree.delete(nodeA);
+    assert.equal(tree.indexOf(nodeA), -1);
+  });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

> Fix invalid index of SplayTree with a single node.
>
> This PR addresses an issue with the indexOf in SplayTree, which was failing to calculate the correct index when there was only one node in the tree. The conditional statement has been updated to account for this scenario.



#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address https://github.com/yorkie-team/yorkie/pull/470

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
