### PR TITLE
Implement to make tree selection info

### DIFF
--- a/public/prosemirror.html
+++ b/public/prosemirror.html
@@ -6,6 +6,27 @@
     <link rel="stylesheet" href="prosemirror.css" />
     <script src="./yorkie.js"></script>
     <script src="./util.js"></script>
+    <style type="text/css">
+      .username-layer::before {
+        content: '';
+        position: absolute;
+        width: 2px;
+        left: -1px;
+        background-color: currentColor;
+        bottom: -100%;
+        height: 100%;
+      }
+
+      .username-layer.first-top::before {
+        content: '';
+        position: absolute;
+        width: 2px;
+        left: -1px;
+        background-color: currentColor;
+        top: -100%;
+        height: 100%;
+      }
+    </style>
   </head>
 
   <body>
@@ -63,12 +84,87 @@
       }
     </script>
     <script type="module">
-      import { EditorState, Transaction } from 'prosemirror-state';
+      import {
+        EditorState,
+        Transaction,
+        TextSelection,
+        Plugin,
+      } from 'prosemirror-state';
       import { EditorView } from 'prosemirror-view';
       import { Schema, Node } from 'prosemirror-model';
       import { exampleSetup } from 'prosemirror-example-setup';
       import { toggleMark } from 'prosemirror-commands';
       import { keymap } from 'prosemirror-keymap';
+
+      const colors = ['#FECEEA', '#FEF1D2', '#A9FDD8', '#D7F8FF', '#CEC5FA'];
+      let nextColorIdx = 0;
+
+      const peersHolder = document.getElementById('peers-holder');
+      const selectionMap = new Map();
+
+      function displayPeers(peers, myClientID) {
+        const usernames = [];
+        for (const { clientID, presence } of peers) {
+          usernames.push(
+            clientID === myClientID ? `<b>${clientID}</b>` : clientID,
+          );
+        }
+        peersHolder.innerHTML = JSON.stringify(usernames);
+      }
+
+      function displayRemoteSelection(view, from, to, actor) {
+        let color, layer;
+        if (selectionMap.has(actor)) {
+          const selection = selectionMap.get(actor);
+          color = selection.color;
+          layer = selection.layer;
+        } else {
+          color = colors[nextColorIdx];
+          nextColorIdx = (nextColorIdx + 1) % colors.length;
+
+          layer = document.createElement('div');
+          layer.className = 'username-layer'; // 레이어에 사용될 CSS 클래스 지정
+          layer.textContent = actor.substr(-2); // 사용자 이름 설정
+          layer.style.position = 'absolute';
+          layer.style.backgroundColor = color;
+          layer.style.color = 'black';
+
+          view.dom.parentNode.appendChild(layer);
+
+          selectionMap.set(actor, {
+            color,
+            layer,
+          });
+        }
+
+        if (from === to) {
+          const newStartCoords = view.coordsAtPos(from);
+
+          // 선택 영역이 변경되었으므로 레이어 업데이트
+          layer.style.left = `${newStartCoords.left - 10}px`;
+
+          if (newStartCoords.top < 130) {
+            layer.classList.add('first-top');
+            layer.style.top = `${newStartCoords.top + 10}px`;
+          } else {
+            layer.classList.remove('first-top');
+            layer.style.top = `${newStartCoords.top - 30}px`;
+          }
+        } else {
+          const newStartCoords = view.coordsAtPos(Math.min(from, to));
+
+          // 선택 영역이 변경되었으므로 레이어 업데이트
+          layer.style.left = `${newStartCoords.left - 10}px`;
+
+          if (newStartCoords.top < 130) {
+            layer.classList.add('first-top');
+            layer.style.top = `${newStartCoords.top + 10}px`;
+          } else {
+            layer.classList.remove('first-top');
+            layer.style.top = `${newStartCoords.top - 30}px`;
+          }
+        }
+      }
 
       window.transactions = [];
 
@@ -207,10 +303,7 @@
       }
 
       function getSelectionInfo(root, from, to) {
-        console.log({ from, to }, root.tree.createRange(from, to));
         return root.tree.createRange(from, to).map((it) => {
-          console.log(yorkie.Primitive.of(it.offset, it.createdAt));
-
           return yorkie.converter.toHexString(
             yorkie.converter.objectToBytes(
               yorkie.Primitive.of(it.offset, it.createdAt),
@@ -252,12 +345,9 @@
         });
 
         // 03. Upstream: ProseMirror to yorkie.Text.
-        console.log(yorkie);
-        console.log('03');
         const view = new EditorView(document.querySelector('#app'), {
           state,
           dispatchTransaction: (transaction) => {
-            console.log('self', transaction);
             view.updateState(view.state.apply(transaction));
 
             // If the steps are empty, it means the transaction is not applied to the document.
@@ -274,18 +364,7 @@
                   transaction.curSelection.from,
                   transaction.curSelection.to,
                 );
-
-                console.log(
-                  getSelectionInfo(
-                    root,
-                    transaction.curSelection.from,
-                    transaction.curSelection.to,
-                  ),
-                );
               });
-
-              console.log(transaction.curSelection);
-
               printLog();
               return;
             }
@@ -348,47 +427,57 @@
           },
         });
 
