### PR TITLE
Add toDocKey to convert to a valid key in tests

### DIFF
--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -10,6 +10,7 @@ import {
   waitFor,
 } from '@yorkie-js-sdk/test/helper/helper';
 import {
+  toDocKey,
   testRPCAddr,
   withTwoClientsAndDocuments,
 } from '@yorkie-js-sdk/test/integration/integration_helper';
@@ -123,7 +124,7 @@ describe('Client', function () {
     await c1.activate();
     await c2.activate();
 
-    const docKey = `${this.test!.title}-${new Date().getTime()}`;
+    const docKey = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
     const d1 = new yorkie.Document<{ k1: string }>(docKey);
     const d2 = new yorkie.Document<{ k1: string }>(docKey);
 
@@ -213,7 +214,7 @@ describe('Client', function () {
         cursor: { x: 1, y: 1 },
       },
     });
-    const docKey = `${this.test!.title}-${new Date().getTime()}`;
+    const docKey = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
     const doc = new yorkie.Document(docKey);
 
     const [emitter1, spy1] = createEmitterAndSpy();

--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -1,6 +1,9 @@
 import { assert } from 'chai';
 import yorkie, { DocEventType } from '@yorkie-js-sdk/src/yorkie';
-import { testRPCAddr } from '@yorkie-js-sdk/test/integration/integration_helper';
+import {
+  testRPCAddr,
+  toDocKey,
+} from '@yorkie-js-sdk/test/integration/integration_helper';
 import {
   createEmitterAndSpy,
   waitFor,
@@ -10,7 +13,7 @@ import type { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
 describe('Document', function () {
   it('Can attach/detach documents', async function () {
     type TestDoc = { k1: { ['k1-1']: string }; k2: Array<string> };
-    const docKey = `${this.test!.title}-${new Date().getTime()}`;
+    const docKey = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
 
@@ -49,7 +52,7 @@ describe('Document', function () {
     await c1.activate();
     await c2.activate();
 
-    const docKey = `${this.test!.title}-${new Date().getTime()}`;
+    const docKey = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
     const d1 = new yorkie.Document<{ k1: string }>(docKey);
     const d2 = new yorkie.Document<{ k1: string }>(docKey);
     await c1.attach(d1);
@@ -79,7 +82,7 @@ describe('Document', function () {
 
   it('Can handle tombstone', async function () {
     type TestDoc = { k1: Array<number> };
-    const docKey = `${this.test!.title}-${new Date().getTime()}`;
+    const docKey = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
     const d1 = new yorkie.Document<TestDoc>(docKey);
     const d2 = new yorkie.Document<TestDoc>(docKey);
 

--- a/test/integration/gc_test.ts
+++ b/test/integration/gc_test.ts
@@ -2,7 +2,10 @@ import { assert } from 'chai';
 import { MaxTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';
 import yorkie from '@yorkie-js-sdk/src/yorkie';
-import { testRPCAddr } from '@yorkie-js-sdk/test/integration/integration_helper';
+import {
+  testRPCAddr,
+  toDocKey,
+} from '@yorkie-js-sdk/test/integration/integration_helper';
 import { Text } from '@yorkie-js-sdk/src/yorkie';
 
 describe('Garbage Collection', function () {
@@ -172,7 +175,7 @@ describe('Garbage Collection', function () {
 
   it('Can handle garbage collection for container type', async function () {
     type TestDoc = { 1: number; 2?: Array<number>; 3: number };
-    const docKey = `${this.test!.title}-${new Date().getTime()}`;
+    const docKey = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
 
@@ -240,7 +243,7 @@ describe('Garbage Collection', function () {
 
   it('Can handle garbage collection for text type', async function () {
     type TestDoc = { text: Text; textWithAttr: Text };
-    const docKey = `${this.test!.title}-${new Date().getTime()}`;
+    const docKey = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
 
@@ -317,7 +320,7 @@ describe('Garbage Collection', function () {
       4: Text;
       5: Text;
     };
-    const docKey = `${this.test!.title}-${new Date().getTime()}`;
+    const docKey = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
 

--- a/test/integration/integration_helper.ts
+++ b/test/integration/integration_helper.ts
@@ -6,6 +6,13 @@ const __karma__ = (global as any).__karma__;
 export const testRPCAddr =
   __karma__?.config?.testRPCAddr || 'http://localhost:8080';
 
+export function toDocKey(title: string): string {
+  return title
+    .replace(/[^a-z0-9-]/g, '-')
+    .toLowerCase()
+    .substring(0, 120);
+}
+
 export async function withTwoClientsAndDocuments<T>(
   callback: (
     c1: Client,
@@ -20,7 +27,7 @@ export async function withTwoClientsAndDocuments<T>(
   await client1.activate();
   await client2.activate();
 
-  const docKey = `${title}-${new Date().getTime()}`;
+  const docKey = `${toDocKey(title)}-${new Date().getTime()}`;
   const doc1 = new yorkie.Document<T>(docKey);
   const doc2 = new yorkie.Document<T>(docKey);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Add toDocKey to convert to a valid key in tests.

As the key validation logic was added to the server, the test failed, so `toDocKey` is added to change them to valid keys in tests.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to https://github.com/yorkie-team/yorkie/pull/467

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
