### PR TITLE
Modify config to run the webpack-bundle-analyzer when using `profile:bundle` script

### DIFF
--- a/config/webpack.dev.config.js
+++ b/config/webpack.dev.config.js
@@ -19,62 +19,67 @@ const webpack = require('webpack');
 const NodePolyfillPlugin = require('node-polyfill-webpack-plugin');
 const WebpackBundleAnalyzer = require('webpack-bundle-analyzer');
 
-module.exports = {
-  entry: './src/yorkie',
-  devtool: 'inline-source-map',
-  mode: 'development',
-  module: {
-    rules: [
-      {
-        test: /\.ts$/,
-        use: {
-          loader: 'ts-loader',
-          options: {
-            configFile: path.resolve(__dirname, '../tsconfig.json'),
+module.exports = (env, arg) => {
+  const config = {
+    entry: './src/yorkie',
+    devtool: 'inline-source-map',
+    mode: 'development',
+    module: {
+      rules: [
+        {
+          test: /\.ts$/,
+          use: {
+            loader: 'ts-loader',
+            options: {
+              configFile: path.resolve(__dirname, '../tsconfig.json'),
+            },
+          },
+          exclude: /node_modules/,
+        },
+        {
+          test: /\.ts$/,
+          exclude: [path.resolve(__dirname, 'test')],
+          enforce: 'post',
+          use: {
+            loader: 'istanbul-instrumenter-loader',
+            options: { esModules: true },
           },
         },
-        exclude: /node_modules/,
+      ],
+    },
+    resolve: {
+      alias: {
+        '@yorkie-js-sdk/src': path.resolve(__dirname, '../src/'),
+        '@yorkie-js-sdk/test': path.resolve(__dirname, '../test/'),
       },
-      {
-        test: /\.ts$/,
-        exclude: [path.resolve(__dirname, 'test')],
-        enforce: 'post',
-        use: {
-          loader: 'istanbul-instrumenter-loader',
-          options: { esModules: true },
+      extensions: ['.ts', '.js'],
+    },
+    output: {
+      library: 'yorkie',
+      libraryTarget: 'umd',
+      libraryExport: 'default',
+      filename: 'yorkie.js',
+      path: path.resolve(__dirname, '../public/dist'),
+    },
+    devServer: {
+      static: path.join(__dirname, '../public'),
+      compress: true,
+      hot: true,
+      host: '0.0.0.0',
+      port: 9000,
+      proxy: {
+        '/api': {
+          target: 'http://localhost:8080',
+          pathRewrite: { '^/api': '' },
         },
       },
-    ],
-  },
-  resolve: {
-    alias: {
-      '@yorkie-js-sdk/src': path.resolve(__dirname, '../src/'),
-      '@yorkie-js-sdk/test': path.resolve(__dirname, '../test/'),
     },
-    extensions: ['.ts', '.js'],
-  },
-  output: {
-    library: 'yorkie',
-    libraryTarget: 'umd',
-    libraryExport: 'default',
-    filename: 'yorkie.js',
-    path: path.resolve(__dirname, '../public/dist'),
-  },
-  devServer: {
-    static: path.join(__dirname, '../public'),
-    compress: true,
-    hot: true,
-    host: '0.0.0.0',
-    port: 9000,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:8080',
-        pathRewrite: { '^/api': '' },
-      },
-    },
-  },
-  plugins: [
-    new WebpackBundleAnalyzer.BundleAnalyzerPlugin(),
-    new NodePolyfillPlugin(),
-  ],
+    plugins: [new NodePolyfillPlugin()],
+  };
+
+  if (arg.profile) {
+    config.plugins.push(new WebpackBundleAnalyzer.BundleAnalyzerPlugin());
+  }
+
+  return config;
 };

--- a/config/webpack.karma.config.js
+++ b/config/webpack.karma.config.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-const config = require('./webpack.dev.config');
+const config = require('./webpack.dev.config')({}, {});
 
 // Do not include entry - karma-webpack does not support it
 delete config.entry;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Modify the webpack config to run the `webpack-bundle-analyzer` plugin 
when using `profile:bundle` script.

It's inconvenient that the `webpack-bundle-analyzer` plugin runs every time 
we execute `npm run dev` or `npm run test`.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
