### PR TITLE
Apply the updated specification for peers-changed event

### DIFF
--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -103,7 +103,7 @@ export enum DocumentSyncResultType {
  * @public
  */
 export type PeersChangedValue<P> = {
-  type: 'initialization' | 'watched' | 'unwatched' | 'presence-changed';
+  type: 'initialized' | 'watched' | 'unwatched' | 'presence-changed';
   peers: Record<DocumentKey, Array<{ clientID: ActorID; presence: P }>>;
 };
 
@@ -819,7 +819,7 @@ export class Client<P = Indexable> implements Observable<ClientEvent<P>> {
       this.eventStreamObserver.next({
         type: ClientEventType.PeersChanged,
         value: {
-          type: 'initialization',
+          type: 'initialized',
           peers,
         },
       });

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -60,7 +60,7 @@ export async function waitStubCallCount(
 ) {
   return new Promise<void>((resolve) => {
     const doLoop = () => {
-      if (stub.callCount === callCount) {
+      if (stub.callCount >= callCount) {
         resolve();
       }
       return false;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

After issue #464, we have additional specification changes for the peers-changed event as follows.
- Rename `initialization` to `initialized`.
- ~Change the value of the peers-changed event to the `DocPeersRecord` type.~
- ~Add the `getPeersListByDocKey` method that returns the peers array of the document.~

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address https://github.com/yorkie-team/yorkie-js-sdk/pull/464

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