-        console.log('fdsaf');
         // 03. Downstream: yorkie.Tree to ProseMirror.
         doc.subscribe((event) => {
           if (event.type !== 'remote-change') {
             return;
           }
 
-          console.log('remote-change', event);
-
           const root = doc.getRoot();
-          const { operations } = event.value;
+          const { operations, actor } = event.value;
           let fromPos = -1;
           let toPos = -1;
           for (const op of operations) {
             if (op.type !== 'tree-edit') {
-              if (op.type === 'add' && op.path === '$.selection') {
-                if (op.index === 0) {
-                  // const obj = yorkie.converter.bytesToObject(
-                  //   yorkie.converter.toUint8Array(doc.getRoot().selection[0]),
-                  // );
-                  fromPos = yorkie.converter.bytesToPrimitive(
-                    yorkie.converter.toUint8Array(doc.getRoot().selection[0]),
-                  );
-                  fromPos = {
-                    offset: fromPos.value,
-                    createdAt: fromPos.createdAt,
-                  };
-                } else if (op.index === 1) {
-                  toPos = yorkie.converter.bytesToPrimitive(
-                    yorkie.converter.toUint8Array(doc.getRoot().selection[1]),
-                  );
-                  toPos = { offset: toPos.value, createdAt: toPos.createdAt };
+              if (
+                op.type === 'set' &&
+                op.path === '$' &&
+                op.key === 'selection'
+              ) {
+                fromPos = yorkie.converter.bytesToPrimitive(
+                  yorkie.converter.toUint8Array(doc.getRoot().selection[0]),
+                );
+                fromPos = {
+                  offset: fromPos.value,
+                  createdAt: fromPos.createdAt,
+                };
 
-                  console.log(fromPos, toPos);
-                  const [fromIndex, toIndex] = root.tree.rangeToIndex([
-                    fromPos,
-                    toPos,
-                  ]);
+                toPos = yorkie.converter.bytesToPrimitive(
+                  yorkie.converter.toUint8Array(doc.getRoot().selection[1]),
+                );
+                toPos = { offset: toPos.value, createdAt: toPos.createdAt };
 
-                  console.log(fromIndex, toIndex);
-                }
+                const [fromIndex, toIndex] = root.tree.rangeToIndex([
+                  fromPos,
+                  toPos,
+                ]);
+
+                // update prosemirror text selection
+                const selection = TextSelection.create(
+                  view.state.doc,
+                  fromIndex,
+                  toIndex,
+                );
+
+                const transform = view.state.tr;
+
+                view.focus();
+
+                transform.setSelection(selection);
+                const newState = view.state.apply(transform);
+                view.updateState(newState);
+
+                displayRemoteSelection(view, fromIndex, toIndex, actor);
               }
               continue;
             }

--- a/public/prosemirror.html
+++ b/public/prosemirror.html
@@ -371,10 +371,15 @@
                   fromPos = yorkie.converter.bytesToPrimitive(
                     yorkie.converter.toUint8Array(doc.getRoot().selection[0]),
                   );
+                  fromPos = {
+                    offset: fromPos.value,
+                    createdAt: fromPos.createdAt,
+                  };
                 } else if (op.index === 1) {
                   toPos = yorkie.converter.bytesToPrimitive(
                     yorkie.converter.toUint8Array(doc.getRoot().selection[1]),
                   );
+                  toPos = { offset: toPos.value, createdAt: toPos.createdAt };
 
                   console.log(fromPos, toPos);
                   const [fromIndex, toIndex] = root.tree.rangeToIndex([

--- a/public/prosemirror.html
+++ b/public/prosemirror.html
@@ -57,7 +57,8 @@
           "prosemirror-transform": "https://cdn.jsdelivr.net//npm/prosemirror-transform@1.7.3/+esm",
           "prosemirror-keymap": "https://cdn.jsdelivr.net/npm/prosemirror-keymap@1.2.2/+esm",
           "prosemirror-example-setup": "https://cdn.jsdelivr.net/npm/prosemirror-example-setup@1.2.2/+esm",
-          "prosemirror-commands": "https://cdn.jsdelivr.net/npm/prosemirror-commands@1.5.2/+esm"
+          "prosemirror-commands": "https://cdn.jsdelivr.net/npm/prosemirror-commands@1.5.2/+esm",
+          "yorkie-js-sdk": "./yorkie.js"
         }
       }
     </script>
@@ -205,6 +206,19 @@
         return true;
       }
 
+      function getSelectionInfo(root, from, to) {
+        console.log({ from, to }, root.tree.createRange(from, to));
+        return root.tree.createRange(from, to).map((it) => {
+          console.log(yorkie.Primitive.of(it.offset, it.createdAt));
+
+          return yorkie.converter.toHexString(
+            yorkie.converter.objectToBytes(
+              yorkie.Primitive.of(it.offset, it.createdAt),
+            ),
+          );
+        });
+      }
+
       /**
        * main is the entry point of the example.
        */
@@ -213,7 +227,7 @@
         await client.activate();
 
         // 01. Build yorkie.Text from ProseMirror doc.
-        const doc = new yorkie.Document('prosemirror');
+        const doc = new yorkie.Document('prosemirror-3');
         window.doc = doc;
         await client.attach(doc);
         doc.update((root) => {
@@ -237,41 +251,13 @@
           ],
         });
 
-        // 04. Downstream: yorkie.Text to ProseMirror.
-        doc.subscribe('$.tree', (event) => {
-          if (event.type !== 'remote-change') {
-            return;
-          }
-
-          const { message, actor, operations } = event.value;
-          for (const op of operations) {
-            if (op.type !== 'tree-edit') {
-              continue;
-            }
-
-            const { from, to, value: content } = op;
-            const transform = view.state.tr;
-            if (content) {
-              transform.replaceWith(
-                from,
-                to,
-                Node.fromJSON(mySchema, {
-                  type: content.type,
-                  text: content.value,
-                }),
-              );
-            } else {
-              transform.replace(from, to);
-            }
-            const newState = view.state.apply(transform);
-            view.updateState(newState);
-          }
-        });
-
         // 03. Upstream: ProseMirror to yorkie.Text.
+        console.log(yorkie);
+        console.log('03');
         const view = new EditorView(document.querySelector('#app'), {
           state,
           dispatchTransaction: (transaction) => {
+            console.log('self', transaction);
             view.updateState(view.state.apply(transaction));
 
             // If the steps are empty, it means the transaction is not applied to the document.
@@ -281,6 +267,25 @@
                 type: 'selection',
                 selection: transaction.curSelection,
               });
+
+              doc.update((root) => {
+                root.selection = getSelectionInfo(
+                  root,
+                  transaction.curSelection.from,
+                  transaction.curSelection.to,
+                );
+
+                console.log(
+                  getSelectionInfo(
+                    root,
+                    transaction.curSelection.from,
+                    transaction.curSelection.to,
+                  ),
+                );
+              });
+
+              console.log(transaction.curSelection);
+
               printLog();
               return;
             }
@@ -332,42 +337,74 @@
                   root.tree.edit(from, to, docToTreeNode(node.toJSON()));
                 }
               }
