### PR TITLE
Replace Text.onChanges with Document.subscribe

### DIFF
--- a/examples/react-todomvc/src/App.tsx
+++ b/examples/react-todomvc/src/App.tsx
@@ -7,25 +7,36 @@ import MainSection from './MainSection';
 import { Todo } from './model';
 import './App.css';
 
-const initialState = [{
-  id: 0,
-  text: 'Yorkie JS SDK',
-  completed: false,
-}, {
-  id: 1,
-  text: 'Garbage collection',
-  completed: false,
-}, {
-  id: 2,
-  text: 'RichText datatype',
-  completed: false,
-}] as Array<Todo>;
+const initialState = [
+  {
+    id: 0,
+    text: 'Yorkie JS SDK',
+    completed: false,
+  },
+  {
+    id: 1,
+    text: 'Garbage collection',
+    completed: false,
+  },
+  {
+    id: 2,
+    text: 'RichText datatype',
+    completed: false,
+  },
+] as Array<Todo>;
 
+/**
+ * `App` is the root component of the application.
+ */
 export default function App() {
-  const [doc,] = useState<Document<{ todos: JSONArray<Todo> }>>(() =>
-    new yorkie.Document<{ todos: JSONArray<Todo> }>(
-      `react-todomvc-${(new Date()).toISOString().substring(0, 10).replace(/-/g, '')}`
-    )
+  const [doc] = useState<Document<{ todos: JSONArray<Todo> }>>(
+    () =>
+      new yorkie.Document<{ todos: JSONArray<Todo> }>(
+        `react-todomvc-${new Date()
+          .toISOString()
+          .substring(0, 10)
+          .replace(/-/g, '')}`,
+      ),
   );
   const [todos, setTodos] = useState<Array<Todo>>([]);
 
@@ -33,7 +44,9 @@ export default function App() {
     addTodo: (text: string) => {
       doc?.update((root) => {
         root.todos.push({
-          id: root.todos.reduce((maxId, todo) => Math.max(todo.id, maxId), -1) + 1,
+          id:
+            root.todos.reduce((maxId, todo) => Math.max(todo.id, maxId), -1) +
+            1,
           completed: false,
           text,
         });
@@ -90,7 +103,7 @@ export default function App() {
           }
         }
       }, '');
-    }
+    },
   };
 
   useEffect(() => {
@@ -98,7 +111,13 @@ export default function App() {
       apiKey: import.meta.env.VITE_YORKIE_API_KEY,
     });
 
-    async function attachDoc(doc: Document<{ todos: JSONArray<Todo> }>, callback: (todos: any) => void) {
+    /**
+     * `attachDoc` is a helper function to attach the document into the client.
+     */
+    async function attachDoc(
+      doc: Document<{ todos: JSONArray<Todo> }>,
+      callback: (todos: any) => void,
+    ) {
       // 01. create client with RPCAddr(envoy) then activate it.
       await client.activate();
 

--- a/examples/vanilla-codemirror6/src/main.ts
+++ b/examples/vanilla-codemirror6/src/main.ts
@@ -1,8 +1,5 @@
 /* eslint-disable jsdoc/require-jsdoc */
-import yorkie, {
-  type Text as YorkieText,
-  type EditOpInfo,
-} from 'yorkie-js-sdk';
+import yorkie, { type Text as YorkieText, OperationInfo } from 'yorkie-js-sdk';
 import { basicSetup, EditorView } from 'codemirror';
 import { keymap } from '@codemirror/view';
 import {
@@ -119,17 +116,23 @@ async function main() {
   });
 
   // 03-3. define event handler that apply remote changes to local
-  const changeEventHandler = (ops: Array<EditOpInfo>) => {
-    const changeSpecs: Array<ChangeSpec> = ops
-      .filter((op) => op.type === 'edit')
-      .map((op) => ({
-        from: Math.max(0, op.from),
-        to: Math.max(0, op.to),
-        insert: op.value!.content,
-      }));
+  const changeEventHandler = (ops: Array<OperationInfo>) => {
+    const changeSpecs: Array<ChangeSpec | undefined> = ops
+      .map((op) => {
+        if (op.type === 'edit') {
+          return {
+            from: Math.max(0, op.from),
+            to: Math.max(0, op.to),
+            insert: op.value!.content,
+          };
+        }
+
+        return undefined;
+      })
+      .filter(Boolean);
 
     view.dispatch({
-      changes: changeSpecs,
+      changes: changeSpecs as Array<ChangeSpec>,
       annotations: [Transaction.remote.of(true)],
     });
   };

--- a/examples/vanilla-quill/src/main.ts
+++ b/examples/vanilla-quill/src/main.ts
@@ -96,7 +96,7 @@ async function main() {
       const changes = event.value;
       for (const change of changes) {
         const { actor, operations } = change;
-        changeEventHandler(operations, actor);
+        handleOperations(operations, actor);
       }
     }
   });
@@ -195,7 +195,7 @@ async function main() {
     });
 
   // 04-2. document to Quill(remote).
-  function changeEventHandler(
+  function handleOperations(
     ops: Array<OperationInfo>,
     actor: string | undefined,
   ) {

--- a/public/editor.html
+++ b/public/editor.html
@@ -164,17 +164,46 @@
             });
           });
 
+          function changeEventHandler(ops) {
+            const selectionStr = rangy.serializeSelection(
+              rangy.getSelection(),
+              true,
+            );
+
+            const deltaOperations = [];
+            let prevTo = 0;
+            for (const op of ops) {
+              if (op.type === 'edit') {
+                const content = op.value.content || '';
+                renderText();
+                // Restore local cursor
+                // TODO: When text input occurs from a remote peer before the location
+                // of the local cursor, index adjustment is necessary.
+                try {
+                  rangy.deserializeSelection(selectionStr);
+                } catch (err) {
+                  console.warn(err);
+                }
+              }
+            }
+          }
+
           // 02-2. subscribe document event.
