### PR TITLE
change to next method as synchronously

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -44,7 +44,7 @@
             doc.getRoot().content.toString().length ||
           (textLength != doc.getRoot().content.length && textLength != 0)
         ) {
-          debugger;
+          // debugger;
         }
         textLogHolder.innerText = doc.getRoot().content.getStructureAsString();
       }

--- a/public/index.html
+++ b/public/index.html
@@ -38,14 +38,7 @@
 
       function displayLog(doc, codemirror) {
         logHolder.innerText = doc.toJSON();
-        const textLength = codemirror.getValue().length;
-        if (
-          doc.getRoot().content.length !=
-            doc.getRoot().content.toString().length ||
-          (textLength != doc.getRoot().content.length && textLength != 0)
-        ) {
-          // debugger;
-        }
+
         textLogHolder.innerText = doc.getRoot().content.getStructureAsString();
       }
 
@@ -162,8 +155,7 @@
           // 02-2. subscribe document event.
           doc.subscribe((event) => {
             if (event.type === 'snapshot') {
-              // The text is replaced to snapshot and must be re-synced.
-              syncText();
+              codemirror.setValue(doc.getRoot().content.toString());
             }
             displayLog(doc, codemirror);
           });
@@ -174,6 +166,15 @@
               for (const change of changes) {
                 const { actor, operations } = change;
                 handleOperations(operations, actor);
+              }
+
+              const textLength = codemirror.getValue().length;
+              if (
+                doc.getRoot().content.length !=
+                  doc.getRoot().content.toString().length ||
+                (textLength != doc.getRoot().content.length && textLength != 0)
+              ) {
+                debugger;
               }
             }
           });
@@ -201,6 +202,21 @@
 
             console.log(`%c local: ${from}-${to}: ${content}`, 'color: green');
           });
