### PR TITLE
Feat/subscribe message extends

### DIFF
--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -16,7 +16,12 @@
 
 import { assert } from 'chai';
 
-import yorkie, { Tree, ElementNode } from '@yorkie-js-sdk/src/yorkie';
+import yorkie, {
+  Tree,
+  ElementNode,
+  DocEventType,
+  DocEvent,
+} from '@yorkie-js-sdk/src/yorkie';
 import { IndexTree } from '@yorkie-js-sdk/src/util/index_tree';
 import { CRDTTreeNode } from '@yorkie-js-sdk/src/document/crdt/tree';
 import { OperationInfo } from '@yorkie-js-sdk/src/document/operation/operation';
@@ -29,7 +34,9 @@ export async function waitStubCallCount(
 ) {
   return new Promise<void>((resolve) => {
     const doLoop = () => {
+      console.log(`waitStubCallCount: ${stub.callCount} >= ${callCount}`);
       if (stub.callCount >= callCount) {
+        console.log(`waitStubCallCount: ${stub.callCount} >= ${callCount}`);
         resolve();
       }
       return false;
@@ -147,3 +154,11 @@ export function buildIndexTree(node: ElementNode): IndexTree<CRDTTreeNode> {
   });
   return doc.getRoot().t.getIndexTree();
 }
+
+export const subscribeFilter =
+  (type: DocEventType) => (callback: any) => (event: DocEvent) =>
+    event.type === type && callback(event);
+
+export const snapshot = subscribeFilter(DocEventType.Snapshot);
+export const local = subscribeFilter(DocEventType.LocalChange);
+export const remote = subscribeFilter(DocEventType.RemoteChange);

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -34,9 +34,7 @@ export async function waitStubCallCount(
 ) {
   return new Promise<void>((resolve) => {
     const doLoop = () => {
-      console.log(`waitStubCallCount: ${stub.callCount} >= ${callCount}`);
       if (stub.callCount >= callCount) {
-        console.log(`waitStubCallCount: ${stub.callCount} >= ${callCount}`);
         resolve();
       }
       return false;

--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -474,7 +474,7 @@ describe('Document', function () {
     await c2.deactivate();
   });
 
-  it.only('specify the custom message topic to subscribe to', async function () {
+  it('specify the remote message filter to subscribe to', async function () {
     const c1 = new yorkie.Client(testRPCAddr);
     const c2 = new yorkie.Client(testRPCAddr);
     await c1.activate();

--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -489,9 +489,9 @@ describe('Document', function () {
     const pushEvent = (event: DocEvent, events: Array<OperationInfo>) => {
       console.log({ event });
       if (event.type !== DocEventType.RemoteChange) return;
-      for (const { operations } of event.value) {
-        events.push(...operations);
-      }
+      const change = event.value;
+      const { operations } = change;
+      events.push(...operations);
     };
     const stub = sinon.stub().callsFake((event) => pushEvent(event, events));
     const remoteStub = sinon

--- a/test/unit/document/document_test.ts
+++ b/test/unit/document/document_test.ts
@@ -1323,7 +1323,7 @@ describe('Document', function () {
     });
   });
 
-  it.only('subscribe for local-change message', async function () {
+  it('subscribe for local-change message', async function () {
     const doc = Document.create<{ text: string }>('test-doc');
     await new Promise((resolve) => setTimeout(resolve, 0));
     const expectedOps: Array<OperationInfo> = [];

--- a/test/unit/document/document_test.ts
+++ b/test/unit/document/document_test.ts
@@ -1326,9 +1326,9 @@ describe('Document', function () {
     const secondOps: Array<string> = [];
     const stub1 = sinon.stub().callsFake((event: DocEvent) => {
       if (event.type !== DocEventType.LocalChange) return;
-      for (const { operations } of event.value) {
-        ops.push(...operations);
-      }
+
+      const { operations } = event.value;
+      ops.push(...operations);
     });
     const unsub1 = doc.subscribe(local(stub1));
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Filter the type of subscribe to reduce the usage of event code.


#### Any background context you want to provide?

* Always require code of the form `if (event.type == "remote-change")` when handling events with subscribe 
* Proactively remove if statements while wrapping them in a simple filtering function

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #518

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
