### PR TITLE
Remove unnecessary checkpoint validation from applyChangePack

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -513,7 +513,7 @@ export class Client<P = Indexable> implements Observable<ClientEvent<P>> {
           }
 
           const pack = converter.fromChangePack(res.getChangePack()!);
-          doc.applyChangePack(pack, this.id!);
+          doc.applyChangePack(pack);
           if (doc.getStatus() !== DocumentStatus.Removed) {
             doc.setStatus(DocumentStatus.Attached);
             this.attachmentMap.set(
@@ -572,7 +572,7 @@ export class Client<P = Indexable> implements Observable<ClientEvent<P>> {
           }
 
           const pack = converter.fromChangePack(res.getChangePack()!);
-          doc.applyChangePack(pack, this.id!);
+          doc.applyChangePack(pack);
           if (doc.getStatus() !== DocumentStatus.Removed) {
             doc.setStatus(DocumentStatus.Detached);
           }
@@ -754,7 +754,7 @@ export class Client<P = Indexable> implements Observable<ClientEvent<P>> {
           }
 
           const pack = converter.fromChangePack(res.getChangePack()!);
-          doc.applyChangePack(pack, this.id!);
+          doc.applyChangePack(pack);
           this.detachInternal(doc.getKey());
 
           logger.info(`[RD] c:"${this.getKey()}" removes d:"${doc.getKey()}"`);
@@ -1155,7 +1155,7 @@ export class Client<P = Indexable> implements Observable<ClientEvent<P>> {
               return;
             }
 
-            doc.applyChangePack(respPack, this.id!, syncMode);
+            doc.applyChangePack(respPack);
             this.eventStreamObserver.next({
               type: ClientEventType.DocumentSynced,
               value: DocumentSyncResultType.Synced,

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -25,7 +25,6 @@ import {
   CompleteFn,
   NextFn,
 } from '@yorkie-js-sdk/src/util/observable';
-import { SyncMode } from '@yorkie-js-sdk/src/client/client';
 import { ActorID } from '@yorkie-js-sdk/src/document/time/actor_id';
 import { Change } from '@yorkie-js-sdk/src/document/change/change';
 import {
@@ -367,11 +366,7 @@ export class Document<T> {
    * @param pack - change pack
    * @internal
    */
-  public applyChangePack(
-    pack: ChangePack,
-    clientID: ActorID,
-    syncMode = SyncMode.PushPull,
-  ): void {
+  public applyChangePack(pack: ChangePack): void {
     if (pack.hasSnapshot()) {
       this.applySnapshot(
         pack.getCheckpoint().getServerSeq(),
@@ -391,13 +386,7 @@ export class Document<T> {
     }
 
     // 03. Update the checkpoint.
-    const serverSeq =
-      syncMode === SyncMode.PushOnly
-        ? this.checkpoint.getServerSeq()
-        : pack.getCheckpoint().getServerSeq();
-    this.checkpoint = this.checkpoint.forward(
-      new Checkpoint(serverSeq, pack.getCheckpoint().getClientSeq()),
-    );
+    this.checkpoint = this.checkpoint.forward(pack.getCheckpoint());
 
     // 04. Do Garbage collection.
     this.garbageCollect(pack.getMinSyncedTicket()!);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Remove unnecessary checkpoint validation from applyChangePack.
Since we trust the server's response, we can apply the checkpoint 
received from it without further verification.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
