### PR TITLE
Clarify the ClientEvent that is sent to `client.subscribe`

### DIFF
--- a/public/counter.html
+++ b/public/counter.html
@@ -25,6 +25,16 @@
       const counterIncreaseButton = document.getElementById('increaseButton');
       const counterDecreaseButton = document.getElementById('decreaseButton');
 
+      function displayPeers(peers, myClientID) {
+        const usernames = [];
+        for (const { clientID, presence } of peers) {
+          usernames.push(
+            clientID === myClientID ? `<b>${clientID}</b>` : clientID,
+          );
+        }
+        peersHolder.innerHTML = JSON.stringify(usernames);
+      }
+
       async function main() {
         try {
           // 01. create client with RPCAddr(envoy) then activate it.
@@ -32,15 +42,10 @@
           client.subscribe(network.statusListener(statusHolder));
           client.subscribe((event) => {
             if (event.type === 'peers-changed') {
-              const usernames = [];
-              const myClientID = client.getID();
-              const peers = event.value.peers[doc.getKey()];
-              for (const { clientID, presence } of peers) {
-                usernames.push(
-                  clientID === myClientID ? `<b>${clientID}</b>` : clientID,
-                );
-              }
-              peersHolder.innerHTML = JSON.stringify(usernames);
+              displayPeers(
+                client.getPeersByDocKey(doc.getKey()),
+                client.getID(),
+              );
             }
           });
           await client.activate();

--- a/public/counter.html
+++ b/public/counter.html
@@ -30,18 +30,12 @@
           // 01. create client with RPCAddr(envoy) then activate it.
           const client = new yorkie.Client('http://localhost:8080');
           client.subscribe(network.statusListener(statusHolder));
-          await client.activate();
-
-          // 02. create a document then attach it into the client.
-          const doc = new yorkie.Document('counter');
-          await client.attach(doc);
-
           client.subscribe((event) => {
             if (event.type === 'peers-changed') {
               const usernames = [];
               const myClientID = client.getID();
-              const peers = event.value[doc.getKey()];
-              for (const [clientID, presence] of Object.entries(peers)) {
+              const peers = event.value.peers[doc.getKey()];
+              for (const { clientID, presence } of peers) {
                 usernames.push(
                   clientID === myClientID ? `<b>${clientID}</b>` : clientID,
                 );
@@ -49,6 +43,11 @@
               peersHolder.innerHTML = JSON.stringify(usernames);
             }
           });
+          await client.activate();
+
+          // 02. create a document then attach it into the client.
+          const doc = new yorkie.Document('counter');
+          await client.attach(doc);
 
           // 03. initialize document properties
           doc.update((root) => {

--- a/public/index.html
+++ b/public/index.html
@@ -49,12 +49,14 @@
         textLogHolder.innerText = doc.getRoot().content.getStructureAsString();
       }
 
-      function displayPeers(peers, clientID) {
-        const clientIDs = peers.map((peer) => peer.clientID);
-        peersHolder.innerHTML = JSON.stringify(clientIDs).replace(
-          clientID,
-          `<b>${clientID}</b>`,
-        );
+      function displayPeers(peers, myClientID) {
+        const usernames = [];
+        for (const { clientID, presence } of peers) {
+          usernames.push(
+            clientID === myClientID ? `<b>${clientID}</b>` : clientID,
+          );
+        }
+        peersHolder.innerHTML = JSON.stringify(usernames);
       }
 
       // https://github.com/codemirror/CodeMirror/pull/5619
@@ -138,7 +140,10 @@
           client.subscribe(network.statusListener(statusHolder));
           client.subscribe((event) => {
             if (event.type === 'peers-changed') {
-              displayPeers(event.value.peers[doc.getKey()], client.getID());
+              displayPeers(
+                client.getPeersByDocKey(doc.getKey()),
+                client.getID(),
+              );
             }
           });
           // 01-3. activate client

--- a/public/index.html
+++ b/public/index.html
@@ -50,12 +50,7 @@
       }
 
       function displayPeers(peers, clientID) {
-        const clientIDs = [];
-
-        for (const [clientID, _] of Object.entries(peers)) {
-          clientIDs.push(clientID);
-        }
-
+        const clientIDs = peers.map((peer) => peer.clientID);
         peersHolder.innerHTML = JSON.stringify(clientIDs).replace(
           clientID,
           `<b>${clientID}</b>`,
@@ -137,17 +132,17 @@
 
       async function main() {
         try {
-          // 01. create client with RPCAddr(envoy) then activate it.
+          // 01-1. create client with RPCAddr(envoy).
           const client = new yorkie.Client('http://localhost:8080');
-          client.subscribe(network.statusListener(statusHolder));
-          await client.activate();
-
           // 01-2. subscribe client event.
+          client.subscribe(network.statusListener(statusHolder));
           client.subscribe((event) => {
             if (event.type === 'peers-changed') {
-              displayPeers(event.value[doc.getKey()], client.getID());
+              displayPeers(event.value.peers[doc.getKey()], client.getID());
             }
           });
+          // 01-3. activate client
+          await client.activate();
 
           // 02. create a document then attach it into the client.
           const doc = new yorkie.Document('codemirror');

--- a/public/quill.html
+++ b/public/quill.html
@@ -41,7 +41,7 @@
         const { embed, ...restAttributes } = textValue.attributes ?? {};
 
         if (embed) {
-          return { insert: JSON.parse(embed), attributes: restAttributes }
+          return { insert: JSON.parse(embed), attributes: restAttributes };
         }
 
         return {
@@ -50,50 +50,57 @@
         };
       }
 
-      function displayPeers(elem, peers, clientID) {
+      function displayPeers(peers, myClientID) {
         const usernames = [];
-        for (const [clientID, presence] of Object.entries(peers)) {
+        for (const { clientID, presence } of peers) {
           usernames.push(
-            clientID === clientID ? `<b>${presence.username}</b>` : presence.username,
+            myClientID === clientID
+              ? `<b>${presence.username}</b>`
+              : presence.username,
           );
         }
-        elem.innerHTML = JSON.stringify(usernames);
+        peersElem.innerHTML = JSON.stringify(usernames);
       }
 
-      function findDefectors(peers, newPeers) {
-        const usernames = [];
-        for (const [clientID, presence] of Object.entries(peers)) {
-          if (!newPeers[clientID]) {
-            usernames.push(presence.username);
+      function getPeerPresence(peers, peerID) {
+        for (const peer of peers) {
+          if (peer.clientID === peerID) {
+            return peer.presence;
           }
         }
-        return usernames;
+        return null;
       }
 
       async function main() {
         try {
-          let peers;
+          let quillPeers;
 
-          // 01-1. create client with RPCAddr(envoy) then activate it.
+          // 01. create client with RPCAddr(envoy) then activate it.
           const client = new yorkie.Client('http://localhost:8080', {
             presence: {
               username: `username-${shortUniqueID()}`,
             },
           });
           await client.activate();
-
-          // 01-2. subscribe client event.
+          client.subscribe(network.statusListener(networkStatusElem));
           client.subscribe((event) => {
-            network.statusListener(networkStatusElem)(event);
-            if (event.type === 'peers-changed') {
-              const newPeers = event.value[doc.getKey()];
-              if (peers) {
-                for (const username of findDefectors(peers, newPeers)) {
-                  cursors.removeCursor(username);
-                }
+            if (event.type !== 'peers-changed') return;
+
+            const { type, changedPeers, peers } = event.value;
+            const quillChangedPeers = changedPeers[doc.getKey()];
+            quillPeers = peers[doc.getKey()];
+
+            switch (type) {
+              case 'unwatched': {
+                cursors.removeCursor(
+                  quillChangedPeers.map((peer) => peer.presence.username),
+                );
+                break;
               }
-              peers = newPeers;
-              displayPeers(peersElem, event.value[doc.getKey()], client.getID() || '');
+              default: {
+                displayPeers(quillPeers, client.getID());
+                break;
+              }
             }
           });
 
@@ -220,12 +227,12 @@
             const deltaOperations = [];
             let prevTo = 0;
             for (const change of changes) {
-              const actor = change.actor;
-              if (actor === client.getID()) {
+              const actorID = change.actor;
+              if (actorID === client.getID()) {
                 continue;
               }
 
-              const actorName = peers[actor]['username'];
+              const actorName = getPeerPresence(quillPeers, actorID).username;
               const from = change.from;
               const to = change.to;
               const retainFrom = from - prevTo;

--- a/public/quill.html
+++ b/public/quill.html
@@ -86,22 +86,13 @@
           client.subscribe((event) => {
             if (event.type !== 'peers-changed') return;
 
-            const { type, changedPeers, peers } = event.value;
-            const quillChangedPeers = changedPeers[doc.getKey()];
-            quillPeers = peers[doc.getKey()];
-
-            switch (type) {
-              case 'unwatched': {
-                cursors.removeCursor(
-                  quillChangedPeers.map((peer) => peer.presence.username),
-                );
-                break;
-              }
-              default: {
-                displayPeers(quillPeers, client.getID());
-                break;
-              }
+            const { type, peers } = event.value;
+            if (type === 'unwatched') {
+              cursors.removeCursor(
+                peers[doc.getKey()].map((peer) => peer.presence.username),
+              );
             }
+            displayPeers(client.getPeersByDocKey(doc.getKey()), client.getID());
           });
 
           // 02. create a document then attach it into the client.

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -145,13 +145,19 @@ export interface RemoteChangeEvent extends BaseDocEvent {
 export type Indexable = Record<string, any>;
 
 /**
+ * Document key type
+ * @public
+ */
+export type DocumentKey = string;
+
+/**
  * `Document` is a CRDT-based data type. We can represent the model
  * of the application and edit it even while offline.
  *
  * @public
  */
 export class Document<T> implements Observable<DocEvent> {
-  private key: string;
+  private key: DocumentKey;
   private root: CRDTRoot;
   private clone?: CRDTRoot;
   private changeID: ChangeID;

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -47,15 +47,11 @@ export function delay(timeout: number): Promise<void> {
   });
 }
 
-export function createEmitterAndSpy(
-  fn?: (event: ClientEvent | DocEvent) => string,
-): [EventEmitter, NextFn<ClientEvent | DocEvent>] {
+export function createEmitterAndSpy<
+  E extends { type: any } = ClientEvent | DocEvent,
+>(fn?: (event: E) => string): [EventEmitter, NextFn<E>] {
   const emitter = new EventEmitter();
-  return [
-    emitter,
-    (event: ClientEvent | DocEvent) =>
-      emitter.emit(fn ? fn(event) : event.type),
-  ];
+  return [emitter, (event: E) => emitter.emit(fn ? fn(event) : event.type)];
 }
 
 /**

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -54,6 +54,23 @@ export function createEmitterAndSpy<
   return [emitter, (event: E) => emitter.emit(fn ? fn(event) : event.type)];
 }
 
+export async function waitStubCallCount(
+  stub: sinon.SinonStub,
+  callCount: number,
+) {
+  return new Promise<void>((resolve) => {
+    const doLoop = () => {
+      if (stub.callCount === callCount) {
+        resolve();
+      }
+      return false;
+    };
+    if (!doLoop()) {
+      setTimeout(doLoop, 1000);
+    }
+  });
+}
+
 export function deepSortObject(object: Record<string, any>) {
   for (const [key, value] of Object.entries(object)) {
     if (typeof value === 'object') {

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -54,6 +54,24 @@ export function createEmitterAndSpy<
   return [emitter, (event: E) => emitter.emit(fn ? fn(event) : event.type)];
 }
 
+export function deepSortObject(object: Record<string, any>) {
+  for (const [key, value] of Object.entries(object)) {
+    if (typeof value === 'object') {
+      object[key] = deepSortObject(value);
+    }
+  }
+  return sortObject(object);
+}
+
+function sortObject(unordered: Record<string, any>) {
+  return Object.keys(unordered)
+    .sort()
+    .reduce((obj, key: string) => {
+      obj[key] = unordered[key];
+      return obj;
+    }, {} as Record<string, any>);
+}
+
 /**
  * TextView emulates an external editor like CodeMirror to test whether change
  * events are delivered properly.

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -71,22 +71,41 @@ export async function waitStubCallCount(
   });
 }
 
-export function deepSortObject(object: Record<string, any>) {
-  for (const [key, value] of Object.entries(object)) {
-    if (typeof value === 'object') {
-      object[key] = deepSortObject(value);
-    }
+export function deepSort(target: any): any {
+  if (Array.isArray(target)) {
+    return target.map(deepSort).sort(compareFunction);
   }
-  return sortObject(object);
+  if (typeof target === 'object') {
+    return Object.keys(target)
+      .sort()
+      .reduce((result, key) => {
+        result[key] = deepSort(target[key]);
+        return result;
+      }, {} as Record<string, any>);
+  }
+  return target;
 }
 
-function sortObject(unordered: Record<string, any>) {
-  return Object.keys(unordered)
-    .sort()
-    .reduce((obj, key: string) => {
-      obj[key] = unordered[key];
-      return obj;
-    }, {} as Record<string, any>);
+function compareFunction(a: any, b: any): number {
+  if (
+    typeof a === 'object' &&
+    typeof b === 'object' &&
+    a !== null &&
+    b !== null
+  ) {
+    const aKeys = Object.keys(a).sort();
+    const bKeys = Object.keys(b).sort();
+    const len = Math.min(aKeys.length, bKeys.length);
+    for (let i = 0; i < len; i++) {
+      const key = aKeys[i];
+      const result = compareFunction(a[key], b[key]);
+      if (result !== 0) {
+        return result;
+      }
+    }
+    return aKeys.length - bKeys.length;
+  }
+  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 /**

--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -537,11 +537,9 @@ describe('Client', function () {
     });
     await waitStubCallCount(stub2, 6);
     assert.equal(6, stub2.callCount);
-    // NOTE(chacha912): The events have to be sorted because
-    // the 'peers-changed' event does not guarantee order.
     assert.deepEqual(
-      c2ExpectedEvents.sort(),
-      c2Events.sort(),
+      c2ExpectedEvents,
+      c2Events,
       `[c2] c1 attach doc2: \n actual: ${JSON.stringify(
         c2Events,
       )} \n expected: ${JSON.stringify(c2ExpectedEvents)}`,

--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -338,9 +338,6 @@ describe('Client', function () {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'initialization',
-        changedPeers: {
-          [docKey1]: [{ clientID: c1ID, presence: { ...c1Presence } }],
-        },
         peers: {
           [docKey1]: [{ clientID: c1ID, presence: { ...c1Presence } }],
         },
@@ -364,12 +361,6 @@ describe('Client', function () {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'initialization',
-        changedPeers: {
-          [docKey1]: [
-            { clientID: c1ID, presence: { ...c1Presence } },
-            { clientID: c2ID, presence: { ...c2Presence } },
-          ],
-        },
         peers: {
           [docKey1]: [
             { clientID: c1ID, presence: { ...c1Presence } },
@@ -391,14 +382,8 @@ describe('Client', function () {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'watched',
-        changedPeers: {
-          [docKey1]: [{ clientID: c2ID, presence: { ...c2Presence } }],
-        },
         peers: {
-          [docKey1]: [
-            { clientID: c1ID, presence: { ...c1Presence } },
-            { clientID: c2ID, presence: { ...c2Presence } },
-          ],
+          [docKey1]: [{ clientID: c2ID, presence: { ...c2Presence } }],
         },
       },
     });
@@ -417,15 +402,9 @@ describe('Client', function () {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'presence-changed',
-        changedPeers: {
-          [docKey1]: [
-            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
-          ],
-        },
         peers: {
           [docKey1]: [
             { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
-            { clientID: c2ID, presence: { ...c2Presence } },
           ],
         },
       },
@@ -443,15 +422,9 @@ describe('Client', function () {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'presence-changed',
-        changedPeers: {
-          [docKey1]: [
-            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
-          ],
-        },
         peers: {
           [docKey1]: [
             { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
-            { clientID: c2ID, presence: { ...c2Presence } },
           ],
         },
       },
@@ -479,15 +452,6 @@ describe('Client', function () {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'initialization',
-        changedPeers: {
-          [docKey1]: [
-            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
-            { clientID: c2ID, presence: { ...c2Presence } },
-          ],
-          [docKey2]: [
-            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
-          ],
-        },
         peers: {
           [docKey1]: [
             { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
@@ -512,13 +476,10 @@ describe('Client', function () {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'unwatched',
-        changedPeers: {
+        peers: {
           [docKey1]: [
             { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
           ],
-        },
-        peers: {
-          [docKey1]: [{ clientID: c2ID, presence: { ...c2Presence } }],
         },
       },
     });
@@ -526,15 +487,9 @@ describe('Client', function () {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'watched',
-        changedPeers: {
-          [docKey1]: [
-            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
-          ],
-        },
         peers: {
           [docKey1]: [
             { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
-            { clientID: c2ID, presence: { ...c2Presence } },
           ],
         },
       },
@@ -562,11 +517,6 @@ describe('Client', function () {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'initialization',
-        changedPeers: {
-          [docKey2]: [
-            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
-          ],
-        },
         peers: {
           [docKey2]: [
             { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
@@ -587,13 +537,10 @@ describe('Client', function () {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'unwatched',
-        changedPeers: {
+        peers: {
           [docKey1]: [
             { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
           ],
-        },
-        peers: {
-          [docKey1]: [{ clientID: c2ID, presence: { ...c2Presence } }],
         },
       },
     });

--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -251,7 +251,11 @@ describe('Client', function () {
     unsub2();
   });
 
-  it('client event flow', async function () {
+  it('client.subscribe correctly detects the events', async function () {
+    // The test verifies whether `client.subscribe` correctly detects events
+    // when the client performs activate, attach, updatePresence, detach, and deactivate.
+    // Please refer to the figure in the yorkie-js-sdk issue for the test code flow.
+    // https://github.com/yorkie-team/yorkie-js-sdk/pull/464
     type PresenceType = {
       name: string;
       cursor: { x: number; y: number };

--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -256,144 +256,144 @@ describe('Client', function () {
       name: string;
       cursor: { x: number; y: number };
     };
-    const c1_presence = {
+    const c1Presence = {
       name: 'a',
       cursor: { x: 0, y: 0 },
     };
-    const c2_presence = {
+    const c2Presence = {
       name: 'b',
       cursor: { x: 1, y: 1 },
     };
     const c1 = new yorkie.Client<PresenceType>(testRPCAddr, {
-      presence: c1_presence,
+      presence: c1Presence,
     });
     const c2 = new yorkie.Client<PresenceType>(testRPCAddr, {
-      presence: c2_presence,
+      presence: c2Presence,
     });
 
     const docKey1 = 'event-flow1';
     const docKey2 = 'event-flow2';
-    const doc1_c1 = new yorkie.Document(docKey1);
-    const doc1_c2 = new yorkie.Document(docKey1);
-    const doc2_c1 = new yorkie.Document(docKey2);
+    const doc1C1 = new yorkie.Document(docKey1);
+    const doc1C2 = new yorkie.Document(docKey1);
+    const doc2C1 = new yorkie.Document(docKey2);
 
-    const c1_events: Array<string> = [];
-    const c1_expectedEvents: Array<string> = [];
-    const c2_events: Array<string> = [];
-    const c2_expectedEvents: Array<string> = [];
+    const c1Events: Array<string> = [];
+    const c1ExpectedEvents: Array<string> = [];
+    const c2Events: Array<string> = [];
+    const c2ExpectedEvents: Array<string> = [];
     function pushEvent(array: Array<string>, event: ClientEvent) {
       const sortedEvent = deepSort(event);
       array.push(JSON.stringify(sortedEvent));
     }
 
     const stub1 = sinon.stub().callsFake((event) => {
-      pushEvent(c1_events, event);
+      pushEvent(c1Events, event);
     });
     const stub2 = sinon.stub().callsFake((event) => {
-      pushEvent(c2_events, event);
+      pushEvent(c2Events, event);
     });
     const unsub1 = c1.subscribe(stub1);
     const unsub2 = c2.subscribe(stub2);
 
     await c1.activate();
-    const c1_ID = c1.getID()!;
-    pushEvent(c1_expectedEvents, {
+    const c1ID = c1.getID()!;
+    pushEvent(c1ExpectedEvents, {
       type: ClientEventType.StatusChanged,
       value: ClientStatus.Activated,
     });
     assert.equal(1, stub1.callCount);
     assert.deepEqual(
-      c1_expectedEvents,
-      c1_events,
+      c1ExpectedEvents,
+      c1Events,
       `[c1] c1 activate: \n actual: ${JSON.stringify(
-        c1_events,
-      )} \n expected: ${JSON.stringify(c1_expectedEvents)}`,
+        c1Events,
+      )} \n expected: ${JSON.stringify(c1ExpectedEvents)}`,
     );
 
     await c2.activate();
-    const c2_ID = c2.getID()!;
-    pushEvent(c2_expectedEvents, {
+    const c2ID = c2.getID()!;
+    pushEvent(c2ExpectedEvents, {
       type: ClientEventType.StatusChanged,
       value: ClientStatus.Activated,
     });
     assert.equal(1, stub2.callCount);
     assert.deepEqual(
-      c2_expectedEvents,
-      c2_events,
+      c2ExpectedEvents,
+      c2Events,
       `[c2] c2 activate: \n actual: ${JSON.stringify(
-        c2_events,
-      )} \n expected: ${JSON.stringify(c2_expectedEvents)}`,
+        c2Events,
+      )} \n expected: ${JSON.stringify(c2ExpectedEvents)}`,
     );
 
-    await c1.attach(doc1_c1);
-    pushEvent(c1_expectedEvents, {
+    await c1.attach(doc1C1);
+    pushEvent(c1ExpectedEvents, {
       type: ClientEventType.StreamConnectionStatusChanged,
       value: StreamConnectionStatus.Connected,
     });
-    pushEvent(c1_expectedEvents, {
+    pushEvent(c1ExpectedEvents, {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'initialization',
         changedPeers: {
-          [docKey1]: [{ clientID: c1_ID, presence: { ...c1_presence } }],
+          [docKey1]: [{ clientID: c1ID, presence: { ...c1Presence } }],
         },
         peers: {
-          [docKey1]: [{ clientID: c1_ID, presence: { ...c1_presence } }],
+          [docKey1]: [{ clientID: c1ID, presence: { ...c1Presence } }],
         },
       },
     });
     assert.equal(3, stub1.callCount);
     assert.deepEqual(
-      c1_expectedEvents,
-      c1_events,
+      c1ExpectedEvents,
+      c1Events,
       `[c1] c1 attach doc1: \n actual: ${JSON.stringify(
-        c1_events,
-      )} \n expected: ${JSON.stringify(c1_expectedEvents)}`,
+        c1Events,
+      )} \n expected: ${JSON.stringify(c1ExpectedEvents)}`,
     );
 
-    await c2.attach(doc1_c2);
-    pushEvent(c2_expectedEvents, {
+    await c2.attach(doc1C2);
+    pushEvent(c2ExpectedEvents, {
       type: ClientEventType.StreamConnectionStatusChanged,
       value: StreamConnectionStatus.Connected,
     });
-    pushEvent(c2_expectedEvents, {
+    pushEvent(c2ExpectedEvents, {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'initialization',
         changedPeers: {
           [docKey1]: [
-            { clientID: c1_ID, presence: { ...c1_presence } },
-            { clientID: c2_ID, presence: { ...c2_presence } },
+            { clientID: c1ID, presence: { ...c1Presence } },
+            { clientID: c2ID, presence: { ...c2Presence } },
           ],
         },
         peers: {
           [docKey1]: [
-            { clientID: c1_ID, presence: { ...c1_presence } },
-            { clientID: c2_ID, presence: { ...c2_presence } },
+            { clientID: c1ID, presence: { ...c1Presence } },
+            { clientID: c2ID, presence: { ...c2Presence } },
           ],
         },
       },
     });
     assert.equal(3, stub2.callCount);
     assert.deepEqual(
-      c2_expectedEvents,
-      c2_events,
+      c2ExpectedEvents,
+      c2Events,
       `[c2] c2 attach doc1: \n actual: ${JSON.stringify(
-        c2_events,
-      )} \n expected: ${JSON.stringify(c2_expectedEvents)}`,
+        c2Events,
+      )} \n expected: ${JSON.stringify(c2ExpectedEvents)}`,
     );
 
-    pushEvent(c1_expectedEvents, {
+    pushEvent(c1ExpectedEvents, {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'watched',
         changedPeers: {
-          [docKey1]: [{ clientID: c2_ID, presence: { ...c2_presence } }],
+          [docKey1]: [{ clientID: c2ID, presence: { ...c2Presence } }],
         },
         peers: {
           [docKey1]: [
-            { clientID: c1_ID, presence: { ...c1_presence } },
-            { clientID: c2_ID, presence: { ...c2_presence } },
+            { clientID: c1ID, presence: { ...c1Presence } },
+            { clientID: c2ID, presence: { ...c2Presence } },
           ],
         },
       },
@@ -401,53 +401,53 @@ describe('Client', function () {
     await waitStubCallCount(stub1, 4);
     assert.equal(4, stub1.callCount);
     assert.deepEqual(
-      c1_expectedEvents,
-      c1_events,
+      c1ExpectedEvents,
+      c1Events,
       `[c1] c2 attach doc1: \n actual: ${JSON.stringify(
-        c1_events,
-      )} \n expected: ${JSON.stringify(c1_expectedEvents)}`,
+        c1Events,
+      )} \n expected: ${JSON.stringify(c1ExpectedEvents)}`,
     );
 
     await c1.updatePresence('name', 'z');
-    pushEvent(c1_expectedEvents, {
+    pushEvent(c1ExpectedEvents, {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'presence-changed',
         changedPeers: {
           [docKey1]: [
-            { clientID: c1_ID, presence: { ...c1_presence, name: 'z' } },
+            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
           ],
         },
         peers: {
           [docKey1]: [
-            { clientID: c1_ID, presence: { ...c1_presence, name: 'z' } },
-            { clientID: c2_ID, presence: { ...c2_presence } },
+            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
+            { clientID: c2ID, presence: { ...c2Presence } },
           ],
         },
       },
     });
     assert.equal(5, stub1.callCount);
     assert.deepEqual(
-      c1_expectedEvents,
-      c1_events,
+      c1ExpectedEvents,
+      c1Events,
       `[c1] c1 updatePresence: \n actual: ${JSON.stringify(
-        c1_events,
-      )} \n expected: ${JSON.stringify(c1_expectedEvents)}`,
+        c1Events,
+      )} \n expected: ${JSON.stringify(c1ExpectedEvents)}`,
     );
 
-    pushEvent(c2_expectedEvents, {
+    pushEvent(c2ExpectedEvents, {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'presence-changed',
         changedPeers: {
           [docKey1]: [
-            { clientID: c1_ID, presence: { ...c1_presence, name: 'z' } },
+            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
           ],
         },
         peers: {
           [docKey1]: [
-            { clientID: c1_ID, presence: { ...c1_presence, name: 'z' } },
-            { clientID: c2_ID, presence: { ...c2_presence } },
+            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
+            { clientID: c2ID, presence: { ...c2Presence } },
           ],
         },
       },
@@ -455,82 +455,82 @@ describe('Client', function () {
     await waitStubCallCount(stub2, 4);
     assert.equal(4, stub2.callCount);
     assert.deepEqual(
-      c2_expectedEvents,
-      c2_events,
+      c2ExpectedEvents,
+      c2Events,
       `[c2] c1 updatePresence: \n actual: ${JSON.stringify(
-        c2_events,
-      )} \n expected: ${JSON.stringify(c2_expectedEvents)}`,
+        c2Events,
+      )} \n expected: ${JSON.stringify(c2ExpectedEvents)}`,
     );
 
-    await c1.attach(doc2_c1);
-    pushEvent(c1_expectedEvents, {
+    await c1.attach(doc2C1);
+    pushEvent(c1ExpectedEvents, {
       type: ClientEventType.StreamConnectionStatusChanged,
       value: StreamConnectionStatus.Disconnected,
     });
-    pushEvent(c1_expectedEvents, {
+    pushEvent(c1ExpectedEvents, {
       type: ClientEventType.StreamConnectionStatusChanged,
       value: StreamConnectionStatus.Connected,
     });
-    pushEvent(c1_expectedEvents, {
+    pushEvent(c1ExpectedEvents, {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'initialization',
         changedPeers: {
           [docKey1]: [
-            { clientID: c1_ID, presence: { ...c1_presence, name: 'z' } },
-            { clientID: c2_ID, presence: { ...c2_presence } },
+            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
+            { clientID: c2ID, presence: { ...c2Presence } },
           ],
           [docKey2]: [
-            { clientID: c1_ID, presence: { ...c1_presence, name: 'z' } },
+            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
           ],
         },
         peers: {
           [docKey1]: [
-            { clientID: c1_ID, presence: { ...c1_presence, name: 'z' } },
-            { clientID: c2_ID, presence: { ...c2_presence } },
+            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
+            { clientID: c2ID, presence: { ...c2Presence } },
           ],
           [docKey2]: [
-            { clientID: c1_ID, presence: { ...c1_presence, name: 'z' } },
+            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
           ],
         },
       },
     });
     assert.equal(8, stub1.callCount);
     assert.deepEqual(
-      c1_expectedEvents,
-      c1_events,
+      c1ExpectedEvents,
+      c1Events,
       `[c1] c1 attach doc2: \n actual: ${JSON.stringify(
-        c1_events,
-      )} \n expected: ${JSON.stringify(c1_expectedEvents)}`,
+        c1Events,
+      )} \n expected: ${JSON.stringify(c1ExpectedEvents)}`,
     );
 
-    pushEvent(c2_expectedEvents, {
+    pushEvent(c2ExpectedEvents, {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'unwatched',
         changedPeers: {
           [docKey1]: [
-            { clientID: c1_ID, presence: { ...c1_presence, name: 'z' } },
+            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
           ],
         },
         peers: {
-          [docKey1]: [{ clientID: c2_ID, presence: { ...c2_presence } }],
+          [docKey1]: [{ clientID: c2ID, presence: { ...c2Presence } }],
         },
       },
     });
-    pushEvent(c2_expectedEvents, {
+    pushEvent(c2ExpectedEvents, {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'watched',
         changedPeers: {
           [docKey1]: [
-            { clientID: c1_ID, presence: { ...c1_presence, name: 'z' } },
+            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
           ],
         },
         peers: {
           [docKey1]: [
-            { clientID: c1_ID, presence: { ...c1_presence, name: 'z' } },
-            { clientID: c2_ID, presence: { ...c2_presence } },
+            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
+            { clientID: c2ID, presence: { ...c2Presence } },
           ],
         },
       },
@@ -540,115 +540,115 @@ describe('Client', function () {
     // NOTE(chacha912): The events have to be sorted because
     // the 'peers-changed' event does not guarantee order.
     assert.deepEqual(
-      c2_expectedEvents.sort(),
-      c2_events.sort(),
+      c2ExpectedEvents.sort(),
+      c2Events.sort(),
       `[c2] c1 attach doc2: \n actual: ${JSON.stringify(
-        c2_events,
-      )} \n expected: ${JSON.stringify(c2_expectedEvents)}`,
+        c2Events,
+      )} \n expected: ${JSON.stringify(c2ExpectedEvents)}`,
     );
 
-    await c1.detach(doc1_c1);
-    pushEvent(c1_expectedEvents, {
+    await c1.detach(doc1C1);
+    pushEvent(c1ExpectedEvents, {
       type: ClientEventType.StreamConnectionStatusChanged,
       value: StreamConnectionStatus.Disconnected,
     });
-    pushEvent(c1_expectedEvents, {
+    pushEvent(c1ExpectedEvents, {
       type: ClientEventType.StreamConnectionStatusChanged,
       value: StreamConnectionStatus.Connected,
     });
-    pushEvent(c1_expectedEvents, {
+    pushEvent(c1ExpectedEvents, {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'initialization',
         changedPeers: {
           [docKey2]: [
-            { clientID: c1_ID, presence: { ...c1_presence, name: 'z' } },
+            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
           ],
         },
         peers: {
           [docKey2]: [
-            { clientID: c1_ID, presence: { ...c1_presence, name: 'z' } },
+            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
           ],
         },
       },
     });
     assert.equal(11, stub1.callCount);
     assert.deepEqual(
-      c1_expectedEvents,
-      c1_events,
+      c1ExpectedEvents,
+      c1Events,
       `[c1] c1 detach doc1: \n actual: ${JSON.stringify(
-        c1_events,
-      )} \n expected: ${JSON.stringify(c1_expectedEvents)}`,
+        c1Events,
+      )} \n expected: ${JSON.stringify(c1ExpectedEvents)}`,
     );
 
-    pushEvent(c2_expectedEvents, {
+    pushEvent(c2ExpectedEvents, {
       type: ClientEventType.PeersChanged,
       value: {
         type: 'unwatched',
         changedPeers: {
           [docKey1]: [
-            { clientID: c1_ID, presence: { ...c1_presence, name: 'z' } },
+            { clientID: c1ID, presence: { ...c1Presence, name: 'z' } },
           ],
         },
         peers: {
-          [docKey1]: [{ clientID: c2_ID, presence: { ...c2_presence } }],
+          [docKey1]: [{ clientID: c2ID, presence: { ...c2Presence } }],
         },
       },
     });
     await waitStubCallCount(stub2, 7);
     assert.equal(7, stub2.callCount);
     assert.deepEqual(
-      c2_expectedEvents,
-      c2_events,
+      c2ExpectedEvents,
+      c2Events,
       `[c2] c1 detach doc1: \n actual: ${JSON.stringify(
-        c2_events,
-      )} \n expected: ${JSON.stringify(c2_expectedEvents)}`,
+        c2Events,
+      )} \n expected: ${JSON.stringify(c2ExpectedEvents)}`,
     );
 
     await c1.deactivate();
-    pushEvent(c1_expectedEvents, {
+    pushEvent(c1ExpectedEvents, {
       type: ClientEventType.StreamConnectionStatusChanged,
       value: StreamConnectionStatus.Disconnected,
     });
-    pushEvent(c1_expectedEvents, {
+    pushEvent(c1ExpectedEvents, {
       type: ClientEventType.StatusChanged,
       value: ClientStatus.Deactivated,
     });
     assert.equal(13, stub1.callCount);
     assert.deepEqual(
-      c1_expectedEvents,
-      c1_events,
+      c1ExpectedEvents,
+      c1Events,
       `[c1] c1 deactivate: \n actual: ${JSON.stringify(
-        c1_events,
-      )} \n expected: ${JSON.stringify(c1_expectedEvents)}`,
+        c1Events,
+      )} \n expected: ${JSON.stringify(c1ExpectedEvents)}`,
     );
 
-    await c2.detach(doc1_c2);
-    pushEvent(c2_expectedEvents, {
+    await c2.detach(doc1C2);
+    pushEvent(c2ExpectedEvents, {
       type: ClientEventType.StreamConnectionStatusChanged,
       value: StreamConnectionStatus.Disconnected,
     });
     assert.equal(8, stub2.callCount);
     assert.deepEqual(
-      c2_expectedEvents,
-      c2_events,
+      c2ExpectedEvents,
+      c2Events,
       `[c2] c2 detach doc1: \n actual: ${JSON.stringify(
-        c2_events,
-      )} \n expected: ${JSON.stringify(c2_expectedEvents)}`,
+        c2Events,
+      )} \n expected: ${JSON.stringify(c2ExpectedEvents)}`,
     );
 
     await c2.deactivate();
-    pushEvent(c2_expectedEvents, {
+    pushEvent(c2ExpectedEvents, {
       type: ClientEventType.StatusChanged,
       value: ClientStatus.Deactivated,
     });
     assert.equal(9, stub2.callCount);
     assert.deepEqual(
-      c2_expectedEvents,
-      c2_events,
+      c2ExpectedEvents,
+      c2Events,
       `[c2] c2 deactivate: \n actual: ${JSON.stringify(
-        c2_events,
-      )} \n expected: ${JSON.stringify(c2_expectedEvents)}`,
+        c2Events,
+      )} \n expected: ${JSON.stringify(c2ExpectedEvents)}`,
     );
 
     unsub1();


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Clarify the ClientEvent that is sent to client.subscribe

- [x] Remove `runWatchLoop` when activating the client
- [x] Add sending of `connected` and `disconnected` events

### PeersChanged Event 

- [x] Elaborate on the value of the `PeersChanged` event

- as-is
```ts
// js-sdk
type PeersChangedValue<P> = Record<string, Record<string, P>>;

```

- to-be
```ts
// js-sdk
type PeersChangedValue<P> = {
  type: 'initialization' | 'watched' | 'unwatched' | 'presence-changed';
  peers: Record<DocumentKey, Array<{ clientID: ActorID; presence: P }>>;
};

// example
client.subscribe((event) => {
  switch (event.type) {
    case 'status-changed': {
      // event.value: activated, deactivated
      break;
    }
    case 'stream-connection-status-changed': {
      // event.value: connected, disconnected
      break;
    }
    case 'document-synced': {
      // event.value: synced, sync-failed
      break;
    }
    case 'document-changed': {
      // event.value: docKey[]
      break;
    }
    case 'peers-changed': {
      const { type, peers } = event.value;
      // type: initialization, watched, unwatched, presence-changed

      switch (event.value.type) {
        case 'initialization': {
          displayCursor(peers[doc.getKey()]); 
          break;
        }
        case 'unwatched': {
          // we can get which peer has unwatched.
          removeCursor(peers[doc.getKey()]);
          break;
        }
        case 'watched':
        case 'presence-changed': {
          // we can partially update for changed peers.
          updateCursor(peers[doc.getKey()]);
          break;
        }
      }

      // if you need entire peers
      displayPeers(client.getPeersByDocKey(doc.getKey()));
      break;
    }
  }
});
```

### `ClientEvent` flow in test code

- [x] Add test for `ClientEvent` flow in `client.subscribe`

![image](https://user-images.githubusercontent.com/81357083/220852863-d29be37a-fb11-4754-a3c4-c33ec02e1f10.png)
---
![image](https://user-images.githubusercontent.com/81357083/220852811-6db7cc9e-d93b-4a99-bf35-135031c560f7.png)
---
![image](https://user-images.githubusercontent.com/81357083/220852616-589b2035-683f-4ac4-bd14-bb6286fefefc.png)


#### Any background context you want to provide?



#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