-          doc.subscribe((event) => {
-            if (event.type === 'local-change') {
-              for (const changeInfo of event.value) {
-                const { message } = changeInfo;
+          doc.subscribe('$.text', (event) => {
+            const changes = event.value;
+            if (event.type === 'remote-change') {
+              for (const change of changes) {
+                const { operations } = change;
+                changeEventHandler(operations);
+              }
+            } else if (event.type === 'local-change') {
+              for (const change of changes) {
+                const { message } = change;
                 if (message === 'simulate') {
                   renderText();
                 }
               }
             }
-            displayLog(doc);
           });
 
           function renderText() {
@@ -182,30 +211,6 @@
           }
           function syncText() {
             renderText();
-            doc.getRoot().text.onChanges((changes) => {
-              for (const change of changes) {
-                const selectionStr = rangy.serializeSelection(
-                  rangy.getSelection(),
-                  true,
-                );
-                const { type, actor, from, to, value } = change;
-
-                if (type === 'content') {
-                  const content = value.content || '';
-                  if (actor !== client.getID()) {
-                    renderText();
-                    // Restore local cursor
-                    // TODO: When text input occurs from a remote peer before the location
-                    // of the local cursor, index adjustment is necessary.
-                    try {
-                      rangy.deserializeSelection(selectionStr);
-                    } catch (err) {
-                      console.warn(err);
-                    }
-                  }
-                }
-              }
-            });
           }
           syncText();
           displayLog(doc);

--- a/public/editor.html
+++ b/public/editor.html
@@ -164,7 +164,7 @@
             });
           });
 
-          function changeEventHandler(ops) {
+          function handleOperations(ops) {
             const selectionStr = rangy.serializeSelection(
               rangy.getSelection(),
               true,
@@ -194,7 +194,7 @@
             if (event.type === 'remote-change') {
               for (const change of changes) {
                 const { operations } = change;
-                changeEventHandler(operations);
+                handleOperations(operations);
               }
             } else if (event.type === 'local-change') {
               for (const change of changes) {

--- a/public/index.html
+++ b/public/index.html
@@ -44,7 +44,7 @@
             doc.getRoot().content.toString().length ||
           (textLength != doc.getRoot().content.length && textLength != 0)
         ) {
-          debugger;
+          // debugger;
         }
         textLogHolder.innerText = doc.getRoot().content.getStructureAsString();
       }
@@ -173,7 +173,7 @@
               const changes = event.value;
               for (const change of changes) {
                 const { actor, operations } = change;
-                changeEventHandler(operations, actor);
+                handleOperations(operations, actor);
               }
             }
           });
@@ -219,7 +219,7 @@
           });
 
           // 04-2. document to codemirror(applying remote).
-          function changeEventHandler(ops, actor) {
+          function handleOperations(ops, actor) {
             for (const op of ops) {
               if (op.type === 'edit') {
                 const from = op.from;

--- a/public/index.html
+++ b/public/index.html
@@ -44,7 +44,7 @@
             doc.getRoot().content.toString().length ||
           (textLength != doc.getRoot().content.length && textLength != 0)
         ) {
-          // debugger;
+          debugger;
         }
         textLogHolder.innerText = doc.getRoot().content.getStructureAsString();
       }

--- a/public/index.html
+++ b/public/index.html
@@ -86,10 +86,10 @@
         });
       }
 