+          codemirror.on('change', (cm, change) => {
+            if (change.origin === 'yorkie' || change.origin === 'setValue') {
+              return;
+            }
+
+            const textLength = codemirror.getValue().length;
+            if (
+              doc.getRoot().content.length !=
+                doc.getRoot().content.toString().length ||
+              (textLength != doc.getRoot().content.length && textLength != 0)
+            ) {
+              debugger;
+            }
+          });
+
           codemirror.on('beforeSelectionChange', (cm, change) => {
             // Fix concurrent issue.
             // NOTE: The following conditional statement ignores cursor changes
@@ -241,12 +257,7 @@
           }
 
           // 05. synchronize text of document and codemirror.
-          function syncText() {
-            const text = doc.getRoot().content;
-            codemirror.setValue(text.toString());
-          }
-          syncText();
-
+          codemirror.setValue(doc.getRoot().content.toString());
           displayLog(doc, codemirror);
         } catch (e) {
           console.error(e);

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -256,7 +256,7 @@ export class Document<T> {
       this.changeID = change.getID();
 
       if (this.eventStreamObserver) {
-        this.eventStreamObserver.nextSync({
+        this.eventStreamObserver.next({
           type: DocEventType.LocalChange,
           value: [
             {
@@ -623,7 +623,7 @@ export class Document<T> {
       // with the Document after RemoteChange event is emitted. If the event
       // is emitted asynchronously, the model can be changed and breaking
       // consistency.
-      this.eventStreamObserver.nextSync({
+      this.eventStreamObserver.next({
         type: DocEventType.RemoteChange,
         value: changeInfos,
       });

--- a/src/util/observable.ts
+++ b/src/util/observable.ts
@@ -56,7 +56,7 @@ export interface SubscribeFn<T> {
 }
 
 interface ObserverEntry<T> {
-  id: string;
+  subscriptionID: string;
   observer: Observer<T>;
 }
 
@@ -148,11 +148,11 @@ class ObserverProxy<T> implements Observer<T> {
       observer.complete = Noop as CompleteFn;
     }
 
-    const idString = uuid();
-    const unsub = this.unsubscribeOne.bind(this, idString);
+    const id = uuid();
+    const unsub = this.unsubscribeOne.bind(this, id);
 
     this.observers!.push({
-      id: idString,
+      subscriptionID: id,
       observer: observer as Observer<T>,
     });
 
@@ -172,8 +172,8 @@ class ObserverProxy<T> implements Observer<T> {
     return unsub;
   }
 
-  private unsubscribeOne(subscribeId: string): void {
-    this.observers = this.observers?.filter((it) => it.id !== subscribeId);
+  private unsubscribeOne(id: string): void {
+    this.observers = this.observers?.filter((it) => it.subscriptionID !== id);
   }
 
   private forEachObserver(fn: (observer: Observer<T>) => void): void {
@@ -182,11 +182,11 @@ class ObserverProxy<T> implements Observer<T> {
     }
 
     for (let i = 0; i < this.observers!.length; i++) {
-      this.sendOneSync(i, fn);
+      this.sendOne(i, fn);
     }
   }
 
-  private sendOneSync(i: number, fn: (observer: Observer<T>) => void): void {
+  private sendOne(i: number, fn: (observer: Observer<T>) => void): void {
     if (this.observers !== undefined && this.observers[i] !== undefined) {
       try {
         fn(this.observers[i].observer);

--- a/src/util/observable.ts
+++ b/src/util/observable.ts
@@ -15,6 +15,7 @@
  */
 
 import { logger } from '@yorkie-js-sdk/src/util/logger';
+import { uuid } from '@yorkie-js-sdk/src/util/uuid';
 
 /**
  * @internal
@@ -36,7 +37,6 @@ export type CompleteFn = () => void;
  */
 export interface Observer<T> {
   next: NextFn<T>;
-  nextSync: NextFn<T>;
   error?: ErrorFn;
   complete?: CompleteFn;
 }
@@ -55,6 +55,11 @@ export interface SubscribeFn<T> {
   (observer: Observer<T>): Unsubscribe;
 }
 
+interface ObserverEntry<T> {
+  id: string;
+  observer: Observer<T>;
+}
+
 const Noop = (): void => {
   // Do nothing
 };
@@ -64,17 +69,11 @@ const Noop = (): void => {
  */
 class ObserverProxy<T> implements Observer<T> {
   public finalized = false;
-  public onNoObservers: Executor<T> | undefined;
 
-  private observers: Array<Observer<T>> | undefined = [];
-  private unsubscribes: Array<Unsubscribe> = [];
-  private observerCount = 0;
-  private task = Promise.resolve();
+  private observers: Array<ObserverEntry<T>> | undefined = [];
   private finalError?: Error;
 
-  constructor(executor: Executor<T>, onNoObservers?: Executor<T>) {
-    this.onNoObservers = onNoObservers;
-
+  constructor(executor: Executor<T>) {
     try {
       executor(this);
     } catch (error: any) {
@@ -83,19 +82,10 @@ class ObserverProxy<T> implements Observer<T> {
   }
 
   /**
-   * `next` iterates next observer.
+   * `next` iterates next observer synchronously.
    */
   public next(value: T): void {
     this.forEachObserver((observer: Observer<T>) => {
-      observer.next(value);
-    });
-  }
-
-  /**
-   * `nextSync` iterates next observer synchronously.
-   */
-  public nextSync(value: T): void {
-    this.forEachObserverSync((observer: Observer<T>) => {
       observer.next(value);
     });
   }
@@ -158,41 +148,32 @@ class ObserverProxy<T> implements Observer<T> {
       observer.complete = Noop as CompleteFn;
     }
 
-    const unsub = this.unsubscribeOne.bind(this, this.observers!.length);
+    const idString = uuid();
+    const unsub = this.unsubscribeOne.bind(this, idString);
+
+    this.observers!.push({
+      id: idString,
+      observer: observer as Observer<T>,
+    });
 
     if (this.finalized) {
-      this.task.then(() => {
-        try {
-          if (this.finalError) {
-            observer.error!(this.finalError);
-          } else {
-            observer.complete!();
-          }
-        } catch (err) {
-          // nothing
-          logger.warn(err);
+      try {
+        if (this.finalError) {
+          observer.error!(this.finalError);
+        } else {
+          observer.complete!();
         }
-        return;
-      });
+      } catch (err) {
+        // nothing
+        logger.warn(err);
+      }
     }
-
-    this.observers!.push(observer as Observer<T>);
-    this.observerCount += 1;
 
     return unsub;
   }
 
-  private unsubscribeOne(i: number): void {
-    if (this.observers === undefined || this.observers[i] === undefined) {
-      return;
-    }
-
-    delete this.observers[i];
-
-    this.observerCount -= 1;
-    if (this.observerCount === 0 && this.onNoObservers !== undefined) {
-      this.onNoObservers(this);
-    }
+  private unsubscribeOne(subscribeId: string): void {
+    this.observers = this.observers?.filter((it) => it.id !== subscribeId);
   }
 
   private forEachObserver(fn: (observer: Observer<T>) => void): void {
@@ -201,30 +182,14 @@ class ObserverProxy<T> implements Observer<T> {
     }
 
     for (let i = 0; i < this.observers!.length; i++) {
-      this.sendOne(i, fn);
-    }
-  }
-
-  private forEachObserverSync(fn: (observer: Observer<T>) => void): void {
-    if (this.finalized) {
-      return;
-    }
-
-    for (let i = 0; i < this.observers!.length; i++) {
       this.sendOneSync(i, fn);
     }
-  }
-
-  private sendOne(i: number, fn: (observer: Observer<T>) => void): void {
-    this.task.then(() => {
-      this.sendOneSync(i, fn);
-    });
   }
 
   private sendOneSync(i: number, fn: (observer: Observer<T>) => void): void {
     if (this.observers !== undefined && this.observers[i] !== undefined) {
       try {
-        fn(this.observers[i]);
+        fn(this.observers[i].observer);
       } catch (err) {
         logger.error(err);
       }
@@ -241,10 +206,7 @@ class ObserverProxy<T> implements Observer<T> {
       this.finalError = err;
     }
 
-    this.task.then(() => {
-      this.observers = undefined;
-      this.onNoObservers = undefined;
-    });
+    this.observers = undefined;
   }
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Replace all of the eventStreamObserver.next() functions with synchronous forms.

* Prevents incorrect data updates when eventers run asynchronously.
* Clarify when async events are fired when using them.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #525 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
