### PR TITLE
implement editByPath, onChangesByPath

### DIFF
--- a/src/document/crdt/index_tree.ts
+++ b/src/document/crdt/index_tree.ts
@@ -779,4 +779,13 @@ export class IndexTree<T extends IndexTreeNode<T>> {
 
     return index;
   }
+
+  /**
+   * `indexToPath` returns the path to the given node.
+   */
+  public indexToPath(index: number): Array<number> {
+    const treePos = this.findTreePos(index);
+
+    return this.treePosToPath(treePos);
+  }
 }

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -578,6 +578,18 @@ export class CRDTTree extends CRDTElement {
   }
 
   /**
+   * `pathToPos` finds the position of the given index in the tree by path.
+   */
+  public pathToPos(path: Array<number>) {
+    const treePos = this.indexTree.pathToTreePos(path);
+
+    return {
+      createdAt: treePos.node.pos.createdAt,
+      offset: treePos.node.pos.offset + treePos.offset,
+    };
+  }
+
+  /**
    * `getRoot` returns the root node of the tree.
    */
   public getRoot(): CRDTTreeNode {
@@ -680,5 +692,12 @@ export class CRDTTree extends CRDTElement {
       node,
       offset: pos.offset - node.pos.offset,
     };
+  }
+
+  /**
+   * `indexToPath` converts the given tree index to path.
+   */
+  public indexToPath(index: number): Array<number> {
+    return this.indexTree.indexToPath(index);
   }
 }

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -246,6 +246,34 @@ export class Tree {
   }
 
   /**
+   * `onChangesByPath` registers a handler of onChanges event.
+   */
+  onChangesByPath(
+    handler: (
+      changes: Array<
+        Omit<TreeChange, 'from' | 'to'> & {
+          from: Array<number>;
+          to: Array<number>;
+        }
+      >,
+    ) => void,
+  ): void {
+    if (!this.context || !this.tree) {
+      throw new Error('it is not initialized yet');
+    }
+
+    this.tree.onChanges((changes) => {
+      const changesWithPath = changes.map(({ from, to, ...rest }) => ({
+        ...rest,
+        from: this.tree?.indexToPath(from) as Array<number>,
+        to: this.tree?.indexToPath(to) as Array<number>,
+      }));
+
+      handler(changesWithPath);
+    });
+  }
+
+  /**
    * eslint-disable-next-line jsdoc/require-jsdoc
    * @internal
    */

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -144,7 +144,7 @@ export class Tree {
     if (fromPath.length !== toPath.length) {
       throw new Error('path length should be equal');
     }
-    if (!fromPath.length || !toPath) {
+    if (!fromPath.length || !toPath.length) {
       throw new Error('path should not be empty');
     }
 

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -131,6 +131,50 @@ export class Tree {
   }
 
   /**
+   * `editByPath` edits this tree with the given node and path.
+   */
+  public editByPath(
+    fromPath: Array<number>,
+    toPath: Array<number>,
+    content?: TreeNode,
+  ): boolean {
+    if (!this.context || !this.tree) {
+      throw new Error('it is not initialized yet');
+    }
+    if (fromPath.length !== toPath.length) {
+      throw new Error('path length should be equal');
+    }
+    if (!fromPath.length || !toPath) {
+      throw new Error('path should not be empty');
+    }
+
+    const ticket = this.context.issueTimeTicket();
+    let crdtNode: CRDTTreeNode | undefined;
+    if (content?.type === 'text') {
+      const inlineNode = content as InlineNode;
+      crdtNode = CRDTTreeNode.create(ticket, inlineNode.type, inlineNode.value);
+    } else if (content) {
+      crdtNode = CRDTTreeNode.create(ticket, content.type);
+    }
+
+    const fromPos = this.tree.pathToPos(fromPath);
+    const toPos = this.tree.pathToPos(toPath);
+    this.tree.edit([fromPos, toPos], crdtNode?.deepcopy(), ticket);
+
+    this.context.push(
+      TreeEditOperation.create(
+        this.tree.getCreatedAt(),
+        fromPos,
+        toPos,
+        crdtNode,
+        ticket,
+      ),
+    );
+
+    return true;
+  }
+
+  /**
    * `edit` edits this tree with the given node.
    */
   public edit(fromIdx: number, toIdx: number, content?: TreeNode): boolean {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
implement editByPath, onChangesByPath

#### Any background context you want to provide?
At first, I tried to modify `CRDTTree.edit` method. (returns CRDTTreePos for `from` and `to` rather than number type index)
<img width="376" alt="image" src="https://github.com/yorkie-team/yorkie-js-sdk/assets/46807540/0d2758ec-7c3e-4fa5-bad2-4084cf9fb698">
I stopped because I thought the scope of the modification would be too large. (have to modify operation part, type definition and so on)
But, please let me know if you need this kind of modification
#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
