### PR TITLE
Add util function for Counter and replace Math.floor method with it

### DIFF
--- a/src/document/crdt/counter.ts
+++ b/src/document/crdt/counter.ts
@@ -22,7 +22,7 @@ import {
   Primitive,
   PrimitiveType,
 } from '@yorkie-js-sdk/src/document/crdt/primitive';
-import { removeDecimalPoint } from '@yorkie-js-sdk/src/util/counter';
+import { removeDecimal } from '@yorkie-js-sdk/src/util/number';
 
 /**
  * @internal
@@ -57,7 +57,7 @@ export class CRDTCounter extends CRDTElement {
           if (value > Math.pow(2, 31) - 1 || value < -Math.pow(2, 31)) {
             this.value = Long.fromNumber(value).toInt();
           } else {
-            this.value = removeDecimalPoint(value);
+            this.value = removeDecimal(value);
           }
         } else {
           this.value = value.toInt();
@@ -250,7 +250,7 @@ export class CRDTCounter extends CRDTElement {
         this.value = (this.value as number) + (v.getValue() as Long).toInt();
       } else {
         this.value = Long.fromNumber(
-          (this.value as number) + removeDecimalPoint(v.getValue() as number),
+          (this.value as number) + removeDecimal(v.getValue() as number),
         ).toInt();
       }
     }

--- a/src/document/crdt/counter.ts
+++ b/src/document/crdt/counter.ts
@@ -22,7 +22,7 @@ import {
   Primitive,
   PrimitiveType,
 } from '@yorkie-js-sdk/src/document/crdt/primitive';
-import { truncateNumber } from '@yorkie-js-sdk/src/util/counter';
+import { removeDecimalPoint } from '@yorkie-js-sdk/src/util/counter';
 
 /**
  * @internal
@@ -57,7 +57,7 @@ export class CRDTCounter extends CRDTElement {
           if (value > Math.pow(2, 31) - 1 || value < -Math.pow(2, 31)) {
             this.value = Long.fromNumber(value).toInt();
           } else {
-            this.value = truncateNumber(value);
+            this.value = removeDecimalPoint(value);
           }
         } else {
           this.value = value.toInt();
@@ -250,7 +250,7 @@ export class CRDTCounter extends CRDTElement {
         this.value = (this.value as number) + (v.getValue() as Long).toInt();
       } else {
         this.value = Long.fromNumber(
-          (this.value as number) + truncateNumber(v.getValue() as number),
+          (this.value as number) + removeDecimalPoint(v.getValue() as number),
         ).toInt();
       }
     }

--- a/src/document/crdt/counter.ts
+++ b/src/document/crdt/counter.ts
@@ -22,6 +22,7 @@ import {
   Primitive,
   PrimitiveType,
 } from '@yorkie-js-sdk/src/document/crdt/primitive';
+import { truncateNumber } from '@yorkie-js-sdk/src/util/counter';
 
 /**
  * @internal
@@ -56,7 +57,7 @@ export class CRDTCounter extends CRDTElement {
           if (value > Math.pow(2, 31) - 1 || value < -Math.pow(2, 31)) {
             this.value = Long.fromNumber(value).toInt();
           } else {
-            this.value = Math.floor(value);
+            this.value = truncateNumber(value);
           }
         } else {
           this.value = value.toInt();
@@ -249,7 +250,7 @@ export class CRDTCounter extends CRDTElement {
         this.value = (this.value as number) + (v.getValue() as Long).toInt();
       } else {
         this.value = Long.fromNumber(
-          (this.value as number) + Math.floor(v.getValue() as number),
+          (this.value as number) + truncateNumber(v.getValue() as number),
         ).toInt();
       }
     }

--- a/src/util/counter.ts
+++ b/src/util/counter.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2022 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ 'truncateNumber' returns number with decimal removed
+ */
+export const truncateNumber = (number: number) =>
+  number < 0 ? Math.ceil(number) : Math.floor(number);

--- a/src/util/counter.ts
+++ b/src/util/counter.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- 'truncateNumber' returns number with decimal removed
+ 'removeDecimalPoint' returns number with decimal removed
  */
-export const truncateNumber = (number: number) =>
+export const removeDecimalPoint = (number: number) =>
   number < 0 ? Math.ceil(number) : Math.floor(number);

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022 The Yorkie Authors. All rights reserved.
+ * Copyright 2023 The Yorkie Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  */
 
 /**
- 'removeDecimalPoint' returns number with decimal removed
+ 'removeDecimal' returns number with decimal removed
  */
-export const removeDecimalPoint = (number: number) =>
+export const removeDecimal = (number: number) =>
   number < 0 ? Math.ceil(number) : Math.floor(number);

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- `removeDecimal` returns a number with the decimal point removed.
+ `removeDecimal` returns a number with the decimal part removed.
  */
 export const removeDecimal = (number: number) =>
   number < 0 ? Math.ceil(number) : Math.floor(number);

--- a/src/util/number.ts
+++ b/src/util/number.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- 'removeDecimal' returns number with decimal removed
+ `removeDecimal` returns a number with the decimal point removed.
  */
 export const removeDecimal = (number: number) =>
   number < 0 ? Math.ceil(number) : Math.floor(number);

--- a/test/bench/document_test.ts
+++ b/test/bench/document_test.ts
@@ -426,11 +426,7 @@ const tests = [
         root.price.increase(-100);
         root.price.increase(-20.5);
       });
-      // TODO(JOOHOJANG): We need to check which logic is correct
-      // Math.floor(n) method returns value which is smaller or equal to n when n is negative value
-      // In this case, age field should be 119, not 120
-      // but same TC in yorkie (https://github.com/yorkie-team/yorkie/blob/bbd06b2312e73b267e54970764e5d042e12d810c/test/bench/document_bench_test.go#L387) expect 120 rather than 119
-      assert.equal('{"age":119,"price":9000000000000000003}', doc.toJSON());
+      assert.equal('{"age":120,"price":9000000000000000003}', doc.toJSON());
       // TODO: We need to filter not-allowed type
       // counter.increase() method doesn't filter not-allowed type
     },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Add util function for `Counter` and replace `Math.floor` method with it.

As you can see in the removed TODO below, `increase` method of `Counter` in js-sdk works different from same method in `Go` sdk.
I found out why this difference happened, and it's because `Go` removes decimal point during type casting (float to int)
Also, `long.js`, which used in js-sdk for purpose of handling large number, removes decimal point too. 

Therefore, I replace Math.floor method with this util function so that we can get the same results as others. 

(I couldn't find out detail specification on how `increase` method works, so this PR might be wrong..)
(If this PR is accepted, I'll add some description about how it works when using decimal point as a parameter) (https://yorkie.dev/yorkie-js-sdk/api-reference/yorkie-js-sdk.counter.increase.html)

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
