### PR TITLE
Fix when searching for presence of non-existent peer

### DIFF
--- a/src/client/attachment.ts
+++ b/src/client/attachment.ts
@@ -121,8 +121,8 @@ export class Attachment<P> {
   /**
    * `getPresence` returns the presence information of the client.
    */
-  public getPresence(clientID: ActorID): P {
-    return this.peerPresenceMap.get(clientID)!.data;
+  public getPresence(clientID: ActorID): P | undefined {
+    return this.peerPresenceMap.get(clientID)?.data;
   }
 
   /**

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -616,6 +616,10 @@ export class Client<P = Indexable> implements Observable<ClientEvent<P>> {
       return doc;
     }
 
+    this.eventStreamObserver.next({
+      type: ClientEventType.StreamConnectionStatusChanged,
+      value: StreamConnectionStatus.Disconnected,
+    });
     logger.debug(`[WD] c:"${this.getKey()}" unwatches`);
     return doc;
   }
@@ -755,7 +759,7 @@ export class Client<P = Indexable> implements Observable<ClientEvent<P>> {
               [docKey]: [
                 {
                   clientID: this.id!,
-                  presence: this.getPeerPresence(docKey, this.id!),
+                  presence: this.getPeerPresence(docKey, this.id!)!,
                 },
               ],
             },
@@ -830,7 +834,10 @@ export class Client<P = Indexable> implements Observable<ClientEvent<P>> {
   /**
    * `getPeerPresence` returns the presence of the given document and client.
    */
-  public getPeerPresence(docKey: DocumentKey, clientID: ActorID): P {
+  public getPeerPresence(
+    docKey: DocumentKey,
+    clientID: ActorID,
+  ): P | undefined {
     return this.attachmentMap.get(docKey)!.getPresence(clientID);
   }
 
@@ -987,7 +994,7 @@ export class Client<P = Indexable> implements Observable<ClientEvent<P>> {
               [docKey]: [
                 {
                   clientID: publisher,
-                  presence: attachment.getPresence(publisher),
+                  presence: attachment.getPresence(publisher)!,
                 },
               ],
             },
@@ -996,6 +1003,7 @@ export class Client<P = Indexable> implements Observable<ClientEvent<P>> {
         break;
       case DocEventType.DOC_EVENT_TYPE_DOCUMENTS_UNWATCHED: {
         const presence = attachment.getPresence(publisher);
+        if (!presence) break;
         attachment.removePresence(publisher);
         this.eventStreamObserver.next({
           type: ClientEventType.PeersChanged,
@@ -1023,7 +1031,7 @@ export class Client<P = Indexable> implements Observable<ClientEvent<P>> {
               [docKey]: [
                 {
                   clientID: publisher,
-                  presence: attachment.getPresence(publisher),
+                  presence: attachment.getPresence(publisher)!,
                 },
               ],
             },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Since the peer's watched/unwatched events may be missed, 
it is possible to access the presence of a non-existent peer. 
To address this, it has been modified to return undefined 
when accessing the presence of a non-existent peer.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
