### PR TITLE
Correct ElementNode insert point when edit

### DIFF
--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -530,7 +530,7 @@ export class CRDTTree extends CRDTElement {
         }
       } else {
         const target = fromPos.node;
-        target.insertAt(content, fromPos.offset + 1);
+        target.insertAt(content, fromPos.offset);
       }
     }
 

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -410,6 +410,102 @@ describe.only('Tree', () => {
       }, 'unacceptable path');
     });
   });
+
+  it.only('Can edit its content with path', function () {
+    const key = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
+    const doc = new yorkie.Document<{ t: Tree }>(key);
+
+    doc.update((root) => {
+      root.t = new Tree({
+        type: 'doc',
+        children: [
+          {
+            type: 'tc',
+            children: [
+              {
+                type: 'p',
+                children: [
+                  { type: 'tn', children: [{ type: 'text', value: '' }] },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+
+      assert.equal(root.t.toXML(), '<doc><tc><p><tn></tn></p></tc></doc>');
+
+      root.t.editByPath([0, 0, 0, 0], [0, 0, 0, 0], {
+        type: 'text',
+        value: 'a',
+      });
+      assert.equal(root.t.toXML(), '<doc><tc><p><tn>a</tn></p></tc></doc>');
+
+      root.t.editByPath([0, 1], [0, 1], {
+        type: 'p',
+        children: [{ type: 'tn', children: [{ type: 'text', value: '' }] }],
+      });
+      assert.equal(
+        root.t.toXML(),
+        '<doc><tc><p><tn>a</tn></p><p><tn></tn></p></tc></doc>',
+      );
+
+      root.t.editByPath([0, 1, 0, 0], [0, 1, 0, 0], {
+        type: 'text',
+        value: 'b',
+      });
+      assert.equal(
+        root.t.toXML(),
+        '<doc><tc><p><tn>a</tn></p><p><tn>b</tn></p></tc></doc>',
+      );
+
+      root.t.editByPath([0, 2], [0, 2], {
+        type: 'p',
+        children: [{ type: 'tn', children: [{ type: 'text', value: '' }] }],
+      });
+      assert.equal(
+        root.t.toXML(),
+        '<doc><tc><p><tn>a</tn></p><p><tn>b</tn></p><p><tn></tn></p></tc></doc>',
+      );
+
+      root.t.editByPath([0, 2, 0, 0], [0, 2, 0, 0], {
+        type: 'text',
+        value: 'c',
+      });
+      assert.equal(
+        root.t.toXML(),
+        '<doc><tc><p><tn>a</tn></p><p><tn>b</tn></p><p><tn>c</tn></p></tc></doc>',
+      );
+
+      root.t.editByPath([0, 3], [0, 3], {
+        type: 'p',
+        children: [{ type: 'tn', children: [{ type: 'text', value: '' }] }],
+      });
+      assert.equal(
+        root.t.toXML(),
+        '<doc><tc><p><tn>a</tn></p><p><tn>b</tn></p><p><tn>c</tn></p><p><tn></tn></p></tc></doc>',
+      );
+
+      root.t.editByPath([0, 3, 0, 0], [0, 3, 0, 0], {
+        type: 'text',
+        value: 'd',
+      });
+      assert.equal(
+        root.t.toXML(),
+        '<doc><tc><p><tn>a</tn></p><p><tn>b</tn></p><p><tn>c</tn></p><p><tn>d</tn></p></tc></doc>',
+      );
+
+      root.t.editByPath([0, 3], [0, 3], {
+        type: 'p',
+        children: [{ type: 'tn', children: [{ type: 'text', value: '' }] }],
+      });
+
+      assert.equal(
+        root.t.toXML(),
+        '<doc><tc><p><tn>a</tn></p><p><tn>b</tn></p><p><tn>c</tn></p><p><tn></tn></p><p><tn>d</tn></p></tc></doc>',
+      );
+    });
+  });
 });
 
 describe('Tree.edit', function () {

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -104,7 +104,7 @@ function syncTwoTreeDocsAndAssertEqual<T extends { t: Tree }>(
   assert.equal(doc1.getRoot().t.toXML(), expected);
 }
 
-describe.only('Tree', () => {
+describe('Tree', () => {
   it('Can be created', function () {
     const key = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
     const doc = new yorkie.Document<{ t: Tree }>(key);
@@ -411,7 +411,7 @@ describe.only('Tree', () => {
     });
   });
 
-  it.only('Can edit its content with path', function () {
+  it('Can edit its content with path', function () {
     const key = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
     const doc = new yorkie.Document<{ t: Tree }>(key);
 

--- a/test/unit/document/crdt/tree_test.ts
+++ b/test/unit/document/crdt/tree_test.ts
@@ -102,7 +102,7 @@ function issueTime(): TimeTicket {
   return dummyContext.issueTimeTicket();
 }
 
-describe.only('CRDTTreeNode', function () {
+describe('CRDTTreeNode', function () {
   it('Can be created', function () {
     const node = new CRDTTreeNode(ITP, 'text', 'hello');
     assert.equal(node.pos, ITP);
@@ -133,7 +133,7 @@ describe.only('CRDTTreeNode', function () {
 });
 
 // NOTE: To see the XML string as highlighted, install es6-string-html plugin in VSCode.
-describe.only('CRDTTree', function () {
+describe('CRDTTree', function () {
   it('Can inserts nodes with edit', function () {
     //       0
     // <root> </root>


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Correct `ElementNode` insert point when calling tree.edit()

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
