### PR TITLE
support Observable.nextSync() for synchronously processing

### DIFF
--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -618,7 +618,10 @@ export class Document<T> {
     }
 
     if (changes.length && this.eventStreamObserver) {
-      this.eventStreamObserver.next({
+      // RemoteChange event should be sent synchronously.
+      // Because the next change should be applied after this event.
+      // application of the next change is blocked until this event is processed.
+      this.eventStreamObserver.nextSync({
         type: DocEventType.RemoteChange,
         value: changeInfos,
       });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

After RemoteChange occurs, the Subscribe event can be executed synchronously so that the application can process data synchronously and finally.

*  support Observable.nextSync() 


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #502

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
