### PR TITLE
implement treePosToPath method

### DIFF
--- a/src/document/crdt/index_tree.ts
+++ b/src/document/crdt/index_tree.ts
@@ -641,6 +641,33 @@ export class IndexTree<T extends IndexTreeNode<T>> {
   }
 
   /**
+   * `treePosToPath` returns path from given treePos
+   */
+  public treePosToPath(treePos: TreePos<T>) {
+    const path = [];
+
+    if (treePos.node.isInline || !treePos.node.parent) {
+      path.push(treePos.offset);
+    }
+
+    let node = treePos.node;
+
+    while (node.parent) {
+      const pathInfo = node.parent.children.indexOf(node);
+
+      if (!~pathInfo) {
+        throw new Error('invalid treePos');
+      }
+
+      path.push(pathInfo);
+
+      node = node.parent;
+    }
+
+    return path.reverse();
+  }
+
+  /**
    * `pathToTreePos` returns treePos from given path
    */
   public pathToTreePos(path: Array<number>): TreePos<T> {

--- a/test/unit/document/crdt/index_tree_test.ts
+++ b/test/unit/document/crdt/index_tree_test.ts
@@ -273,4 +273,65 @@ describe('IndexTree', function () {
     pos = tree.pathToTreePos([3]);
     assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['p', 2]);
   });
+
+  it('Can find path from given treePos', function () {
+    //       0   1 2 3    4   5 6 7 8    9   10 11 12   13
+    // <root> <p> a b </p> <p> c d e </p> <p>  f  g  </p>  </root>
+    const tree = buildIndexTree({
+      type: 'root',
+      children: [
+        {
+          type: 'p',
+          children: [
+            { type: 'text', value: 'a' },
+            { type: 'text', value: 'b' },
+          ],
+        },
+        { type: 'p', children: [{ type: 'text', value: 'cde' }] },
+        { type: 'p', children: [{ type: 'text', value: 'fg' }] },
+      ],
+    });
+
+    let pos = tree.findTreePos(0);
+    assert.deepEqual(tree.treePosToPath(pos), [0]);
+
+    pos = tree.findTreePos(1);
+    assert.deepEqual(tree.treePosToPath(pos), [0, 0, 0]);
+
+    pos = tree.findTreePos(2);
+    assert.deepEqual(tree.treePosToPath(pos), [0, 0, 1]);
+
+    pos = tree.findTreePos(3);
+    assert.deepEqual(tree.treePosToPath(pos), [0, 1, 1]);
+
+    pos = tree.findTreePos(4);
+    assert.deepEqual(tree.treePosToPath(pos), [1]);
+
+    pos = tree.findTreePos(5);
+    assert.deepEqual(tree.treePosToPath(pos), [1, 0, 0]);
+
+    pos = tree.findTreePos(6);
+    assert.deepEqual(tree.treePosToPath(pos), [1, 0, 1]);
+
+    pos = tree.findTreePos(7);
+    assert.deepEqual(tree.treePosToPath(pos), [1, 0, 2]);
+
+    pos = tree.findTreePos(8);
+    assert.deepEqual(tree.treePosToPath(pos), [1, 0, 3]);
+
+    pos = tree.findTreePos(9);
+    assert.deepEqual(tree.treePosToPath(pos), [2]);
+
+    pos = tree.findTreePos(10);
+    assert.deepEqual(tree.treePosToPath(pos), [2, 0, 0]);
+
+    pos = tree.findTreePos(11);
+    assert.deepEqual(tree.treePosToPath(pos), [2, 0, 1]);
+
+    pos = tree.findTreePos(12);
+    assert.deepEqual(tree.treePosToPath(pos), [2, 0, 2]);
+
+    pos = tree.findTreePos(13);
+    assert.deepEqual(tree.treePosToPath(pos), [3]);
+  });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
implements `treePosToPath` method (find corresponding path from given treePos).

1. if treePos is `inline` or there's no parent node for `treePos.node` (which meanstreePos pointing root), push offset to `path`
2. from `treePos.node` follow linked list back to its parent node and push index of node into path
3. return reversed path 

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