+
+              root.selection = getSelectionInfo(
+                root,
+                transaction.curSelection.from,
+                transaction.curSelection.to,
+              );
             });
             printLog();
           },
         });
 
+        console.log('fdsaf');
         // 03. Downstream: yorkie.Tree to ProseMirror.
-        doc.subscribe('$.tree', (event) => {
+        doc.subscribe((event) => {
           if (event.type !== 'remote-change') {
             return;
           }
 
-          for (const change of event.value) {
-            const { operations } = change;
-            for (const op of operations) {
-              if (op.type !== 'tree-edit') {
-                continue;
+          console.log('remote-change', event);
+
+          const root = doc.getRoot();
+          const { operations } = event.value;
+          let fromPos = -1;
+          let toPos = -1;
+          for (const op of operations) {
+            if (op.type !== 'tree-edit') {
+              if (op.type === 'add' && op.path === '$.selection') {
+                if (op.index === 0) {
+                  // const obj = yorkie.converter.bytesToObject(
+                  //   yorkie.converter.toUint8Array(doc.getRoot().selection[0]),
+                  // );
+                  fromPos = yorkie.converter.bytesToPrimitive(
+                    yorkie.converter.toUint8Array(doc.getRoot().selection[0]),
+                  );
+                } else if (op.index === 1) {
+                  toPos = yorkie.converter.bytesToPrimitive(
+                    yorkie.converter.toUint8Array(doc.getRoot().selection[1]),
+                  );
+
+                  console.log(fromPos, toPos);
+                  const [fromIndex, toIndex] = root.tree.rangeToIndex([
+                    fromPos,
+                    toPos,
+                  ]);
+
+                  console.log(fromIndex, toIndex);
+                }
               }
-              const { from, to, value: content } = op;
-              const transform = view.state.tr;
-              if (content) {
-                transform.replaceWith(
-                  from,
-                  to,
-                  Node.fromJSON(mySchema, {
-                    type: content.type,
-                    text: content.value,
-                  }),
-                );
-              } else {
-                transform.replace(from, to);
-              }
-              const newState = view.state.apply(transform);
-              view.updateState(newState);
+              continue;
             }
-            printLog();
+            const { from, to, value: content } = op;
+            const transform = view.state.tr;
+            if (content) {
+              transform.replaceWith(
+                from,
+                to,
+                Node.fromJSON(mySchema, {
+                  type: content.type,
+                  text: content.value,
+                }),
+              );
+            } else {
+              transform.replace(from, to);
+            }
+            const newState = view.state.apply(transform);
+            view.updateState(newState);
           }
+          printLog();
         });
 
         window.view = view;

--- a/public/prosemirror.html
+++ b/public/prosemirror.html
@@ -98,75 +98,50 @@
 
       const colors = ['#FECEEA', '#FEF1D2', '#A9FDD8', '#D7F8FF', '#CEC5FA'];
       let nextColorIdx = 0;
+      let transactions = [];
 
-      const peersHolder = document.getElementById('peers-holder');
       const selectionMap = new Map();
 
-      function displayPeers(peers, myClientID) {
-        const usernames = [];
-        for (const { clientID, presence } of peers) {
-          usernames.push(
-            clientID === myClientID ? `<b>${clientID}</b>` : clientID,
-          );
+      /**
+       * `updateSelectionLayer` updates the selection layer of the given actor.
+       */
+      function updateSelectionLayer(view, tree, actor) {
+        const { layer, fromPos, toPos } = selectionMap.get(actor);
+        const [fromIndex, toIndex] = tree.rangeToIndex([fromPos, toPos]);
+        const coords = view.coordsAtPos(Math.min(fromIndex, toIndex));
+
+        layer.style.left = `${coords.left - 10}px`;
+        if (coords.top < 130) {
+          layer.classList.add('first-top');
+          layer.style.top = `${coords.top + 10}px`;
+        } else {
+          layer.classList.remove('first-top');
+          layer.style.top = `${coords.top - 30}px`;
         }
-        peersHolder.innerHTML = JSON.stringify(usernames);
       }
 
-      function displayRemoteSelection(view, from, to, actor) {
-        let color, layer;
-        if (selectionMap.has(actor)) {
-          const selection = selectionMap.get(actor);
-          color = selection.color;
-          layer = selection.layer;
-        } else {
-          color = colors[nextColorIdx];
+      function displayRemoteSelection(view, tree, fromPos, toPos, actor) {
+        if (!selectionMap.has(actor)) {
+          const color = colors[nextColorIdx];
           nextColorIdx = (nextColorIdx + 1) % colors.length;
 
-          layer = document.createElement('div');
-          layer.className = 'username-layer'; // 레이어에 사용될 CSS 클래스 지정
-          layer.textContent = actor.substr(-2); // 사용자 이름 설정
+          const layer = document.createElement('div');
+          layer.className = 'username-layer';
+          layer.textContent = actor.substr(-2);
           layer.style.position = 'absolute';
           layer.style.backgroundColor = color;
           layer.style.color = 'black';
+          selectionMap.set(actor, { color, layer });
 
           view.dom.parentNode.appendChild(layer);
-
-          selectionMap.set(actor, {
-            color,
-            layer,
-          });
         }
+        selectionMap.get(actor).fromPos = fromPos;
+        selectionMap.get(actor).toPos = toPos;
 
-        if (from === to) {
-          const newStartCoords = view.coordsAtPos(from);
-
-          // 선택 영역이 변경되었으므로 레이어 업데이트
-          layer.style.left = `${newStartCoords.left - 10}px`;
-
-          if (newStartCoords.top < 130) {
-            layer.classList.add('first-top');
-            layer.style.top = `${newStartCoords.top + 10}px`;
-          } else {
-            layer.classList.remove('first-top');
-            layer.style.top = `${newStartCoords.top - 30}px`;
-          }
-        } else {
-          const newStartCoords = view.coordsAtPos(Math.min(from, to));
-
-          // 선택 영역이 변경되었으므로 레이어 업데이트
-          layer.style.left = `${newStartCoords.left - 10}px`;
-
-          if (newStartCoords.top < 130) {
-            layer.classList.add('first-top');
-            layer.style.top = `${newStartCoords.top + 10}px`;
-          } else {
-            layer.classList.remove('first-top');
-            layer.style.top = `${newStartCoords.top - 30}px`;
-          }
+        for (var [actor] of selectionMap) {
+          updateSelectionLayer(view, tree, actor);
         }
       }
-
-      window.transactions = [];
 
       const mySchema = new Schema({
         nodes: {
@@ -302,14 +277,17 @@
         return true;
       }
 
-      function getSelectionInfo(root, from, to) {
-        return root.tree.createRange(from, to).map((it) => {
-          return yorkie.converter.toHexString(
-            yorkie.converter.objectToBytes(
-              yorkie.Primitive.of(it.offset, it.createdAt),
-            ),
-          );
-        });
+      function encodeRange(tree, from, to) {
+        const range = tree.createRange(from, to);
+        const fromBytes = yorkie.converter.treePosToBytes(range[0]);
+        const toBytes = yorkie.converter.treePosToBytes(range[1]);
+        return [fromBytes, toBytes];
+      }
+
+      function decodeRange(fromBytes, toBytes) {
+        const from = yorkie.converter.bytesToTreePos(fromBytes);
+        const to = yorkie.converter.bytesToTreePos(toBytes);
+        return [from, to];
       }
 
       /**
@@ -320,7 +298,7 @@
         await client.activate();
 
         // 01. Build yorkie.Text from ProseMirror doc.
-        const doc = new yorkie.Document('prosemirror-3');
+        const doc = new yorkie.Document('prosemirror');
         window.doc = doc;
         await client.attach(doc);
         doc.update((root) => {
@@ -353,14 +331,14 @@
             // If the steps are empty, it means the transaction is not applied to the document.
             // Only the selection is changed.
             if (!transaction.steps.length) {
-              window.transactions.unshift({
+              transactions.unshift({
                 type: 'selection',
                 selection: transaction.curSelection,
               });
 
               doc.update((root) => {
-                root.selection = getSelectionInfo(
-                  root,
+                root.selection = encodeRange(
+                  root.tree,
                   transaction.curSelection.from,
                   transaction.curSelection.to,
                 );
@@ -369,7 +347,7 @@
               return;
             }
 
-            window.transactions.unshift({
+            transactions.unshift({
               type: 'transaction',
               transaction: transaction,
             });
@@ -417,8 +395,8 @@
                 }
               }
 
-              root.selection = getSelectionInfo(
-                root,
+              root.selection = encodeRange(
+                root.tree,
                 transaction.curSelection.from,
                 transaction.curSelection.to,
               );
@@ -444,40 +422,15 @@
                 op.path === '$' &&
                 op.key === 'selection'
               ) {
-                fromPos = yorkie.converter.bytesToPrimitive(
-                  yorkie.converter.toUint8Array(doc.getRoot().selection[0]),
+                const selection = doc.getRoot().selection;
+                const range = decodeRange(selection[0], selection[1]);
+                displayRemoteSelection(
+                  view,
+                  root.tree,
+                  range[0],
+                  range[1],
+                  actor,
                 );
-                fromPos = {
-                  offset: fromPos.value,
-                  createdAt: fromPos.createdAt,
-                };
-
-                toPos = yorkie.converter.bytesToPrimitive(
-                  yorkie.converter.toUint8Array(doc.getRoot().selection[1]),
-                );
-                toPos = { offset: toPos.value, createdAt: toPos.createdAt };
-
-                const [fromIndex, toIndex] = root.tree.rangeToIndex([
-                  fromPos,
-                  toPos,
-                ]);
-
-                // update prosemirror text selection
-                const selection = TextSelection.create(
-                  view.state.doc,
-                  fromIndex,
-                  toIndex,
-                );
-
-                const transform = view.state.tr;
-
-                view.focus();
-
-                transform.setSelection(selection);
-                const newState = view.state.apply(transform);
-                view.updateState(newState);
-
-                displayRemoteSelection(view, fromIndex, toIndex, actor);
               }
               continue;
             }
@@ -514,7 +467,7 @@
       };
 
       function printTransaction(index) {
-        const t = window.transactions[index || 0];
+        const t = transactions[index || 0];
 
         if (t) {
           if (t.type === 'selection') {
@@ -540,7 +493,7 @@
 
       function printLog() {
         // how to show transaction view
-        document.getElementById('tr-log').innerHTML = window.transactions
+        document.getElementById('tr-log').innerHTML = transactions
           .slice(0, 100)
           .map((transaction, index) => {
             if (transaction.type === 'selection') {
@@ -555,16 +508,12 @@
         printDoc(doc.getRoot().tree.tree.getRoot(), 'yorkie-log');
         printDoc(view.state.doc, 'pm-log');
         printDocList(doc.getRoot().tree.tree, 'yorkie-list-log');
-        printChanges();
       }
 
-      let globalIndex = 0;
-
-      function printNode(node, depth, arr, index) {
+      function buildNodes(node, depth, nodes, index) {
         const nodeType = node.type.name || node.type;
-
         if (nodeType === 'text') {
-          arr.push({
+          nodes.push({
             type: nodeType,
             depth,
             index,
@@ -573,17 +522,15 @@
           return;
         }
 
-        arr.push({
+        nodes.push({
           type: nodeType,
           depth,
           index,
           size: node.content?.size || node.size,
         });
-
-        const list = node.content?.content || node.children || [];
-
-        for (let i = 0; i < list.length; i++) {
-          printNode(list[i], depth + 1, arr, i);
+        const children = node.content?.content || node.children || [];
+        for (let i = 0; i < children.length; i++) {
+          buildNodes(children[i], depth + 1, nodes, i);
         }
       }
 
@@ -640,11 +587,10 @@
        * `printDoc` prints the content of the yorkie.Text.
        */
       function printDoc(doc, id) {
-        const arr = [];
-        globalIndex = 0;
-        printNode(doc, 0, arr);
+        const nodes = [];
+        buildNodes(doc, 0, nodes);
 
-        const html = arr
+        const html = nodes
           .map((node) => {
             if (node.type === 'text') {
               return `<div class="inline" style="padding-left: ${
@@ -659,19 +605,6 @@
           })
           .join('');
         document.getElementById(id).innerHTML = html;
-      }
-
-      function printChanges(doc) {
-        const arr = [];
-        globalIndex = 0;
-
-        const html = (window.firstChanges || [])
-          .map((it) => {
-            return `<div>${JSON.stringify(it)}</div>`;
-          })
-          .join('');
-
-        document.getElementById('pm-sub-log').innerHTML = html;
       }
 
       main();

--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -1135,14 +1135,6 @@ function bytesToObject(bytes?: Uint8Array): CRDTObject {
 }
 
 /**
- * `bytesToPrimitive` converts the given bytes to Primitive
- */
-function bytesToPrimitive(bytes: Uint8Array): Primitive {
-  const pbElement = PbJSONElement.deserializeBinary(bytes!);
-  return fromPrimitive(pbElement.getPrimitive()!);
-}
-
-/**
  * `objectToBytes` converts the given JSONObject to byte array.
  */
 function objectToBytes(obj: CRDTObject): Uint8Array {
@@ -1150,7 +1142,7 @@ function objectToBytes(obj: CRDTObject): Uint8Array {
 }
 
 /**
- * `bytesToTree` creates an JSONArray from the given byte array.
+ * `bytesToTree` creates an CRDTTree from the given bytes.
  */
 function bytesToTree(bytes?: Uint8Array): CRDTTree {
   if (!bytes) {
@@ -1162,10 +1154,28 @@ function bytesToTree(bytes?: Uint8Array): CRDTTree {
 }
 
 /**
- * `treeToBytes` converts the given JSONArray to byte array.
+ * `treeToBytes` converts the given tree to bytes.
  */
 function treeToBytes(tree: CRDTTree): Uint8Array {
   return toTree(tree).serializeBinary();
+}
+
+/**
+ * `treePosToBytes` converts the given CRDTTreePos to byte array.
+ */
+function treePosToBytes(pos: CRDTTreePos): Uint8Array {
+  return toTreePos(pos).serializeBinary();
+}
+
+/**
+ * `bytesToTreePos` creates an CRDTTreePos from the given bytes.
+ */
+function bytesToTreePos(bytes: Uint8Array): CRDTTreePos {
+  if (!bytes) {
+    throw new Error('bytes is empty');
+  }
+  const pbTreePos = PbTreePos.deserializeBinary(bytes);
+  return fromTreePos(pbTreePos);
 }
 
 /**
@@ -1218,5 +1228,6 @@ export const converter = {
   bytesToObject,
   toHexString,
   toUint8Array,
-  bytesToPrimitive,
+  bytesToTreePos,
+  treePosToBytes,
 };

--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -1135,6 +1135,14 @@ function bytesToObject(bytes?: Uint8Array): CRDTObject {
 }
 
 /**
+ * `bytesToPrimitive` converts the given bytes to Primitive
+ */
+function bytesToPrimitive(bytes: Uint8Array): Primitive {
+  const pbElement = PbJSONElement.deserializeBinary(bytes!);
+  return fromPrimitive(pbElement.getPrimitive()!);
+}
+
+/**
  * `objectToBytes` converts the given JSONObject to byte array.
  */
 function objectToBytes(obj: CRDTObject): Uint8Array {
@@ -1210,4 +1218,5 @@ export const converter = {
   bytesToObject,
   toHexString,
   toUint8Array,
+  bytesToPrimitive,
 };

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -118,6 +118,8 @@ export interface CRDTTreePos {
   offset: number;
 }
 
+export type TreeRange = [CRDTTreePos, CRDTTreePos];
+
 /**
  * `CRDTTreeNode` is a node of CRDTTree. It is includes the logical clock and
  * links to other nodes to resolve conflicts.
@@ -551,7 +553,7 @@ export class CRDTTree extends CRDTElement {
   }
 
   /**
-   * `findTreePos` finds the position of the given index in the tree.
+   * `findPos` finds the position of the given index in the tree.
    */
   public findPos(index: number, preferText = true): CRDTTreePos {
     const treePos = this.indexTree.findTreePos(index, preferText);
@@ -684,5 +686,31 @@ export class CRDTTree extends CRDTElement {
    */
   public indexToPath(index: number): Array<number> {
     return this.indexTree.indexToPath(index);
+  }
+
+  /**
+   * `createRange` returns pair of RGATreeSplitNodePos of the given integer offsets.
+   */
+  public createRange(fromIdx: number, toIdx: number): TreeRange {
+    const fromPos = this.findPos(fromIdx);
+    if (fromIdx === toIdx) {
+      return [fromPos, fromPos];
+    }
+
+    return [fromPos, this.findPos(toIdx)];
+  }
+
+  /**
+   * `rangeToIndex` returns pair of integer offsets of the given Tree.
+   */
+  public rangeToIndex(range: TreeRange): Array<number> {
+    return [this.toIndex(range[0]), this.toIndex(range[1])];
+  }
+
+  /**
+   * `rangeToPath` returns pair of integer offsets of the given Tree.
+   */
+  public rangeToPath(range: TreeRange): Array<Array<number>> {
+    return this.rangeToIndex(range).map((index) => this.indexToPath(index));
   }
 }

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -118,6 +118,9 @@ export interface CRDTTreePos {
   offset: number;
 }
 
+/**
+ * `TreeRange` represents a pair of CRDTTreePos.
+ */
 export type TreeRange = [CRDTTreePos, CRDTTreePos];
 
 /**

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -3,6 +3,7 @@ import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
 import {
   CRDTTree,
   CRDTTreeNode,
+  TreeRange,
   TreeChange,
 } from '@yorkie-js-sdk/src/document/crdt/tree';
 
@@ -13,6 +14,7 @@ import {
   TreeNodeType,
 } from '@yorkie-js-sdk/src/util/index_tree';
 import { TreeEditOperation } from '@yorkie-js-sdk/src/document/operation/tree_edit_operation';
+import { logger } from '@yorkie-js-sdk/src/util/logger';
 
 export type TreeNode = TextNode | ElementNode;
 export type TreeChangeWithPath = Omit<TreeChange, 'from' | 'to'> & {
@@ -311,5 +313,38 @@ export class Tree {
         };
       }
     }
+  }
+
+  /**
+   * `createRange` returns pair of RGATreeSplitNodePos of the given integer offsets.
+   */
+  createRange(fromIdx: number, toIdx: number): TreeRange {
+    if (!this.context || !this.tree) {
+      logger.fatal('it is not initialized yet');
+      // @ts-ignore
+      return;
+    }
+
+    return this.tree.createRange(fromIdx, toIdx);
+  }
+
+  /**
+   * `rangeToIndex` returns the integer offsets of the given range.
+   */
+  rangeToIndex(range: TreeRange): Array<number> {
+    if (!this.context || !this.tree) {
+      logger.fatal('it is not initialized yet');
+      // @ts-ignore
+      return;
+    }
+
+    return this.tree.rangeToIndex(range);
+  }
+
+  /**
+   * `rangeToPath` returns the path of the given range.
+   */
+  rangeToPath(range: TreeRange): Array<Array<number>> {
+    return this.rangeToPath(range);
   }
 }

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -316,7 +316,7 @@ export class Tree {
   }
 
   /**
-   * `createRange` returns pair of RGATreeSplitNodePos of the given integer offsets.
+   * `createRange` returns pair of CRDTTreePos of the given integer offsets.
    */
   createRange(fromIdx: number, toIdx: number): TreeRange {
     if (!this.context || !this.tree) {

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -20,6 +20,7 @@ import { Text } from '@yorkie-js-sdk/src/document/json/text';
 import { Tree } from '@yorkie-js-sdk/src/document/json/tree';
 import { Counter } from '@yorkie-js-sdk/src/document/json/counter';
 import { CounterType } from '@yorkie-js-sdk/src/document/crdt/counter';
+import { converter } from '@yorkie-js-sdk/src/api/converter';
 
 export {
   Client,
@@ -85,6 +86,8 @@ export {
   Primitive,
   PrimitiveValue,
 } from '@yorkie-js-sdk/src/document/crdt/primitive';
+import { Primitive } from '@yorkie-js-sdk/src/document/crdt/primitive';
+
 export {
   WrappedElement,
   JSONElement,
@@ -100,7 +103,7 @@ export {
   TextNode,
 } from '@yorkie-js-sdk/src/document/json/tree';
 export { Change } from '@yorkie-js-sdk/src/document/change/change';
-export { converter } from '@yorkie-js-sdk/src/api/converter';
+export { converter };
 
 /**
  * The top-level yorkie namespace with additional properties.
@@ -115,11 +118,13 @@ export { converter } from '@yorkie-js-sdk/src/api/converter';
 const yorkie = {
   Client,
   Document,
+  Primitive,
   Text,
   Counter,
   Tree,
   IntType: CounterType.IntegerCnt,
   LongType: CounterType.LongCnt,
+  converter,
 };
 
 export default yorkie;

--- a/test/unit/document/crdt/tree_test.ts
+++ b/test/unit/document/crdt/tree_test.ts
@@ -586,6 +586,35 @@ describe('CRDTTree', function () {
       /*html*/ `<root><p>ab</p><b>cd</b><p>ef</p></root>`,
     );
   });
+
+  it('Get correct range from index', function () {
+    const tree = new CRDTTree(
+      new CRDTTreeNode(issuePos(), 'root'),
+      issueTime(),
+    );
+
+    tree.editByIndex([0, 0], new CRDTTreeNode(issuePos(), 'p'), issueTime());
+    tree.editByIndex([1, 1], new CRDTTreeNode(issuePos(), 'b'), issueTime());
+    tree.editByIndex([2, 2], new CRDTTreeNode(issuePos(), 'i'), issueTime());
+    tree.editByIndex(
+      [3, 3],
+      new CRDTTreeNode(issuePos(), 'text', 'ab'),
+      issueTime(),
+    );
+
+    // console.log('-----------------', tree.toXML());
+    assert.deepEqual(
+      tree.toXML(),
+      /*html*/ `<root><p><b><i>ab</i></b></p></root>`,
+    );
+    assert.equal(tree.getSize(), 8);
+
+    let range = tree.createRange(0, 5);
+    assert.deepEqual(tree.rangeToIndex(range), [0, 5]);
+
+    range = tree.createRange(5, 7);
+    assert.deepEqual(tree.rangeToIndex(range), [5, 7]);
+  });
 });
 
 describe.skip('Tree.split', function () {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Allows selection information from the `yorkie.Tree` to be sent remotely.
support remote selection viewer.

#### Any background context you want to provide?

Tree selection information is provided by the createRange () function.

```
const selection = root.tree.createRange(fromIndex, toIndex);
```

The selection is converted to a string for transmission to the remote. 

```
root.tree.createRange(from, to).map((it) => {
      return yorkie.converter.toHexString(
            yorkie.converter.objectToBytes(
              yorkie.Primitive.of(it.offset, it.createdAt),
            ),
     );
});
```

As you can see in the code, there is no way to simply send pos, so we wrap it in Primitive.of. 
The reason for this is so that we can transform it into bytes and send it. 

The converted selection information is then sent via root.selection to root.tree in the same way as root.tree.

```
root.selection = root.tree.createRange().map( () => {
    .....
});
```

There's a problem: the selection information is an array, which generates quite a few operations.

`Set`, `Add`, `Add` 

At least three things must be done, because range information has from and to.


https://github.com/yorkie-team/yorkie-js-sdk/assets/591983/dcf5aefd-d1f0-4280-9f42-a63795d6e043



#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #543 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
