### PR TITLE
Cleanup TextChange

### DIFF
--- a/src/document/crdt/text.ts
+++ b/src/document/crdt/text.ts
@@ -32,7 +32,7 @@ import { parseObjectValues } from '@yorkie-js-sdk/src/util/object';
  *
  * @internal
  */
-export enum TextChangeType {
+enum TextChangeType {
   Content = 'content',
   Selection = 'selection',
   Style = 'style',
@@ -48,11 +48,10 @@ export interface TextValueType<A> {
 }
 
 /**
- * `TextChange` is the value passed as an argument to `Document.subscribe()`.
- * `Document.subscribe()` is called when the `Text` is modified.
+ * `TextChange` represents the changes to the text
+ * when executing the edit, setstyle, and select methods.
  */
-export interface TextChange<A = Indexable>
-  extends ValueChange<TextValueType<A>> {
+interface TextChange<A = Indexable> extends ValueChange<TextValueType<A>> {
   type: TextChangeType;
 }
 

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -58,10 +58,6 @@ export {
 } from '@yorkie-js-sdk/src/util/observable';
 export { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 export { ActorID } from '@yorkie-js-sdk/src/document/time/actor_id';
-export {
-  TextChange,
-  TextChangeType,
-} from '@yorkie-js-sdk/src/document/crdt/text';
 export type {
   OperationInfo,
   AddOpInfo,
@@ -74,9 +70,6 @@ export type {
   SelectOpInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 
-// TODO(hackerwins): ValueChange is missing in TextChange in the index.d.ts file
-// if not exported. We need to find a way to handle this without exporting the below.
-export { ValueChange } from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';
 export {
   TreeChange,
   TreeChangeType,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

- The comments of TextChange have been corrected.
- The textChange is not exposed to the user anymore. (`text.onchanges` has been replaced with `document.subscribe` #519 ) 


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
