### PR TITLE
Fix ValueChange dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and Yorkie JS SDK adheres to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+## [0.3.1] - 2023-02-27
+
+### Added
+* Add `delete` and `empty` method to `Text` data type by @cozitive in https://github.com/yorkie-team/yorkie-js-sdk/pull/454
+
+### Changed
+* Reduce bundle size for production by @easylogic in https://github.com/yorkie-team/yorkie-js-sdk/pull/460
+* Remove string dependency of RGATreeSplit value by @cozitive in https://github.com/yorkie-team/yorkie-js-sdk/pull/459
+* Remove priority queue from RHTPQMap and entire project by @blurfx in https://github.com/yorkie-team/yorkie-js-sdk/pull/462
+* Modify config to run the webpack-bundle-analyzer when using `profile:bundle` script by @chacha912 in https://github.com/yorkie-team/yorkie-js-sdk/pull/468
+
+### Fixed
+* Fix invalid indexOf SplayTree with single node by @chacha912 in https://github.com/yorkie-team/yorkie-js-sdk/pull/463
+
 ## [0.3.0] - 2023-01-31
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yorkie-js-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "yorkie-js-sdk",
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "Apache-2.0",
       "workspaces": [
         "examples/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yorkie-js-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Yorkie JS SDK",
   "main": "./dist/yorkie-js-sdk.js",
   "typings": "./dist/yorkie-js-sdk.d.ts",

--- a/package.publish.json
+++ b/package.publish.json
@@ -1,6 +1,6 @@
 {
   "name": "yorkie-js-sdk",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Yorkie JS SDK",
   "main": "./dist/yorkie-js-sdk.js",
   "typings": "./dist/yorkie-js-sdk.d.ts",

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -58,6 +58,13 @@ export {
   TextChange,
   TextChangeType,
 } from '@yorkie-js-sdk/src/document/crdt/text';
+
+// TODO(hackerwins): ValueChange is missing in TextChange in the index.d.ts file
+// if not exported. We need to find a way to handle this without exporting the below.
+export {
+  ValueChange,
+} from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';
+
 export {
   Primitive,
   PrimitiveValue,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fix missing ValueChange dependency in TextChange.

`ValueChange` was missing in `TextChange` in the `index.d.ts` file.
If we don't explicitly export `ValueChange`, TS compiler will omit dependency between two interfaces.

Currently we are explicitly exporting `ValueChange` like below:
`export { ValueChange } from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';`
This is temporary solution, so we need to find a way to handle this without exporting the below.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
