### PR TITLE
Fix quill example page image rendering issue

### DIFF
--- a/public/quill.html
+++ b/public/quill.html
@@ -170,7 +170,7 @@
 
                       if (typeof op.insert === 'object') {
                         root.content.edit(from, to, ' ', {
-                          embed: JSON.stringify(op.insert),
+                          embed: op.insert,
                           ...op.attributes,
                         });
                       } else {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
reported by @chacha912  (https://github.com/yorkie-team/yorkie-js-sdk/issues/491)

The cause of this issue is that `JSON.stringify` method is invoked twice. 
- <img width="820" alt="image" src="https://user-images.githubusercontent.com/46807540/233472725-3ca534c1-e468-4b25-a4a1-a0e7301521b9.png">
- https://github.com/yorkie-team/yorkie-js-sdk/blob/5a0d2b45ad9dfbaa56a197e5d083e0bb97a0b6be/src/document/crdt/text.ts#L472
- <img width="858" alt="image" src="https://user-images.githubusercontent.com/46807540/233472770-71ade315-3149-4007-a468-67c9763b51f2.png">
- https://github.com/yorkie-team/yorkie-js-sdk/blob/5a0d2b45ad9dfbaa56a197e5d083e0bb97a0b6be/public/quill.html#L173

Object `{image: "data:..."}` is over-stringified (`'"{"image": "data:...."}"'`)
Therefore, I removed the previously called part because it calls `JSON.stringify` anyway.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #491 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
