### PR TITLE
implement pathToTreePos

### DIFF
--- a/src/document/crdt/index_tree.ts
+++ b/src/document/crdt/index_tree.ts
@@ -641,6 +641,31 @@ export class IndexTree<T extends IndexTreeNode<T>> {
   }
 
   /**
+   * `pathToTreePos` returns treePos from given path
+   */
+  public pathToTreePos(path: Array<number>): TreePos<T> {
+    if (!path.length) {
+      throw new Error('unacceptable path');
+    }
+
+    let node = this.root;
+
+    for (let i = 0; i < path.length - 1; i++) {
+      const pathInfo = path[i];
+
+      node = node.children[pathInfo];
+
+      if (!node) {
+        throw new Error('unacceptable path');
+      }
+    }
+
+    const preperInline = node.isInline;
+
+    return findTreePos(node, path[path.length - 1], preperInline);
+  }
+
+  /**
    * `getRoot` returns the root node of the tree.
    */
   public getRoot(): T {

--- a/test/unit/document/crdt/index_tree_test.ts
+++ b/test/unit/document/crdt/index_tree_test.ts
@@ -203,4 +203,90 @@ describe('IndexTree', function () {
     const thirdP = tree.getRoot().children[2];
     assert.deepEqual([toDiagnostic(secondP), tree.indexOf(thirdP)], ['p', 9]);
   });
+  it('Can find treePos from given path', function () {
+    //       0   1 2 3    4   5 6 7 8    9   10 11 12   13
+    // <root> <p> a b </p> <p> c d e </p> <p>  f  g  </p>  </root>
+    const tree = buildIndexTree({
+      type: 'root',
+      children: [
+        {
+          type: 'p',
+          children: [
+            { type: 'text', value: 'a' },
+            { type: 'text', value: 'b' },
+          ],
+        },
+        { type: 'p', children: [{ type: 'text', value: 'cde' }] },
+        { type: 'p', children: [{ type: 'text', value: 'fg' }] },
+      ],
+    });
+
+    let path = [0];
+    let pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['root', 0]);
+
+    path = [0, 0];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['p', 0]);
+
+    path = [0, 0, 0];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.a', 0]);
+
+    path = [0, 0, 1];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.a', 1]);
+
+    path = [0, 1, 0];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.b', 0]);
+
+    path = [0, 1, 1];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.b', 1]);
+
+    path = [1];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['p', 0]);
+
+    path = [1, 0];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['p', 0]);
+
+    path = [1, 0, 0];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.cde', 0]);
+
+    path = [1, 0, 1];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.cde', 1]);
+
+    path = [1, 0, 2];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.cde', 2]);
+
+    path = [1, 0, 3];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.cde', 3]);
+
+    path = [2];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['p', 1]);
+
+    path = [2, 0, 0];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.fg', 0]);
+
+    path = [2, 0, 1];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.fg', 1]);
+
+    path = [2, 0, 2];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.fg', 2]);
+
+    path = [3];
+    pos = tree.pathToTreePos(path);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['p', 2]);
+  });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
implements `pathToTreePos` method (find corresponding treePos from given path).

path is an array of number. Except for the last element of path, each number of path is on one-one-one response to tree node. last element of path corresponds to position
([a1, a2, a3, ..., an-1, an] where ai is an integer greater than or equal to zero)



#### Any background context you want to provide?
When I checked the code of the edit method, I didn't implement `treePosToPath` because I didn't think it would be necessary to convert from treePos to path(`onChanges` directly can use given path), but if you need it, please leave a comment!

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