-      function displayRemoteSelection(cm, change) {
+      function displayRemoteSelection(cm, change, actor) {
         let color;
-        if (selectionMap.has(change.actor)) {
-          const selection = selectionMap.get(change.actor);
+        if (selectionMap.has(actor)) {
+          const selection = selectionMap.get(actor);
           color = selection.color;
           selection.marker.clear();
         } else {
@@ -108,10 +108,10 @@
             '-1px';
           cursorElement.style.height =
             (cursorCoords.bottom - cursorCoords.top) * 0.9 + 'px';
-          cursorElement.setAttribute('data-actor-id', change.actor);
+          cursorElement.setAttribute('data-actor-id', actor);
           cursorElement.style.zIndex = 0;
 
-          selectionMap.set(change.actor, {
+          selectionMap.set(actor, {
             color: color,
             marker: cm.setBookmark(pos, {
               widget: cursorElement,
@@ -122,7 +122,7 @@
           const fromPos = cm.posFromIndex(Math.min(change.from, change.to));
           const toPos = cm.posFromIndex(Math.max(change.from, change.to));
 
-          selectionMap.set(change.actor, {
+          selectionMap.set(actor, {
             color: color,
             marker: cm.markText(fromPos, toPos, {
               css: `background: ${color}`,
@@ -167,6 +167,16 @@
             }
             displayLog(doc, codemirror);
           });
+
+          doc.subscribe('$.content', (event) => {
+            if (event.type === 'remote-change') {
+              const changes = event.value;
+              for (const change of changes) {
+                const { actor, operations } = change;
+                changeEventHandler(operations, actor);
+              }
+            }
+          });
           await client.sync();
 
           // 03. create an instance of codemirror.
@@ -209,34 +219,23 @@
           });
 
           // 04-2. document to codemirror(applying remote).
-          function changeEventHandler(changes) {
-            for (const change of changes) {
-              if (change.type === 'content') {
-                const actor = change.actor;
-                const from = change.from;
-                const to = change.to;
-                const content = change.value.content || '';
+          function changeEventHandler(ops, actor) {
+            for (const op of ops) {
+              if (op.type === 'edit') {
+                const from = op.from;
+                const to = op.to;
+                const content = op.value.content || '';
 
-                if (actor !== client.getID()) {
-                  console.log(
-                    `%c remote: ${from}-${to}: ${content}`,
-                    'color: skyblue',
-                  );
-                  const fromIdx = codemirror.posFromIndex(from);
-                  const toIdx = codemirror.posFromIndex(to);
-                  replaceRangeFix(
-                    codemirror,
-                    content,
-                    fromIdx,
-                    toIdx,
-                    'yorkie',
-                  );
-                }
-              } else if (change.type === 'selection') {
-                const actor = change.actor;
-                if (actor !== client.getID()) {
-                  displayRemoteSelection(codemirror, change);
-                }
+                console.log(
+                  `%c remote: ${from}-${to}: ${content}`,
+                  'color: skyblue',
+                );
+                const fromIdx = codemirror.posFromIndex(from);
+                const toIdx = codemirror.posFromIndex(to);
+                replaceRangeFix(codemirror, content, fromIdx, toIdx, 'yorkie');
+              } else if (op.type === 'select') {
+                console.log('%c remote selection', 'color: skyblue');
+                displayRemoteSelection(codemirror, op, actor);
               }
             }
           }
@@ -244,7 +243,6 @@
           // 05. synchronize text of document and codemirror.
           function syncText() {
             const text = doc.getRoot().content;
-            text.onChanges(changeEventHandler);
             codemirror.setValue(text.toString());
           }
           syncText();

--- a/public/multi.html
+++ b/public/multi.html
@@ -258,7 +258,7 @@
               const changes = event.value;
               for (const change of changes) {
                 const { actor, message, operations } = change;
-                changeEventHandler(operations, actor);
+                handleOperations(operations, actor);
               }
             }
           });
@@ -359,7 +359,7 @@
             });
 
           // 05-2. Document to Quill(remote).
-          function changeEventHandler(ops, actor) {
+          function handleOperations(ops, actor) {
             const deltaOperations = [];
             let prevTo = 0;
             for (const op of ops) {

--- a/public/multi.html
+++ b/public/multi.html
@@ -386,11 +386,11 @@
                   deltaOperations.push({ delete: retainTo });
                 }
                 if (insert) {
-                  const localOp = { insert };
+                  const deltaOp = { insert };
                   if (attributes) {
-                    localOp.attributes = attributes;
+                    deltaOp.attributes = attributes;
                   }
-                  deltaOperations.push(localOp);
+                  deltaOperations.push(deltaOp);
                 }
               } else if (op.type === 'style') {
                 const { attributes } = toDeltaOperation(op.value);
@@ -403,12 +403,12 @@
                   deltaOperations.push({ retain: retainFrom });
                 }
                 if (attributes) {
-                  const localOp = { attributes };
+                  const deltaOp = { attributes };
                   if (retainTo) {
-                    localOp.retain = retainTo;
+                    deltaOp.retain = retainTo;
                   }
 
-                  deltaOperations.push(localOp);
+                  deltaOperations.push(deltaOp);
                 }
               } else if (op.type === 'select') {
                 cursors.createCursor(

--- a/public/multi.html
+++ b/public/multi.html
@@ -254,7 +254,13 @@
 
           // 05. Quill example
           doc.subscribe('$.content', (event) => {
-            console.log('🔵 quill event', event);
+            if (event.type === 'remote-change') {
+              const changes = event.value;
+              for (const change of changes) {
+                const { actor, message, operations } = change;
+                changeEventHandler(operations, actor);
+              }
+            }
           });
 
           Quill.register('modules/cursors', QuillCursors);
@@ -353,26 +359,21 @@
             });
 
           // 05-2. Document to Quill(remote).
-          function changeEventHandler(changes) {
+          function changeEventHandler(ops, actor) {
             const deltaOperations = [];
             let prevTo = 0;
-            for (const change of changes) {
-              const actorID = change.actor;
-              if (actorID === client.getID()) {
-                continue;
-              }
-
+            for (const op of ops) {
               const actorName = client.getPeerPresence(
                 doc.getKey(),
-                actorID,
+                actor,
               ).username;
-              const from = change.from;
-              const to = change.to;
+              const from = op.from;
+              const to = op.to;
               const retainFrom = from - prevTo;
               const retainTo = to - from;
 
-              if (change.type === 'content') {
-                const { insert, attributes } = toDeltaOperation(change.value);
+              if (op.type === 'edit') {
+                const { insert, attributes } = toDeltaOperation(op.value);
                 console.log(
                   `%c remote: ${from}-${to}: ${insert}`,
                   'color: skyblue',
@@ -385,14 +386,14 @@
                   deltaOperations.push({ delete: retainTo });
                 }
                 if (insert) {
-                  const op = { insert };
+                  const localOp = { insert };
                   if (attributes) {
-                    op.attributes = attributes;
+                    localOp.attributes = attributes;
                   }
-                  deltaOperations.push(op);
+                  deltaOperations.push(localOp);
                 }
-              } else if (change.type === 'style') {
-                const { attributes } = toDeltaOperation(change.value);
+              } else if (op.type === 'style') {
+                const { attributes } = toDeltaOperation(op.value);
                 console.log(
                   `%c remote: ${from}-${to}: ${JSON.stringify(attributes)}`,
                   'color: skyblue',
@@ -402,14 +403,14 @@
                   deltaOperations.push({ retain: retainFrom });
                 }
                 if (attributes) {
-                  const op = { attributes };
+                  const localOp = { attributes };
                   if (retainTo) {
-                    op.retain = retainTo;
+                    localOp.retain = retainTo;
                   }
 
-                  deltaOperations.push(op);
+                  deltaOperations.push(localOp);
                 }
-              } else if (change.type === 'selection') {
+              } else if (op.type === 'select') {
                 cursors.createCursor(
                   actorName,
                   actorName,
@@ -436,7 +437,6 @@
           // 05-3. synchronize text of document and Quill.
           function syncText() {
             const text = doc.getRoot().content;
-            text.onChanges(changeEventHandler);
 
             const delta = {
               ops: text.values().map((val) => toDeltaOperation(val)),

--- a/public/quill.html
+++ b/public/quill.html
@@ -109,7 +109,7 @@
               const changes = event.value;
               for (const change of changes) {
                 const { actor, message, operations } = change;
-                changeEventHandler(operations, actor);
+                handleOperations(operations, actor);
               }
             }
           });
@@ -214,7 +214,7 @@
             });
 
           // 04-2. document to Quill(remote).
-          function changeEventHandler(ops, actor) {
+          function handleOperations(ops, actor) {
             const deltaOperations = [];
             let prevTo = 0;
             for (const op of ops) {

--- a/public/quill.html
+++ b/public/quill.html
@@ -103,6 +103,17 @@
             }
             displayLog(documentElem, documentTextElem, doc);
           });
+
+          doc.subscribe('$.content', (event) => {
+            if (event.type === 'remote-change') {
+              const changes = event.value;
+              for (const change of changes) {
+                const { actor, message, operations } = change;
+                changeEventHandler(operations, actor);
+              }
+            }
+          });
+
           await client.sync();
 
           // 03. create an instance of Quill
@@ -203,26 +214,21 @@
             });
 
           // 04-2. document to Quill(remote).
-          function changeEventHandler(changes) {
+          function changeEventHandler(ops, actor) {
             const deltaOperations = [];
             let prevTo = 0;
-            for (const change of changes) {
-              const actorID = change.actor;
-              if (actorID === client.getID()) {
-                continue;
-              }
-
+            for (const op of ops) {
               const actorName = client.getPeerPresence(
                 doc.getKey(),
-                actorID,
+                actor,
               ).username;
-              const from = change.from;
-              const to = change.to;
+              const from = op.from;
+              const to = op.to;
               const retainFrom = from - prevTo;
               const retainTo = to - from;
 
-              if (change.type === 'content') {
-                const { insert, attributes } = toDeltaOperation(change.value);
+              if (op.type === 'edit') {
+                const { insert, attributes } = toDeltaOperation(op.value);
                 console.log(
                   `%c remote: ${from}-${to}: ${insert}`,
                   'color: skyblue',
@@ -235,14 +241,14 @@
                   deltaOperations.push({ delete: retainTo });
                 }
                 if (insert) {
-                  const op = { insert };
+                  const localOp = { insert };
                   if (attributes) {
-                    op.attributes = attributes;
+                    localOp.attributes = attributes;
                   }
-                  deltaOperations.push(op);
+                  deltaOperations.push(localOp);
                 }
-              } else if (change.type === 'style') {
-                const { attributes } = toDeltaOperation(change.value);
+              } else if (op.type === 'style') {
+                const { attributes } = toDeltaOperation(op.value);
                 console.log(
                   `%c remote: ${from}-${to}: ${JSON.stringify(attributes)}`,
                   'color: skyblue',
@@ -252,14 +258,14 @@
                   deltaOperations.push({ retain: retainFrom });
                 }
                 if (attributes) {
-                  const op = { attributes };
+                  const localOp = { attributes };
                   if (retainTo) {
-                    op.retain = retainTo;
+                    localOp.retain = retainTo;
                   }
 
-                  deltaOperations.push(op);
+                  deltaOperations.push(localOp);
                 }
-              } else if (change.type === 'selection') {
+              } else if (op.type === 'select') {
                 cursors.createCursor(
                   actorName,
                   actorName,
@@ -286,8 +292,6 @@
           // 05. synchronize text of document and Quill.
           function syncText() {
             const text = doc.getRoot().content;
-            text.onChanges(changeEventHandler);
-
             const delta = {
               ops: text.values().map((val) => toDeltaOperation(val)),
             };

--- a/public/quill.html
+++ b/public/quill.html
@@ -241,11 +241,11 @@
                   deltaOperations.push({ delete: retainTo });
                 }
                 if (insert) {
-                  const localOp = { insert };
+                  const deltaOp = { insert };
                   if (attributes) {
-                    localOp.attributes = attributes;
+                    deltaOp.attributes = attributes;
                   }
-                  deltaOperations.push(localOp);
+                  deltaOperations.push(deltaOp);
                 }
               } else if (op.type === 'style') {
                 const { attributes } = toDeltaOperation(op.value);
@@ -258,12 +258,12 @@
                   deltaOperations.push({ retain: retainFrom });
                 }
                 if (attributes) {
-                  const localOp = { attributes };
+                  const deltaOp = { attributes };
                   if (retainTo) {
-                    localOp.retain = retainTo;
+                    deltaOp.retain = retainTo;
                   }
 
-                  deltaOperations.push(localOp);
+                  deltaOperations.push(deltaOp);
                 }
               } else if (op.type === 'select') {
                 cursors.createCursor(

--- a/src/document/crdt/text.ts
+++ b/src/document/crdt/text.ts
@@ -319,13 +319,6 @@ export class CRDTText<A extends Indexable = Indexable> extends CRDTTextElement {
   }
 
   /**
-   * `onChanges` registers a handler of onChanges event.
-   */
-  public onChanges(handler: (changes: Array<TextChange<A>>) => void): void {
-    this.onChangesHandler = handler;
-  }
-
-  /**
    * `createRange` returns pair of RGATreeSplitNodePos of the given integer offsets.
    */
   public createRange(fromIdx: number, toIdx: number): RGATreeSplitNodeRange {

--- a/src/document/crdt/text.ts
+++ b/src/document/crdt/text.ts
@@ -47,8 +47,8 @@ export interface TextValueType<A> {
 }
 
 /**
- * `TextChange` is the value passed as an argument to `Text.onChanges()`.
- * `Text.onChanges()` is called when the `Text` is modified.
+ * `TextChange` is the value passed as an argument to `Document.subscribe()`.
+ * `Document.subscribe()` is called when the `Text` is modified.
  */
 export interface TextChange<A = Indexable>
   extends ValueChange<TextValueType<A>> {
@@ -161,10 +161,8 @@ export class CRDTTextValue {
  * @internal
  */
 export class CRDTText<A extends Indexable = Indexable> extends CRDTTextElement {
-  private onChangesHandler?: (changes: Array<TextChange<A>>) => void;
   private rgaTreeSplit: RGATreeSplit<CRDTTextValue>;
   private selectionMap: Map<string, Selection>;
-  private remoteChangeLock: boolean;
 
   constructor(
     rgaTreeSplit: RGATreeSplit<CRDTTextValue>,
@@ -173,7 +171,6 @@ export class CRDTText<A extends Indexable = Indexable> extends CRDTTextElement {
     super(createdAt);
     this.rgaTreeSplit = rgaTreeSplit;
     this.selectionMap = new Map();
-    this.remoteChangeLock = false;
   }
 
   /**
@@ -231,12 +228,6 @@ export class CRDTText<A extends Indexable = Indexable> extends CRDTTextElement {
       changes.push(selectionChange);
     }
 
-    if (this.onChangesHandler) {
-      this.remoteChangeLock = true;
-      this.onChangesHandler(changes);
-      this.remoteChangeLock = false;
-    }
-
     return [latestCreatedAtMap, changes];
   }
 
@@ -288,11 +279,6 @@ export class CRDTText<A extends Indexable = Indexable> extends CRDTTextElement {
       }
     }
 
-    if (this.onChangesHandler) {
-      this.remoteChangeLock = true;
-      this.onChangesHandler(changes);
-      this.remoteChangeLock = false;
-    }
     return changes;
   }
 
@@ -305,17 +291,7 @@ export class CRDTText<A extends Indexable = Indexable> extends CRDTTextElement {
     range: RGATreeSplitNodeRange,
     updatedAt: TimeTicket,
   ): TextChange<A> | undefined {
-    if (this.remoteChangeLock) {
-      return;
-    }
-
-    const change = this.selectPriv(range, updatedAt);
-    if (this.onChangesHandler && change) {
-      this.remoteChangeLock = true;
-      this.onChangesHandler([change]);
-      this.remoteChangeLock = false;
-    }
-    return change;
+    return this.selectPriv(range, updatedAt);
   }
 
   /**

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -181,30 +181,6 @@ export type Indexable = Record<string, any>;
  */
 export type DocumentKey = string;
 
-type TPropPaths<T> = {
-  [TKey in keyof T]: `$.${TKey & string}`;
-}[keyof T];
-
-// type TPropYorkieType<TObject, TPath> = TPath extends keyof TObject
-//   ? TObject[TPath] extends Text
-//     ? TextOperationInfo
-//     : TObject[TPath] extends Counter
-//     ? CounterOperationInfo
-//     : OperationInfo
-//   : unknown;
-
-// type TPropTypeAtPath<TObject, TPath> = TPath extends keyof TObject
-//   ? TPropYorkieType<TObject, TPath>
-//   : TPath extends `${infer TKey}.${infer TRest}`
-//   ? TKey extends keyof TObject
-//     ? TPropTypeAtPath<TObject[TKey], TRest>
-//     : unknown
-//   : unknown;
-
-// type TPropPathsType<T, TPath> = TPath extends `$.${infer TKeyPath}`
-//   ? TPropTypeAtPath<T, TKeyPath>
-//   : TPropTypeAtPath<T, TPath>;
-
 /**
  * `Document` is a CRDT-based data type. We can represent the model
  * of the application and edit it even while offline.
@@ -299,17 +275,6 @@ export class Document<T> {
       }
     }
   }
-
-  /**
-   * `subscribe` registers a callback to subscribe to events on the document.
-   * The callback will be called when the targetPath or any of its nested values change.
-   */
-  public subscribe<TPath extends TPropPaths<T>>(
-    targetPath: TPath,
-    next: NextFn<DocEvent>,
-    error?: ErrorFn,
-    complete?: CompleteFn,
-  ): Unsubscribe;
 
   /**
    * `subscribe` registers a callback to subscribe to events on the document.

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -46,14 +46,10 @@ import {
 } from '@yorkie-js-sdk/src/document/change/checkpoint';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import {
-  CounterOperationInfo,
   InternalOpInfo,
   OperationInfo,
-  TextOperationInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
-import { Text } from '@yorkie-js-sdk/src/document/json/text';
 import { JSONObject } from '@yorkie-js-sdk/src/document/json/object';
-import { Counter } from '@yorkie-js-sdk/src/document/json/counter';
 import { Trie } from '../util/trie';
 
 /**
@@ -189,25 +185,25 @@ type TPropPaths<T> = {
   [TKey in keyof T]: `$.${TKey & string}`;
 }[keyof T];
 
-type TPropYorkieType<TObject, TPath> = TPath extends keyof TObject
-  ? TObject[TPath] extends Text
-    ? TextOperationInfo
-    : TObject[TPath] extends Counter
-    ? CounterOperationInfo
-    : OperationInfo
-  : unknown;
+// type TPropYorkieType<TObject, TPath> = TPath extends keyof TObject
+//   ? TObject[TPath] extends Text
+//     ? TextOperationInfo
+//     : TObject[TPath] extends Counter
+//     ? CounterOperationInfo
+//     : OperationInfo
+//   : unknown;
 
-type TPropTypeAtPath<TObject, TPath> = TPath extends keyof TObject
-  ? TPropYorkieType<TObject, TPath>
-  : TPath extends `${infer TKey}.${infer TRest}`
-  ? TKey extends keyof TObject
-    ? TPropTypeAtPath<TObject[TKey], TRest>
-    : unknown
-  : unknown;
+// type TPropTypeAtPath<TObject, TPath> = TPath extends keyof TObject
+//   ? TPropYorkieType<TObject, TPath>
+//   : TPath extends `${infer TKey}.${infer TRest}`
+//   ? TKey extends keyof TObject
+//     ? TPropTypeAtPath<TObject[TKey], TRest>
+//     : unknown
+//   : unknown;
 
-type TPropPathsType<T, TPath> = TPath extends `$.${infer TKeyPath}`
-  ? TPropTypeAtPath<T, TKeyPath>
-  : TPropTypeAtPath<T, TPath>;
+// type TPropPathsType<T, TPath> = TPath extends `$.${infer TKeyPath}`
+//   ? TPropTypeAtPath<T, TKeyPath>
+//   : TPropTypeAtPath<T, TPath>;
 
 /**
  * `Document` is a CRDT-based data type. We can represent the model
@@ -310,7 +306,7 @@ export class Document<T> {
    */
   public subscribe<TPath extends TPropPaths<T>>(
     targetPath: TPath,
-    next: NextFn<DocEvent, TPropPathsType<T, TPath>>,
+    next: NextFn<DocEvent>,
     error?: ErrorFn,
     complete?: CompleteFn,
   ): Unsubscribe;

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -46,10 +46,14 @@ import {
 } from '@yorkie-js-sdk/src/document/change/checkpoint';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import {
+  CounterOperationInfo,
   InternalOpInfo,
   OperationInfo,
+  TextOperationInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
-import { JSONObject } from './json/object';
+import { Text } from '@yorkie-js-sdk/src/document/json/text';
+import { JSONObject } from '@yorkie-js-sdk/src/document/json/object';
+import { Counter } from '@yorkie-js-sdk/src/document/json/counter';
 import { Trie } from '../util/trie';
 
 /**
@@ -181,6 +185,30 @@ export type Indexable = Record<string, any>;
  */
 export type DocumentKey = string;
 
+type TPropPaths<T> = {
+  [TKey in keyof T]: `$.${TKey & string}`;
+}[keyof T];
+
+type TPropYorkieType<TObject, TPath> = TPath extends keyof TObject
+  ? TObject[TPath] extends Text
+    ? TextOperationInfo
+    : TObject[TPath] extends Counter
+    ? CounterOperationInfo
+    : OperationInfo
+  : unknown;
+
+type TPropTypeAtPath<TObject, TPath> = TPath extends keyof TObject
+  ? TPropYorkieType<TObject, TPath>
+  : TPath extends `${infer TKey}.${infer TRest}`
+  ? TKey extends keyof TObject
+    ? TPropTypeAtPath<TObject[TKey], TRest>
+    : unknown
+  : unknown;
+
+type TPropPathsType<T, TPath> = TPath extends `$.${infer TKeyPath}`
+  ? TPropTypeAtPath<T, TKeyPath>
+  : TPropTypeAtPath<T, TPath>;
+
 /**
  * `Document` is a CRDT-based data type. We can represent the model
  * of the application and edit it even while offline.
@@ -256,7 +284,7 @@ export class Document<T> {
       this.changeID = change.getID();
 
       if (this.eventStreamObserver) {
-        this.eventStreamObserver.next({
+        this.eventStreamObserver.nextSync({
           type: DocEventType.LocalChange,
           value: [
             {
@@ -275,6 +303,17 @@ export class Document<T> {
       }
     }
   }
+
+  /**
+   * `subscribe` registers a callback to subscribe to events on the document.
+   * The callback will be called when the targetPath or any of its nested values change.
+   */
+  public subscribe<TPath extends TPropPaths<T>>(
+    targetPath: TPath,
+    next: NextFn<DocEvent, TPropPathsType<T, TPath>>,
+    error?: ErrorFn,
+    complete?: CompleteFn,
+  ): Unsubscribe;
 
   /**
    * `subscribe` registers a callback to subscribe to events on the document.

--- a/src/document/json/text.ts
+++ b/src/document/json/text.ts
@@ -256,16 +256,4 @@ export class Text<A extends Indexable = Indexable> {
 
     return this.text.createRange(fromIdx, toIdx);
   }
-
-  /**
-   * `onChanges` registers a handler of onChanges event.
-   */
-  onChanges(handler: (changes: Array<TextChange<A>>) => void): void {
-    if (!this.context || !this.text) {
-      logger.fatal('it is not initialized yet');
-      return;
-    }
-
-    this.text.onChanges(handler);
-  }
 }

--- a/src/document/json/text.ts
+++ b/src/document/json/text.ts
@@ -19,11 +19,7 @@ import { Indexable } from '@yorkie-js-sdk/src/document/document';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
 import { RGATreeSplitNodeRange } from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';
-import {
-  CRDTText,
-  TextValueType,
-  TextChange,
-} from '@yorkie-js-sdk/src/document/crdt/text';
+import { CRDTText, TextValueType } from '@yorkie-js-sdk/src/document/crdt/text';
 import { EditOperation } from '@yorkie-js-sdk/src/document/operation/edit_operation';
 import { StyleOperation } from '@yorkie-js-sdk/src/document/operation/style_operation';
 import { SelectOperation } from '@yorkie-js-sdk/src/document/operation/select_operation';

--- a/src/document/operation/operation.ts
+++ b/src/document/operation/operation.ts
@@ -32,6 +32,14 @@ export type OperationInfo =
   | EditOpInfo
   | StyleOpInfo
   | SelectOpInfo;
+export type TextOperationInfo = EditOpInfo | StyleOpInfo | SelectOpInfo;
+export type JSONOperationInfo =
+  | AddOpInfo
+  | IncreaseOpInfo
+  | RemoveOpInfo
+  | SetOpInfo
+  | MoveOpInfo;
+export type CounterOperationInfo = IncreaseOpInfo;
 export type AddOpInfo = {
   type: 'add';
   path: string;

--- a/src/document/operation/operation.ts
+++ b/src/document/operation/operation.ts
@@ -32,14 +32,6 @@ export type OperationInfo =
   | EditOpInfo
   | StyleOpInfo
   | SelectOpInfo;
-export type TextOperationInfo = EditOpInfo | StyleOpInfo | SelectOpInfo;
-export type JSONOperationInfo =
-  | AddOpInfo
-  | IncreaseOpInfo
-  | RemoveOpInfo
-  | SetOpInfo
-  | MoveOpInfo;
-export type CounterOperationInfo = IncreaseOpInfo;
 export type AddOpInfo = {
   type: 'add';
   path: string;

--- a/src/util/observable.ts
+++ b/src/util/observable.ts
@@ -19,7 +19,7 @@ import { logger } from '@yorkie-js-sdk/src/util/logger';
 /**
  * @internal
  */
-export type NextFn<T> = (value: T) => void;
+export type NextFn<T, B = unknown> = (value: T) => void;
 
 /**
  * @internal
@@ -74,13 +74,12 @@ class ObserverProxy<T> implements Observer<T> {
 
   constructor(executor: Executor<T>, onNoObservers?: Executor<T>) {
     this.onNoObservers = onNoObservers;
-    this.task
-      .then(() => {
-        executor(this);
-      })
-      .catch((error) => {
-        this.error(error);
-      });
+
+    try {
+      executor(this);
+    } catch (error: any) {
+      this.error(error);
+    }
   }
 
   /**

--- a/src/util/observable.ts
+++ b/src/util/observable.ts
@@ -19,7 +19,7 @@ import { logger } from '@yorkie-js-sdk/src/util/logger';
 /**
  * @internal
  */
-export type NextFn<T, B = unknown> = (value: T) => void;
+export type NextFn<T> = (value: T) => void;
 
 /**
  * @internal

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -62,9 +62,14 @@ export {
 } from '@yorkie-js-sdk/src/document/crdt/text';
 export type {
   OperationInfo,
+  AddOpInfo,
+  IncreaseOpInfo,
+  RemoveOpInfo,
+  SetOpInfo,
+  MoveOpInfo,
   EditOpInfo,
-  SelectOpInfo,
   StyleOpInfo,
+  SelectOpInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 
 // TODO(hackerwins): ValueChange is missing in TextChange in the index.d.ts file

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -60,7 +60,12 @@ export {
   TextChange,
   TextChangeType,
 } from '@yorkie-js-sdk/src/document/crdt/text';
-export type { OperationInfo } from '@yorkie-js-sdk/src/document/operation/operation';
+export type {
+  OperationInfo,
+  EditOpInfo,
+  SelectOpInfo,
+  StyleOpInfo,
+} from '@yorkie-js-sdk/src/document/operation/operation';
 
 // TODO(hackerwins): ValueChange is missing in TextChange in the index.d.ts file
 // if not exported. We need to find a way to handle this without exporting the below.

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -102,7 +102,7 @@ export class TextView {
     this.value = '';
   }
 
-  public applyChanges(
+  public applyOperations(
     operations: Array<OperationInfo>,
     enableLog = false,
   ): void {

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -15,11 +15,7 @@
  */
 
 import { assert } from 'chai';
-
-import {
-  TextChange,
-  TextChangeType,
-} from '@yorkie-js-sdk/src/document/crdt/text';
+import { OperationInfo } from '@yorkie-js-sdk/src/document/operation/operation';
 
 export type Indexable = Record<string, any>;
 
@@ -106,18 +102,21 @@ export class TextView {
     this.value = '';
   }
 
-  public applyChanges(changes: Array<TextChange>, enableLog = false): void {
+  public applyChanges(
+    operations: Array<OperationInfo>,
+    enableLog = false,
+  ): void {
     const oldValue = this.value;
     const changeLogs = [];
-    for (const change of changes) {
-      if (change.type === TextChangeType.Content) {
+    for (const op of operations) {
+      if (op.type === 'edit') {
         this.value = [
-          this.value.substring(0, change.from),
-          change.value?.content,
-          this.value.substring(change.to),
+          this.value.substring(0, op.from),
+          op.value?.content,
+          this.value.substring(op.to),
         ].join('');
         changeLogs.push(
-          `{f:${change.from}, t:${change.to}, c:${change.value || ''}}`,
+          `{f:${op.from}, t:${op.to}, c:${op.value?.content || ''}}`,
         );
       }
     }

--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -197,22 +197,30 @@ describe('Client', function () {
 
     await waitStubCallCount(stubD2, 2); // d2 should be able to update
     assert.equal(d2Events.pop(), DocEventType.LocalChange);
-    await waitStubCallCount(stubC2, 1); // c2 should fail to sync
-    assert.equal(c2Events.pop(), DocumentSyncResultType.SyncFailed);
+    await waitStubCallCount(stubC2, 2); // c2 should fail to sync
+    assert.equal(
+      c2Events.pop(),
+      DocumentSyncResultType.SyncFailed,
+      'c2 sync fail',
+    );
 
     c1.sync();
-    await waitStubCallCount(stubC1, 1); // c1 should also fail to sync
-    assert.equal(c1Events.pop(), DocumentSyncResultType.SyncFailed);
+    await waitStubCallCount(stubC1, 4); // c1 should also fail to sync
+    assert.equal(
+      c1Events.pop(),
+      DocumentSyncResultType.SyncFailed,
+      'c1 sync fail',
+    );
     assert.equal(d1.toSortedJSON(), '{"k1":"undefined"}');
     assert.equal(d2.toSortedJSON(), '{"k1":"v1"}');
 
     // Back to normal condition
     xhr.restore();
 
-    await waitStubCallCount(stubC2, 2);
-    assert.equal(c2Events.pop(), DocumentSyncResultType.Synced);
-    await waitStubCallCount(stubC1, 2);
-    assert.equal(c1Events.pop(), DocumentSyncResultType.Synced);
+    await waitStubCallCount(stubC2, 4); // wait for c2 to sync
+    assert.equal(c2Events.pop(), DocumentSyncResultType.Synced, 'c2 sync');
+    await waitStubCallCount(stubC1, 6);
+    assert.equal(c1Events.pop(), DocumentSyncResultType.Synced, 'c1 sync');
     await waitStubCallCount(stubD1, 2);
     assert.equal(d1Events.pop(), DocEventType.RemoteChange); // d1 should be able to receive d2's update
     assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
@@ -678,7 +686,7 @@ describe('Client', function () {
       root.version = 'v2';
     });
     await c1.sync();
-    await waitStubCallCount(stubC2, 1);
+    await waitStubCallCount(stubC2, 2);
     assert.equal(c2Events.pop(), ClientEventType.DocumentSynced);
     assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
     unsub1();

--- a/test/integration/text_test.ts
+++ b/test/integration/text_test.ts
@@ -6,6 +6,8 @@ import {
   Text,
   TextChange,
   TextChangeType,
+  JSONArray,
+  JSONObject,
 } from '@yorkie-js-sdk/src/yorkie';
 
 describe('Text', function () {
@@ -94,10 +96,20 @@ describe('Text', function () {
   });
 
   it('should handle deletion of nested nodes', function () {
-    const doc = Document.create<{ text: Text }>('test-doc');
+    const doc = Document.create<{
+      text: Text;
+    }>('test-doc');
     const view = new TextView();
     doc.update((root) => (root.text = new Text()));
-    doc.getRoot().text.onChanges((changes) => view.applyChanges(changes));
+    doc.subscribe('$.text', (event) => {
+      if (event.type === 'local-change') {
+        const changes = event.value;
+        for (const change of changes) {
+          const { operations } = change;
+          view.applyChanges(operations);
+        }
+      }
+    });
 
     const commands = [
       { from: 0, to: 0, content: 'ABC' },
@@ -116,7 +128,15 @@ describe('Text', function () {
     const doc = Document.create<{ text: Text }>('test-doc');
     const view = new TextView();
     doc.update((root) => (root.text = new Text()));
-    doc.getRoot().text.onChanges((changes) => view.applyChanges(changes));
+    doc.subscribe('$.text', (event) => {
+      if (event.type === 'local-change') {
+        const changes = event.value;
+        for (const change of changes) {
+          const { operations } = change;
+          view.applyChanges(operations);
+        }
+      }
+    });
 
     const commands = [
       { from: 0, to: 0, content: 'A' },
@@ -143,7 +163,15 @@ describe('Text', function () {
     const doc = Document.create<{ text: Text }>('test-doc');
     const view = new TextView();
     doc.update((root) => (root.text = new Text()));
-    doc.getRoot().text.onChanges((changes) => view.applyChanges(changes));
+    doc.subscribe('$.text', (event) => {
+      if (event.type === 'local-change') {
+        const changes = event.value;
+        for (const change of changes) {
+          const { operations } = change;
+          view.applyChanges(operations);
+        }
+      }
+    });
 
     const commands = [
       { from: 0, to: 0, content: '1A1BCXEF1' },
@@ -173,10 +201,17 @@ describe('Text', function () {
       root.text.edit(0, 0, 'ABCD');
     });
 
-    doc.getRoot().text.onChanges((changes: Array<TextChange>): void => {
-      if (changes[0].type === TextChangeType.Selection) {
-        assert.equal(changes[0].from, 2);
-        assert.equal(changes[0].to, 4);
+    doc.subscribe('$.text', (event) => {
+      if (event.type === 'local-change') {
+        const changes = event.value;
+        for (const change of changes) {
+          const { operations } = change;
+
+          if (operations[0].type === 'select') {
+            assert.equal(operations[0].from, 2);
+            assert.equal(operations[0].to, 4);
+          }
+        }
       }
     });
     doc.update((root) => root.text.select(2, 4));
@@ -321,7 +356,15 @@ describe('Text', function () {
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
       const view1 = new TextView();
-      d1.getRoot().k1.onChanges((changes) => view1.applyChanges(changes));
+      d1.subscribe('$.k1', (event) => {
+        if (event.type === 'local-change') {
+          const changes = event.value;
+          for (const change of changes) {
+            const { operations } = change;
+            view1.applyChanges(operations);
+          }
+        }
+      });
 
       d1.update((root) => {
         root.k1.edit(1, 7, '');

--- a/test/integration/text_test.ts
+++ b/test/integration/text_test.ts
@@ -1,14 +1,7 @@
 import { assert } from 'chai';
 import { TextView } from '@yorkie-js-sdk/test/helper/helper';
 import { withTwoClientsAndDocuments } from '@yorkie-js-sdk/test/integration/integration_helper';
-import {
-  Document,
-  Text,
-  TextChange,
-  TextChangeType,
-  JSONArray,
-  JSONObject,
-} from '@yorkie-js-sdk/src/yorkie';
+import { Document, Text } from '@yorkie-js-sdk/src/yorkie';
 
 describe('Text', function () {
   it('should handle edit operations', function () {

--- a/test/integration/text_test.ts
+++ b/test/integration/text_test.ts
@@ -99,7 +99,7 @@ describe('Text', function () {
         const changes = event.value;
         for (const change of changes) {
           const { operations } = change;
-          view.applyChanges(operations);
+          view.applyOperations(operations);
         }
       }
     });
@@ -126,7 +126,7 @@ describe('Text', function () {
         const changes = event.value;
         for (const change of changes) {
           const { operations } = change;
-          view.applyChanges(operations);
+          view.applyOperations(operations);
         }
       }
     });
@@ -161,7 +161,7 @@ describe('Text', function () {
         const changes = event.value;
         for (const change of changes) {
           const { operations } = change;
-          view.applyChanges(operations);
+          view.applyOperations(operations);
         }
       }
     });
@@ -354,7 +354,7 @@ describe('Text', function () {
           const changes = event.value;
           for (const change of changes) {
             const { operations } = change;
-            view1.applyChanges(operations);
+            view1.applyOperations(operations);
           }
         }
       });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Remove text.onChanges and unify the event system with doc.subscribe. 

#### Any background context you want to provide?

* remove Text.onChanges, onChangeHandler
* Integration with doc.subscribe

```js
const doc = Document.create<{
      text: Text;
    }>('test-doc');

    doc.subscribe('$.text', (event) => {
      if (event.type === 'remote-change') {
        const changes = event.value;
        for (const change of changes) {
          const { operations } = change;

          if (operations[0].type === 'select') {
            assert.equal(operations[0].from, 2);
            assert.equal(operations[0].to, 4);
          }
        }
      }
    });

    doc.update((root) => {
      root.text = new Text();
      root.text.edit(0, 0, 'ABCD');
    });


```

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Fixes #357, Fixes #376
#502

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
