### PR TITLE
Use TreeRangeStruct to represent tree selection

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -39,7 +39,7 @@
       function displayLog(doc, codemirror) {
         logHolder.innerText = doc.toJSON();
 
-        textLogHolder.innerText = doc.getRoot().content.getStructureAsString();
+        textLogHolder.innerText = doc.getRoot().content.toTestString();
       }
 
       function displayPeers(peers, myClientID) {

--- a/public/prosemirror.html
+++ b/public/prosemirror.html
@@ -107,7 +107,7 @@
        */
       function updateSelectionLayer(view, tree, actor) {
         const { layer, fromPos, toPos } = selectionMap.get(actor);
-        const [fromIndex, toIndex] = tree.rangeToIndex([fromPos, toPos]);
+        const [fromIndex, toIndex] = tree.toIndexRange([fromPos, toPos]);
         const coords = view.coordsAtPos(Math.min(fromIndex, toIndex));
 
         layer.style.left = `${coords.left - 10}px`;
@@ -277,19 +277,6 @@
         return true;
       }
 
-      function encodeRange(tree, from, to) {
-        const range = tree.createRange(from, to);
-        const fromBytes = yorkie.converter.treePosToBytes(range[0]);
-        const toBytes = yorkie.converter.treePosToBytes(range[1]);
-        return [fromBytes, toBytes];
-      }
-
-      function decodeRange(fromBytes, toBytes) {
-        const from = yorkie.converter.bytesToTreePos(fromBytes);
-        const to = yorkie.converter.bytesToTreePos(toBytes);
-        return [from, to];
-      }
-
       /**
        * main is the entry point of the example.
        */
@@ -337,11 +324,10 @@
               });
 
               doc.update((root) => {
-                root.selection = encodeRange(
-                  root.tree,
+                root.selection = root.tree.toPosRange([
                   transaction.curSelection.from,
                   transaction.curSelection.to,
-                );
+                ]);
               });
               printLog();
               return;
@@ -395,11 +381,10 @@
                 }
               }
 
-              root.selection = encodeRange(
-                root.tree,
+              root.selection = root.tree.toPosRange([
                 transaction.curSelection.from,
                 transaction.curSelection.to,
-              );
+              ]);
             });
             printLog();
           },
@@ -423,12 +408,11 @@
                 op.key === 'selection'
               ) {
                 const selection = doc.getRoot().selection;
-                const range = decodeRange(selection[0], selection[1]);
                 displayRemoteSelection(
                   view,
                   root.tree,
-                  range[0],
-                  range[1],
+                  selection[0],
+                  selection[1],
                   actor,
                 );
               }

--- a/public/prosemirror.html
+++ b/public/prosemirror.html
@@ -525,9 +525,7 @@
         let node = head;
         while (node) {
           const nodeType = node.type;
-          const pos = `${node.pos.createdAt.getStructureAsString()}-${
-            node.pos.offset
-          }`;
+          const pos = `${node.pos.createdAt.toTestString()}-${node.pos.offset}`;
           if (nodeType === 'text') {
             arr.push({
               type: nodeType,

--- a/public/quill.html
+++ b/public/quill.html
@@ -34,7 +34,7 @@
 
       function displayLog(elem, textElem, doc) {
         elem.innerText = doc.toJSON();
-        textElem.innerText = doc.getRoot().content.getStructureAsString();
+        textElem.innerText = doc.getRoot().content.toTestString();
       }
 
       function toDeltaOperation(textValue) {

--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -256,8 +256,8 @@ function toTextNodePos(pos: RGATreeSplitNodePos): PbTextNodePos {
  */
 function toTreePos(pos: CRDTTreePos): PbTreePos {
   const pbTreePos = new PbTreePos();
-  pbTreePos.setCreatedAt(toTimeTicket(pos.createdAt));
-  pbTreePos.setOffset(pos.offset);
+  pbTreePos.setCreatedAt(toTimeTicket(pos.getCreatedAt()));
+  pbTreePos.setOffset(pos.getOffset());
   return pbTreePos;
 }
 
@@ -831,10 +831,10 @@ function fromTextNode(pbTextNode: PbTextNode): RGATreeSplitNode<CRDTTextValue> {
  * `fromTreePos` converts the given Protobuf format to model format.
  */
 function fromTreePos(pbTreePos: PbTreePos): CRDTTreePos {
-  return {
-    createdAt: fromTimeTicket(pbTreePos.getCreatedAt())!,
-    offset: pbTreePos.getOffset(),
-  };
+  return CRDTTreePos.of(
+    fromTimeTicket(pbTreePos.getCreatedAt())!,
+    pbTreePos.getOffset(),
+  );
 }
 
 /**

--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -1212,24 +1212,6 @@ function treeToBytes(tree: CRDTTree): Uint8Array {
 }
 
 /**
- * `treePosToBytes` converts the given CRDTTreePos to byte array.
- */
-function treePosToBytes(pos: CRDTTreePos): Uint8Array {
-  return toTreePos(pos).serializeBinary();
-}
-
-/**
- * `bytesToTreePos` creates an CRDTTreePos from the given bytes.
- */
-function bytesToTreePos(bytes: Uint8Array): CRDTTreePos {
-  if (!bytes) {
-    throw new Error('bytes is empty');
-  }
-  const pbTreePos = PbTreePos.deserializeBinary(bytes);
-  return fromTreePos(pbTreePos);
-}
-
-/**
  * `bytesToHex` creates an hex string from the given byte array.
  */
 function bytesToHex(bytes?: Uint8Array): string {
@@ -1279,6 +1261,4 @@ export const converter = {
   bytesToObject,
   toHexString,
   toUint8Array,
-  bytesToTreePos,
-  treePosToBytes,
 };

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -1171,7 +1171,7 @@ export class Client<P = Indexable> implements Observable<ClientEvent<P>> {
             logger.info(
               `[PP] c:"${this.getKey()}" sync d:"${docKey}", push:${localSize} pull:${remoteSize} cp:${respPack
                 .getCheckpoint()
-                .getStructureAsString()}`,
+                .toTestString()}`,
             );
           },
         )

--- a/src/document/change/change.ts
+++ b/src/document/change/change.ts
@@ -96,11 +96,11 @@ export class Change {
   }
 
   /**
-   * `getStructureAsString` returns a string containing the meta data of this change.
+   * `toTestString` returns a string containing the meta data of this change.
    */
-  public getStructureAsString(): string {
+  public toTestString(): string {
     return `${this.operations
-      .map((operation) => operation.getStructureAsString())
+      .map((operation) => operation.toTestString())
       .join(',')}`;
   }
 }

--- a/src/document/change/change_id.ts
+++ b/src/document/change/change_id.ts
@@ -113,9 +113,9 @@ export class ChangeID {
   }
 
   /**
-   * `getStructureAsString` returns a string containing the meta data of this ID.
+   * `toTestString` returns a string containing the meta data of this ID.
    */
-  public getStructureAsString(): string {
+  public toTestString(): string {
     if (!this.actor) {
       return `${this.lamport.toString()}:nil:${this.clientSeq}`;
     }

--- a/src/document/change/checkpoint.ts
+++ b/src/document/change/checkpoint.ts
@@ -99,10 +99,10 @@ export class Checkpoint {
   }
 
   /**
-   * `getStructureAsString` returns a string containing the meta data of this
+   * `toTestString` returns a string containing the meta data of this
    * checkpoint.
    */
-  public getStructureAsString(): string {
+  public toTestString(): string {
     return `serverSeq=${this.serverSeq}, clientSeq=${this.clientSeq}`;
   }
 }

--- a/src/document/crdt/array.ts
+++ b/src/document/crdt/array.ts
@@ -163,11 +163,11 @@ export class CRDTArray extends CRDTContainer {
   }
 
   /**
-   * `getStructureAsString` returns a String containing the meta data of this value
+   * `toTestString` returns a String containing the meta data of this value
    * for debugging purpose.
    */
-  public getStructureAsString(): string {
-    return this.elements.getStructureAsString();
+  public toTestString(): string {
+    return this.elements.toTestString();
   }
 
   /**

--- a/src/document/crdt/rga_tree_list.ts
+++ b/src/document/crdt/rga_tree_list.ts
@@ -387,10 +387,10 @@ export class RGATreeList {
   }
 
   /**
-   * `getStructureAsString` returns a String containing the meta data of the node id
+   * `toTestString` returns a String containing the meta data of the node id
    * for debugging purpose.
    */
-  public getStructureAsString(): string {
+  public toTestString(): string {
     const json = [];
 
     for (const node of this) {

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -23,6 +23,7 @@ import {
   InitialTimeTicket,
   MaxTimeTicket,
   TimeTicket,
+  TimeTicketStruct,
 } from '@yorkie-js-sdk/src/document/time/ticket';
 
 export interface ValueChange<T> {
@@ -36,6 +37,11 @@ interface RGATreeSplitValue {
   length: number;
   substring(indexStart: number, indexEnd?: number): RGATreeSplitValue;
 }
+
+type RGATreeSplitNodeIDStruct = {
+  createdAt: TimeTicketStruct;
+  offset: number;
+};
 
 /**
  * `RGATreeSplitNodeID` is an ID of RGATreeSplitNode.
@@ -95,11 +101,28 @@ export class RGATreeSplitNodeID {
   }
 
   /**
-   * `getStructureAsString` returns a String containing
+   * `toStructure` returns the structure of this node id.
+   */
+  public toStructure(): RGATreeSplitNodeIDStruct {
+    return {
+      createdAt: this.createdAt.toStructure(),
+      offset: this.offset,
+    };
+  }
+
+  /**
+   * `toTestString` returns a String containing
    * the meta data of the node id for debugging purpose.
    */
-  public getStructureAsString(): string {
-    return `${this.createdAt.getStructureAsString()}:${this.offset}`;
+  public toTestString(): string {
+    return `${this.createdAt.toTestString()}:${this.offset}`;
+  }
+
+  /**
+   * `toIDString` returns a string that can be used as an ID for this node id.
+   */
+  public toIDString(): string {
+    return `${this.createdAt.toIDString()}:${this.offset}`;
   }
 }
 
@@ -152,11 +175,11 @@ export class RGATreeSplitNodePos {
   }
 
   /**
-   *`getStructureAsString` returns a String containing
+   *`toTestString` returns a String containing
    * the meta data of the position for debugging purpose.
    */
-  public getStructureAsString(): string {
-    return `${this.id.getStructureAsString()}:${this.relativeOffset}`;
+  public toTestString(): string {
+    return `${this.id.toTestString()}:${this.relativeOffset}`;
   }
 
   /**
@@ -405,11 +428,11 @@ export class RGATreeSplitNode<
   }
 
   /**
-   * `getStructureAsString` returns a String containing
+   * `toTestString` returns a String containing
    * the meta data of the node for debugging purpose.
    */
-  public getStructureAsString(): string {
-    return `${this.id.getStructureAsString()} ${this.value ? this.value : ''}`;
+  public toTestString(): string {
+    return `${this.id.toTestString()} ${this.value ? this.value : ''}`;
   }
 
   private splitValue(offset: number): T {
@@ -547,7 +570,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
       : this.findFloorNode(absoluteID);
     if (!node) {
       logger.fatal(
-        `the node of the given id should be found: ${absoluteID.getStructureAsString()}`,
+        `the node of the given id should be found: ${absoluteID.toTestString()}`,
       );
     }
     const index = this.treeByIndex.indexOf(node!);
@@ -635,18 +658,18 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
   }
 
   /**
-   * `getStructureAsString` returns a String containing the meta data of the node
+   * `toTestString` returns a String containing the meta data of the node
    * for debugging purpose.
    */
-  public getStructureAsString(): string {
+  public toTestString(): string {
     const result = [];
 
     let node: RGATreeSplitNode<T> | undefined = this.head;
     while (node) {
       if (node.isRemoved()) {
-        result.push(`{${node.getStructureAsString()}}`);
+        result.push(`{${node.toTestString()}}`);
       } else {
-        result.push(`[${node.getStructureAsString()}]`);
+        result.push(`[${node.toTestString()}]`);
       }
 
       node = node.getNext();
@@ -700,7 +723,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
     let node = this.findFloorNode(id);
     if (!node) {
       logger.fatal(
-        `the node of the given id should be found: ${id.getStructureAsString()}`,
+        `the node of the given id should be found: ${id.toTestString()}`,
       );
     }
 
@@ -810,7 +833,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
       ) {
         createdAtMapByActor.set(actorID, node.getID().getCreatedAt());
       }
-      removedNodeMap.set(node.getID().getStructureAsString(), node);
+      removedNodeMap.set(node.getID().toIDString(), node);
       node.remove(editedAt);
     }
     // Finally remove index nodes of tombstones.
@@ -937,7 +960,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
         this.treeByIndex.delete(node);
         this.purge(node);
         this.treeByID.remove(node.getID());
-        this.removedNodeMap.delete(node.getID().getStructureAsString());
+        this.removedNodeMap.delete(node.getID().toIDString());
         count++;
       }
     }

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -38,6 +38,10 @@ interface RGATreeSplitValue {
   substring(indexStart: number, indexEnd?: number): RGATreeSplitValue;
 }
 
+/**
+ * `RGATreeSplitNodeIDStruct` is a structure represents the meta data of the node id.
+ * It is used to serialize and deserialize the node id.
+ */
 type RGATreeSplitNodeIDStruct = {
   createdAt: TimeTicketStruct;
   offset: number;

--- a/src/document/crdt/text.ts
+++ b/src/document/crdt/text.ts
@@ -379,11 +379,11 @@ export class CRDTText<A extends Indexable = Indexable> extends CRDTGCElement {
   }
 
   /**
-   * `getStructureAsString` returns a String containing the meta data of this value
+   * `toTestString` returns a String containing the meta data of this value
    * for debugging purpose.
    */
-  public getStructureAsString(): string {
-    return this.rgaTreeSplit.getStructureAsString();
+  public toTestString(): string {
+    return this.rgaTreeSplit.toTestString();
   }
 
   /**

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -133,6 +133,13 @@ export class CRDTTreePos {
       offset: this.offset,
     };
   }
+
+  /**
+   * `toIDString` returns a string that can be used as an ID for this position.
+   */
+  public toIDString(): string {
+    return `${this.createdAt.toIDString()}:${this.offset}`;
+  }
 }
 
 export type CRDTTreePosStruct = { createdAt: TimeTicketStruct; offset: number };
@@ -336,9 +343,9 @@ export function toXML(node: CRDTTreeNode): string {
 }
 
 /**
- * `toStructure` converts the given CRDTNode JSON for debugging.
+ * `toTestTreeNode` converts the given CRDTNode JSON for debugging.
  */
-function toStructure(node: CRDTTreeNode): TreeNodeForTest {
+function toTestTreeNode(node: CRDTTreeNode): TreeNodeForTest {
   if (node.isText) {
     const currentNode = node;
     return {
@@ -351,7 +358,7 @@ function toStructure(node: CRDTTreeNode): TreeNodeForTest {
 
   return {
     type: node.type,
-    children: node.children.map(toStructure),
+    children: node.children.map(toTestTreeNode),
     size: node.size,
     isRemoved: node.isRemoved,
   };
@@ -592,12 +599,7 @@ export class CRDTTree extends CRDTGCElement {
         node.remove(editedAt);
 
         if (node.isRemoved) {
-          this.removedNodeMap.set(
-            `${node
-              .getCreatedAt()
-              .getStructureAsString()}:${node.pos.getOffset()}`,
-            node,
-          );
+          this.removedNodeMap.set(node.pos.toIDString(), node);
         }
       }
 
@@ -717,9 +719,7 @@ export class CRDTTree extends CRDTGCElement {
     [...nodesToRemoved].forEach((node) => {
       this.nodeMapByPos.remove(node.pos);
       this.purge(node);
-      this.removedNodeMap.delete(
-        `${node.getCreatedAt().getStructureAsString()}:${node.pos.getOffset()}`,
-      );
+      this.removedNodeMap.delete(node.pos.toIDString());
     });
 
     return count;
@@ -853,10 +853,10 @@ export class CRDTTree extends CRDTGCElement {
   }
 
   /**
-   * `toStructure` returns the JSON of this tree for debugging.
+   * `toTestTreeNode` returns the JSON of this tree for debugging.
    */
-  public toStructure(): TreeNodeForTest {
-    return toStructure(this.indexTree.getRoot());
+  public toTestTreeNode(): TreeNodeForTest {
+    return toTestTreeNode(this.indexTree.getRoot());
   }
 
   /**

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -125,11 +125,11 @@ export class CRDTTreePos {
   }
 
   /**
-   * `getStructure` returns the structure of this position.
+   * `toStructure` returns the structure of this position.
    */
-  public getStructure(): CRDTTreePosStruct {
+  public toStructure(): CRDTTreePosStruct {
     return {
-      createdAt: this.createdAt.getStructure(),
+      createdAt: this.createdAt.toStructure(),
       offset: this.offset,
     };
   }
@@ -957,12 +957,12 @@ export class CRDTTree extends CRDTGCElement {
    */
   public toPosRange(range: [number, number]): TreeRangeStruct {
     const [fromIdx, toIdx] = range;
-    const fromPos = this.findPos(fromIdx).getStructure();
+    const fromPos = this.findPos(fromIdx).toStructure();
     if (fromIdx === toIdx) {
       return [fromPos, fromPos];
     }
 
-    return [fromPos, this.findPos(toIdx).getStructure()];
+    return [fromPos, this.findPos(toIdx).toStructure()];
   }
 
   /**

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -14,9 +14,11 @@
  * limitations under the License.
  */
 
+import Long from 'long';
 import {
   TimeTicket,
   InitialTimeTicket,
+  TimeTicketStruct,
 } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTGCElement } from '@yorkie-js-sdk/src/document/crdt/element';
 import {
@@ -80,52 +82,88 @@ export interface TreeChange {
 }
 
 /**
+ * `CRDTTreePos` represent a position in the tree. It indicates the virtual
+ * location in the tree, so whether the node is splitted or not, we can find
+ * the adjacent node to pos by calling `map.floorEntry()`.
+ */
+export class CRDTTreePos {
+  /**
+   * `createdAt` is the creation time of the node.
+   */
+  private createdAt: TimeTicket;
+
+  /**
+   * `offset` is the distance from the beginning of the node if the node is
+   * split.
+   */
+  private offset: number;
+
+  constructor(createdAt: TimeTicket, offset: number) {
+    this.createdAt = createdAt;
+    this.offset = offset;
+  }
+
+  /**
+   * `of` creates a new instance of CRDTTreePos.
+   */
+  public static of(createdAt: TimeTicket, offset: number): CRDTTreePos {
+    return new CRDTTreePos(createdAt, offset);
+  }
+
+  /**
+   * `getCreatedAt` returns the creation time of the node.
+   */
+  public getCreatedAt(): TimeTicket {
+    return this.createdAt;
+  }
+
+  /**
+   * `getOffset` returns returns the offset of the node.
+   */
+  public getOffset(): number {
+    return this.offset;
+  }
+
+  /**
+   * `getStructure` returns the structure of this position.
+   */
+  public getStructure(): CRDTTreePosStruct {
+    return {
+      createdAt: this.createdAt.getStructure(),
+      offset: this.offset,
+    };
+  }
+}
+
+export type CRDTTreePosStruct = { createdAt: TimeTicketStruct; offset: number };
+
+/**
  * `InitialCRDTTreePos` is the initial position of the tree.
  */
-export const InitialCRDTTreePos = {
-  createdAt: InitialTimeTicket,
-  offset: 0,
-};
+export const InitialCRDTTreePos = CRDTTreePos.of(InitialTimeTicket, 0);
 
 /**
  * `compareCRDTTreePos` compares the given two CRDTTreePos.
  */
 function compareCRDTTreePos(posA: CRDTTreePos, posB: CRDTTreePos): number {
-  const compare = posA.createdAt.compare(posB.createdAt);
+  const compare = posA.getCreatedAt().compare(posB.getCreatedAt());
   if (compare !== 0) {
     return compare;
   }
 
-  if (posA.offset > posB.offset) {
+  if (posA.getOffset() > posB.getOffset()) {
     return 1;
-  } else if (posA.offset < posB.offset) {
+  } else if (posA.getOffset() < posB.getOffset()) {
     return -1;
   }
   return 0;
 }
 
 /**
- * `CRDTTreePos` represent a position in the tree. It indicates the virtual
- * location in the tree, so whether the node is splitted or not, we can find
- * the adjacent node to pos by calling `map.floorEntry()`.
- */
-export interface CRDTTreePos {
-  /**
-   * `createdAt` is the creation time of the node.
-   */
-  createdAt: TimeTicket;
-
-  /**
-   * `offset` is the distance from the beginning of the node if the node is
-   * split.
-   */
-  offset: number;
-}
-
-/**
  * `TreeRange` represents a pair of CRDTTreePos.
  */
 export type TreeRange = [CRDTTreePos, CRDTTreePos];
+export type TreeRangeStruct = [CRDTTreePosStruct, CRDTTreePosStruct];
 
 /**
  * `CRDTTreeNode` is a node of CRDTTree. It is includes the logical clock and
@@ -249,10 +287,7 @@ export class CRDTTreeNode extends IndexTreeNode<CRDTTreeNode> {
    */
   clone(offset: number): CRDTTreeNode {
     return new CRDTTreeNode(
-      {
-        createdAt: this.pos.createdAt,
-        offset,
-      },
+      CRDTTreePos.of(this.pos.getCreatedAt(), offset),
       this.type,
     );
   }
@@ -261,7 +296,7 @@ export class CRDTTreeNode extends IndexTreeNode<CRDTTreeNode> {
    * `getCreatedAt` returns the creation time of this element.
    */
   public getCreatedAt(): TimeTicket {
-    return this.pos.createdAt;
+    return this.pos.getCreatedAt();
   }
 }
 
@@ -407,7 +442,7 @@ export class CRDTTree extends CRDTGCElement {
     // handle the same position insertion of RGA.
     let current = treePos;
     while (
-      current.node.next?.pos.createdAt.after(editedAt) &&
+      current.node.next?.pos.getCreatedAt().after(editedAt) &&
       current.node.parent === current.node.next.parent
     ) {
       current = {
@@ -441,7 +476,7 @@ export class CRDTTree extends CRDTGCElement {
     // handle the same position insertion of RGA.
     let current = treePos;
     while (
-      current.node.next?.pos.createdAt.after(editedAt) &&
+      current.node.next?.pos.getCreatedAt().after(editedAt) &&
       current.node.parent === current.node.next.parent
     ) {
       current = {
@@ -558,7 +593,9 @@ export class CRDTTree extends CRDTGCElement {
 
         if (node.isRemoved) {
           this.removedNodeMap.set(
-            `${node.getCreatedAt().getStructureAsString()}:${node.pos.offset}`,
+            `${node
+              .getCreatedAt()
+              .getStructureAsString()}:${node.pos.getOffset()}`,
             node,
           );
         }
@@ -681,7 +718,7 @@ export class CRDTTree extends CRDTGCElement {
       this.nodeMapByPos.remove(node.pos);
       this.purge(node);
       this.removedNodeMap.delete(
-        `${node.getCreatedAt().getStructureAsString()}:${node.pos.offset}`,
+        `${node.getCreatedAt().getStructureAsString()}:${node.pos.getOffset()}`,
       );
     });
 
@@ -713,10 +750,10 @@ export class CRDTTree extends CRDTGCElement {
   public findPos(index: number, preferText = true): CRDTTreePos {
     const treePos = this.indexTree.findTreePos(index, preferText);
 
-    return {
-      createdAt: treePos.node.pos.createdAt,
-      offset: treePos.node.pos.offset + treePos.offset,
-    };
+    return CRDTTreePos.of(
+      treePos.node.pos.getCreatedAt(),
+      treePos.node.pos.getOffset() + treePos.offset,
+    );
   }
 
   /**
@@ -774,10 +811,10 @@ export class CRDTTree extends CRDTGCElement {
   public pathToPos(path: Array<number>): CRDTTreePos {
     const treePos = this.indexTree.pathToTreePos(path);
 
-    return {
-      createdAt: treePos.node.pos.createdAt,
-      offset: treePos.node.pos.offset + treePos.offset,
-    };
+    return CRDTTreePos.of(
+      treePos.node.pos.getCreatedAt(),
+      treePos.node.pos.getOffset() + treePos.offset,
+    );
   }
 
   /**
@@ -869,19 +906,23 @@ export class CRDTTree extends CRDTGCElement {
    */
   private toTreePos(pos: CRDTTreePos): TreePos<CRDTTreeNode> | undefined {
     const entry = this.nodeMapByPos.floorEntry(pos);
-    if (!entry || !entry.key.createdAt.equals(pos.createdAt)) {
+    if (!entry || !entry.key.getCreatedAt().equals(pos.getCreatedAt())) {
       return;
     }
 
     // Choose the left node if the position is on the boundary of the split nodes.
     let node = entry.value;
-    if (pos.offset > 0 && pos.offset === node.pos.offset && node.insPrev) {
+    if (
+      pos.getOffset() > 0 &&
+      pos.getOffset() === node.pos.getOffset() &&
+      node.insPrev
+    ) {
       node = node.insPrev;
     }
 
     return {
       node,
-      offset: pos.offset - node.pos.offset,
+      offset: pos.getOffset() - node.pos.getOffset(),
     };
   }
 
@@ -912,10 +953,40 @@ export class CRDTTree extends CRDTGCElement {
   }
 
   /**
-   * `rangeToIndex` returns pair of integer offsets of the given Tree.
+   * `toPosRange` converts the integer index range into the Tree position range structure.
    */
-  public rangeToIndex(range: TreeRange): [number, number] {
-    return [this.toIndex(range[0]), this.toIndex(range[1])];
+  public toPosRange(range: [number, number]): TreeRangeStruct {
+    const [fromIdx, toIdx] = range;
+    const fromPos = this.findPos(fromIdx).getStructure();
+    if (fromIdx === toIdx) {
+      return [fromPos, fromPos];
+    }
+
+    return [fromPos, this.findPos(toIdx).getStructure()];
+  }
+
+  /**
+   * `toIndexRange` converts the Tree position range into the integer index range.
+   */
+  public toIndexRange(range: TreeRangeStruct): [number, number] {
+    const [fromPosStruct, toPosStruct] = range;
+    const fromPos = CRDTTreePos.of(
+      TimeTicket.of(
+        Long.fromString(fromPosStruct.createdAt.lamport, true),
+        fromPosStruct.createdAt.delimiter,
+        fromPosStruct.createdAt.actorID,
+      ),
+      fromPosStruct.offset,
+    );
+    const toPos = CRDTTreePos.of(
+      TimeTicket.of(
+        Long.fromString(toPosStruct.createdAt.lamport, true),
+        toPosStruct.createdAt.delimiter,
+        toPosStruct.createdAt.actorID,
+      ),
+      toPosStruct.offset,
+    );
+    return [this.toIndex(fromPos), this.toIndex(toPos)];
   }
 
   /**

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -142,6 +142,10 @@ export class CRDTTreePos {
   }
 }
 
+/**
+ * `CRDTTreePosStruct` represents the structure of CRDTTreePos.
+ * It is used to serialize and deserialize the CRDTTreePos.
+ */
 export type CRDTTreePosStruct = { createdAt: TimeTicketStruct; offset: number };
 
 /**
@@ -170,6 +174,11 @@ function compareCRDTTreePos(posA: CRDTTreePos, posB: CRDTTreePos): number {
  * `TreeRange` represents a pair of CRDTTreePos.
  */
 export type TreeRange = [CRDTTreePos, CRDTTreePos];
+
+/**
+ * `TreeRangeStruct` represents the structure of TreeRange.
+ * It is used to serialize and deserialize the TreeRange.
+ */
 export type TreeRangeStruct = [CRDTTreePosStruct, CRDTTreePosStruct];
 
 /**

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -739,9 +739,7 @@ export class Document<T> {
         changes
           .map(
             (change) =>
-              `${change
-                .getID()
-                .getStructureAsString()}\t${change.getStructureAsString()}`,
+              `${change.getID().toTestString()}\t${change.toTestString()}`,
           )
           .join('\n'),
       );

--- a/src/document/json/array.ts
+++ b/src/document/json/array.ts
@@ -96,10 +96,10 @@ export type JSONArray<T> = {
   moveLast?(id: TimeTicket): void;
 
   /**
-   * `getStructureAsString` returns a String containing the meta data of the node
+   * `toTestString` returns a String containing the meta data of the node
    * for debugging purpose.
    */
-  getStructureAsString?(): string;
+  toTestString?(): string;
 } & Array<T>;
 
 /**
@@ -288,8 +288,8 @@ export class ArrayProxy {
               fromIndex,
             );
           };
-        } else if (method === 'getStructureAsString') {
-          return (): string => ArrayProxy.getStructureAsString(target);
+        } else if (method === 'toTestString') {
+          return (): string => ArrayProxy.toTestString(target);
         } else if (
           typeof method === 'string' &&
           isReadOnlyArrayMethod(method)
@@ -705,11 +705,11 @@ export class ArrayProxy {
     return -1;
   }
   /**
-   * `getStructureAsString` returns a String containing the meta data of the node
+   * `toTestString` returns a String containing the meta data of the node
    * for debugging purpose.
    */
-  public static getStructureAsString(target: CRDTArray): string {
-    return target.getStructureAsString();
+  public static toTestString(target: CRDTArray): string {
+    return target.toTestString();
   }
 
   /**

--- a/src/document/json/text.ts
+++ b/src/document/json/text.ts
@@ -75,7 +75,7 @@ export class Text<A extends Indexable = Indexable> {
     const range = this.text.createRange(fromIdx, toIdx);
     if (logger.isEnabled(LogLevel.Debug)) {
       logger.debug(
-        `EDIT: f:${fromIdx}->${range[0].getStructureAsString()}, t:${toIdx}->${range[1].getStructureAsString()} c:${content}`,
+        `EDIT: f:${fromIdx}->${range[0].toTestString()}, t:${toIdx}->${range[1].toTestString()} c:${content}`,
       );
     }
     const attrs = attributes ? stringifyObjectValues(attributes) : undefined;
@@ -137,7 +137,7 @@ export class Text<A extends Indexable = Indexable> {
     const range = this.text.createRange(fromIdx, toIdx);
     if (logger.isEnabled(LogLevel.Debug)) {
       logger.debug(
-        `STYL: f:${fromIdx}->${range[0].getStructureAsString()}, t:${toIdx}->${range[1].getStructureAsString()} a:${JSON.stringify(
+        `STYL: f:${fromIdx}->${range[0].toTestString()}, t:${toIdx}->${range[1].toTestString()} a:${JSON.stringify(
           attributes,
         )}`,
       );
@@ -172,7 +172,7 @@ export class Text<A extends Indexable = Indexable> {
     const range = this.text.createRange(fromIdx, toIdx);
     if (logger.isEnabled(LogLevel.Debug)) {
       logger.debug(
-        `SELT: f:${fromIdx}->${range[0].getStructureAsString()}, t:${toIdx}->${range[1].getStructureAsString()}`,
+        `SELT: f:${fromIdx}->${range[0].toTestString()}, t:${toIdx}->${range[1].toTestString()}`,
       );
     }
     const ticket = this.context.issueTimeTicket();
@@ -186,17 +186,17 @@ export class Text<A extends Indexable = Indexable> {
   }
 
   /**
-   * `getStructureAsString` returns a String containing the meta data of the node
+   * `toTestString` returns a String containing the meta data of the node
    * for debugging purpose.
    */
-  getStructureAsString(): string {
+  toTestString(): string {
     if (!this.context || !this.text) {
       logger.fatal('it is not initialized yet');
       // @ts-ignore
       return;
     }
 
-    return this.text.getStructureAsString();
+    return this.text.toTestString();
   }
 
   /**

--- a/src/document/operation/add_operation.ts
+++ b/src/document/operation/add_operation.ts
@@ -86,10 +86,10 @@ export class AddOperation extends Operation {
   }
 
   /**
-   * `getStructureAsString` returns a string containing the meta data.
+   * `toTestString` returns a string containing the meta data.
    */
-  public getStructureAsString(): string {
-    return `${this.getParentCreatedAt().getStructureAsString()}.ADD`;
+  public toTestString(): string {
+    return `${this.getParentCreatedAt().toTestString()}.ADD`;
   }
 
   /**

--- a/src/document/operation/edit_operation.ts
+++ b/src/document/operation/edit_operation.ts
@@ -124,12 +124,12 @@ export class EditOperation extends Operation {
   }
 
   /**
-   * `getStructureAsString` returns a string containing the meta data.
+   * `toTestString` returns a string containing the meta data.
    */
-  public getStructureAsString(): string {
-    const parent = this.getParentCreatedAt().getStructureAsString();
-    const fromPos = this.fromPos.getStructureAsString();
-    const toPos = this.toPos.getStructureAsString();
+  public toTestString(): string {
+    const parent = this.getParentCreatedAt().toTestString();
+    const fromPos = this.fromPos.toTestString();
+    const toPos = this.toPos.toTestString();
     const content = this.content;
     return `${parent}.EDIT(${fromPos},${toPos},${content})`;
   }

--- a/src/document/operation/increase_operation.ts
+++ b/src/document/operation/increase_operation.ts
@@ -83,10 +83,10 @@ export class IncreaseOperation extends Operation {
   }
 
   /**
-   * `getStructureAsString` returns a string containing the meta data.
+   * `toTestString` returns a string containing the meta data.
    */
-  public getStructureAsString(): string {
-    return `${this.getParentCreatedAt().getStructureAsString()}.INCREASE`;
+  public toTestString(): string {
+    return `${this.getParentCreatedAt().toTestString()}.INCREASE`;
   }
 
   /**

--- a/src/document/operation/move_operation.ts
+++ b/src/document/operation/move_operation.ts
@@ -91,10 +91,10 @@ export class MoveOperation extends Operation {
   }
 
   /**
-   * `getStructureAsString` returns a string containing the meta data.
+   * `toTestString` returns a string containing the meta data.
    */
-  public getStructureAsString(): string {
-    return `${this.getParentCreatedAt().getStructureAsString()}.MOVE`;
+  public toTestString(): string {
+    return `${this.getParentCreatedAt().toTestString()}.MOVE`;
   }
 
   /**

--- a/src/document/operation/operation.ts
+++ b/src/document/operation/operation.ts
@@ -165,9 +165,9 @@ export abstract class Operation {
   public abstract getEffectedCreatedAt(): TimeTicket;
 
   /**
-   * `getStructureAsString` returns a string containing the meta data.
+   * `toTestString` returns a string containing the meta data for debugging purpose.
    */
-  public abstract getStructureAsString(): string;
+  public abstract toTestString(): string;
 
   /**
    * `execute` executes this operation on the given `CRDTRoot`.

--- a/src/document/operation/remove_operation.ts
+++ b/src/document/operation/remove_operation.ts
@@ -91,10 +91,10 @@ export class RemoveOperation extends Operation {
   }
 
   /**
-   * `getStructureAsString` returns a string containing the meta data.
+   * `toTestString` returns a string containing the meta data.
    */
-  public getStructureAsString(): string {
-    return `${this.getParentCreatedAt().getStructureAsString()}.REMOVE`;
+  public toTestString(): string {
+    return `${this.getParentCreatedAt().toTestString()}.REMOVE`;
   }
 
   /**

--- a/src/document/operation/select_operation.ts
+++ b/src/document/operation/select_operation.ts
@@ -92,12 +92,12 @@ export class SelectOperation extends Operation {
   }
 
   /**
-   * `getStructureAsString` returns a string containing the meta data.
+   * `toTestString` returns a string containing the meta data.
    */
-  public getStructureAsString(): string {
-    const parent = this.getParentCreatedAt().getStructureAsString();
-    const fromPos = this.fromPos.getStructureAsString();
-    const toPos = this.toPos.getStructureAsString();
+  public toTestString(): string {
+    const parent = this.getParentCreatedAt().toTestString();
+    const fromPos = this.fromPos.toTestString();
+    const toPos = this.toPos.toTestString();
     return `${parent}.SELT(${fromPos},${toPos})`;
   }
 

--- a/src/document/operation/set_operation.ts
+++ b/src/document/operation/set_operation.ts
@@ -87,10 +87,10 @@ export class SetOperation extends Operation {
   }
 
   /**
-   * `getStructureAsString` returns a string containing the meta data.
+   * `toTestString` returns a string containing the meta data.
    */
-  public getStructureAsString(): string {
-    return `${this.getParentCreatedAt().getStructureAsString()}.SET`;
+  public toTestString(): string {
+    return `${this.getParentCreatedAt().toTestString()}.SET`;
   }
 
   /**

--- a/src/document/operation/style_operation.ts
+++ b/src/document/operation/style_operation.ts
@@ -101,12 +101,12 @@ export class StyleOperation extends Operation {
   }
 
   /**
-   * `getStructureAsString` returns a string containing the meta data.
+   * `toTestString` returns a string containing the meta data.
    */
-  public getStructureAsString(): string {
-    const parent = this.getParentCreatedAt().getStructureAsString();
-    const fromPos = this.fromPos.getStructureAsString();
-    const toPos = this.toPos.getStructureAsString();
+  public toTestString(): string {
+    const parent = this.getParentCreatedAt().toTestString();
+    const fromPos = this.fromPos.toTestString();
+    const toPos = this.toPos.toTestString();
     const attributes = this.attributes;
     return `${parent}.STYL(${fromPos},${toPos},${JSON.stringify(attributes)})`;
   }

--- a/src/document/operation/tree_edit_operation.ts
+++ b/src/document/operation/tree_edit_operation.ts
@@ -86,8 +86,8 @@ export class TreeEditOperation extends Operation {
     );
 
     if (
-      !this.fromPos.createdAt.equals(this.toPos.createdAt) ||
-      this.fromPos.offset !== this.toPos.offset
+      !this.fromPos.getCreatedAt().equals(this.toPos.getCreatedAt()) ||
+      this.fromPos.getOffset() !== this.toPos.getOffset()
     ) {
       root.registerElementHasRemovedNodes(tree);
     }
@@ -116,12 +116,12 @@ export class TreeEditOperation extends Operation {
    */
   public getStructureAsString(): string {
     const parent = this.getParentCreatedAt().getStructureAsString();
-    const fromPos = `${this.fromPos.createdAt.getStructureAsString()}:${
-      this.fromPos.offset
-    }`;
-    const toPos = `${this.toPos.createdAt.getStructureAsString()}:${
-      this.toPos.offset
-    }`;
+    const fromPos = `${this.fromPos
+      .getCreatedAt()
+      .getStructureAsString()}:${this.fromPos.getOffset()}`;
+    const toPos = `${this.toPos
+      .getCreatedAt()
+      .getStructureAsString()}:${this.toPos.getOffset()}`;
     const content = this.content;
     return `${parent}.EDIT(${fromPos},${toPos},${content})`;
   }

--- a/src/document/operation/tree_edit_operation.ts
+++ b/src/document/operation/tree_edit_operation.ts
@@ -112,16 +112,16 @@ export class TreeEditOperation extends Operation {
   }
 
   /**
-   * `getStructureAsString` returns a string containing the meta data.
+   * `toTestString` returns a string containing the meta data.
    */
-  public getStructureAsString(): string {
-    const parent = this.getParentCreatedAt().getStructureAsString();
+  public toTestString(): string {
+    const parent = this.getParentCreatedAt().toTestString();
     const fromPos = `${this.fromPos
       .getCreatedAt()
-      .getStructureAsString()}:${this.fromPos.getOffset()}`;
+      .toTestString()}:${this.fromPos.getOffset()}`;
     const toPos = `${this.toPos
       .getCreatedAt()
-      .getStructureAsString()}:${this.toPos.getOffset()}`;
+      .toTestString()}:${this.toPos.getOffset()}`;
     const content = this.content;
     return `${parent}.EDIT(${fromPos},${toPos},${content})`;
   }

--- a/src/document/operation/tree_style_operation.ts
+++ b/src/document/operation/tree_style_operation.ts
@@ -106,16 +106,16 @@ export class TreeStyleOperation extends Operation {
   }
 
   /**
-   * `getStructureAsString` returns a string containing the meta data.
+   * `toTestString` returns a string containing the meta data.
    */
-  public getStructureAsString(): string {
-    const parent = this.getParentCreatedAt().getStructureAsString();
+  public toTestString(): string {
+    const parent = this.getParentCreatedAt().toTestString();
     const fromPos = `${this.fromPos
       .getCreatedAt()
-      .getStructureAsString()}:${this.fromPos.getOffset()}`;
+      .toTestString()}:${this.fromPos.getOffset()}`;
     const toPos = `${this.toPos
       .getCreatedAt()
-      .getStructureAsString()}:${this.toPos.getOffset()}`;
+      .toTestString()}:${this.toPos.getOffset()}`;
 
     return `${parent}.STYLE(${fromPos},${toPos},${Object.entries(
       this.attributes || {},

--- a/src/document/operation/tree_style_operation.ts
+++ b/src/document/operation/tree_style_operation.ts
@@ -110,12 +110,12 @@ export class TreeStyleOperation extends Operation {
    */
   public getStructureAsString(): string {
     const parent = this.getParentCreatedAt().getStructureAsString();
-    const fromPos = `${this.fromPos.createdAt.getStructureAsString()}:${
-      this.fromPos.offset
-    }`;
-    const toPos = `${this.toPos.createdAt.getStructureAsString()}:${
-      this.toPos.offset
-    }`;
+    const fromPos = `${this.fromPos
+      .getCreatedAt()
+      .getStructureAsString()}:${this.fromPos.getOffset()}`;
+    const toPos = `${this.toPos
+      .getCreatedAt()
+      .getStructureAsString()}:${this.toPos.getOffset()}`;
 
     return `${parent}.STYLE(${fromPos},${toPos},${Object.entries(
       this.attributes || {},

--- a/src/document/time/ticket.ts
+++ b/src/document/time/ticket.ts
@@ -29,6 +29,12 @@ export const TicketComparator: Comparator<TimeTicket> = (
   return p1.compare(p2);
 };
 
+export type TimeTicketStruct = {
+  lamport: string;
+  delimiter: number;
+  actorID: ActorID | undefined;
+};
+
 /**
  * `TimeTicket` is a timestamp of the logical clock. Ticket is immutable.
  * It is created by `ChangeID`.
@@ -66,6 +72,17 @@ export class TimeTicket {
       return `${this.lamport.toString()}:nil:${this.delimiter}`;
     }
     return `${this.lamport.toString()}:${this.actorID}:${this.delimiter}`;
+  }
+
+  /**
+   * `getStructure` returns the structure of this Ticket.
+   */
+  public getStructure(): TimeTicketStruct {
+    return {
+      lamport: this.getLamportAsString(),
+      delimiter: this.getDelimiter(),
+      actorID: this.getActorID(),
+    };
   }
 
   /**

--- a/src/document/time/ticket.ts
+++ b/src/document/time/ticket.ts
@@ -86,10 +86,10 @@ export class TimeTicket {
   }
 
   /**
-   * `getStructureAsString` returns a string containing the meta data of the ticket
+   * `toTestString` returns a string containing the meta data of the ticket
    * for debugging purpose.
    */
-  public getStructureAsString(): string {
+  public toTestString(): string {
     if (!this.actorID) {
       return `${this.lamport.toString()}:nil:${this.delimiter}`;
     }

--- a/src/document/time/ticket.ts
+++ b/src/document/time/ticket.ts
@@ -75,9 +75,9 @@ export class TimeTicket {
   }
 
   /**
-   * `getStructure` returns the structure of this Ticket.
+   * `toStructure` returns the structure of this Ticket.
    */
-  public getStructure(): TimeTicketStruct {
+  public toStructure(): TimeTicketStruct {
     return {
       lamport: this.getLamportAsString(),
       delimiter: this.getDelimiter(),

--- a/src/document/time/ticket.ts
+++ b/src/document/time/ticket.ts
@@ -29,6 +29,10 @@ export const TicketComparator: Comparator<TimeTicket> = (
   return p1.compare(p2);
 };
 
+/**
+ * `TimeTicketStruct` is a structure represents the meta data of the ticket.
+ * It is used to serialize and deserialize the ticket.
+ */
 export type TimeTicketStruct = {
   lamport: string;
   delimiter: number;

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -415,10 +415,10 @@ export class SplayTree<V> {
   }
 
   /**
-   * `getStructureAsString` returns a string containing the meta data of the Node
+   * `toTestString` returns a string containing the meta data of the Node
    * for debugging purpose.
    */
-  public getStructureAsString(): string {
+  public toTestString(): string {
     const metaString: Array<SplayNode<V>> = [];
     this.traverseInorder(this.root!, metaString);
     return metaString

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -20,7 +20,6 @@ import { Text } from '@yorkie-js-sdk/src/document/json/text';
 import { Tree } from '@yorkie-js-sdk/src/document/json/tree';
 import { Counter } from '@yorkie-js-sdk/src/document/json/counter';
 import { CounterType } from '@yorkie-js-sdk/src/document/crdt/counter';
-import { converter } from '@yorkie-js-sdk/src/api/converter';
 
 export {
   Client,
@@ -96,7 +95,7 @@ export {
   TextNode,
 } from '@yorkie-js-sdk/src/document/json/tree';
 export { Change } from '@yorkie-js-sdk/src/document/change/change';
-export { converter };
+export { converter } from '@yorkie-js-sdk/src/api/converter';
 
 /**
  * The top-level yorkie namespace with additional properties.
@@ -117,7 +116,6 @@ const yorkie = {
   Tree,
   IntType: CounterType.IntegerCnt,
   LongType: CounterType.LongCnt,
-  converter,
 };
 
 export default yorkie;

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -55,7 +55,7 @@ export {
   CompleteFn,
   Unsubscribe,
 } from '@yorkie-js-sdk/src/util/observable';
-export { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
+export { TimeTicket, TimeTicketStruct } from '@yorkie-js-sdk/src/document/time/ticket';
 export { ActorID } from '@yorkie-js-sdk/src/document/time/actor_id';
 export type {
   OperationInfo,
@@ -72,6 +72,8 @@ export type {
 export {
   TreeChange,
   TreeChangeType,
+  CRDTTreePosStruct,
+  TreeRangeStruct,
 } from '@yorkie-js-sdk/src/document/crdt/tree';
 
 export {

--- a/test/bench/document_test.ts
+++ b/test/bench/document_test.ts
@@ -246,7 +246,7 @@ const tests = [
         assert.equal(root.k1.length, 3);
         assert.equal(
           '[1:000000000000000000000000:2:1][1:000000000000000000000000:3:2][1:000000000000000000000000:4:3]',
-          root.k1.getStructureAsString!(),
+          root.k1.toTestString!(),
         );
 
         root.k1.splice(1, 1);
@@ -254,7 +254,7 @@ const tests = [
         assert.equal(root.k1.length, 2);
         assert.equal(
           '[1:000000000000000000000000:2:1]{1:000000000000000000000000:3:2}[1:000000000000000000000000:4:3]',
-          root.k1.getStructureAsString!(),
+          root.k1.toTestString!(),
         );
 
         const first = root.k1.getElementByIndex!(0);
@@ -263,7 +263,7 @@ const tests = [
         assert.equal(root.k1.length, 3);
         assert.equal(
           '[1:000000000000000000000000:2:1][1:000000000000000000000000:6:2]{1:000000000000000000000000:3:2}[1:000000000000000000000000:4:3]',
-          root.k1.getStructureAsString!(),
+          root.k1.toTestString!(),
         );
 
         const third = root.k1.getElementByIndex!(2);
@@ -272,7 +272,7 @@ const tests = [
         assert.equal(root.k1.length, 4);
         assert.equal(
           '[1:000000000000000000000000:2:1][1:000000000000000000000000:6:2]{1:000000000000000000000000:3:2}[1:000000000000000000000000:4:3][1:000000000000000000000000:7:4]',
-          root.k1.getStructureAsString!(),
+          root.k1.toTestString!(),
         );
 
         for (let i = 0; i < root.k1.length; i++) {
@@ -296,19 +296,19 @@ const tests = [
       );
       assert.equal(
         `[0:00:0:0 ][1:00:2:0 A][1:00:3:0 12]{1:00:2:1 BC}[1:00:2:3 D]`,
-        doc.getRoot().k1.getStructureAsString(),
+        doc.getRoot().k1.toTestString(),
       );
       doc.update((root) => {
         const [pos1] = root.k1.createRange(0, 0);
-        assert.equal('0:00:0:0:0', pos1.getStructureAsString());
+        assert.equal('0:00:0:0:0', pos1.toTestString());
         const [pos2] = root.k1.createRange(1, 1);
-        assert.equal('1:00:2:0:1', pos2.getStructureAsString());
+        assert.equal('1:00:2:0:1', pos2.toTestString());
         const [pos3] = root.k1.createRange(2, 2);
-        assert.equal('1:00:3:0:1', pos3.getStructureAsString());
+        assert.equal('1:00:3:0:1', pos3.toTestString());
         const [pos4] = root.k1.createRange(3, 3);
-        assert.equal('1:00:3:0:2', pos4.getStructureAsString());
+        assert.equal('1:00:3:0:2', pos4.toTestString());
         const [pos5] = root.k1.createRange(4, 4);
-        assert.equal('1:00:2:3:1', pos5.getStructureAsString());
+        assert.equal('1:00:2:3:1', pos5.toTestString());
       });
     },
   },
@@ -337,7 +337,7 @@ const tests = [
         root.k1.edit(0, 0, 'Hello world');
         assert.equal(
           '[0:00:0:0 ][1:00:2:0 Hello world]',
-          root.k1.getStructureAsString(),
+          root.k1.toTestString(),
         );
       });
       assert.equal('{"k1":[{"val":"Hello world"}]}', doc.toJSON());
@@ -345,7 +345,7 @@ const tests = [
         root.k1.setStyle(0, 5, { b: '1' });
         assert.equal(
           '[0:00:0:0 ][1:00:2:0 Hello][1:00:2:5  world]',
-          root.k1.getStructureAsString(),
+          root.k1.toTestString(),
         );
       });
       assert.equal(
@@ -356,12 +356,12 @@ const tests = [
         root.k1.setStyle(0, 5, { b: '1' });
         assert.equal(
           '[0:00:0:0 ][1:00:2:0 Hello][1:00:2:5  world]',
-          root.k1.getStructureAsString(),
+          root.k1.toTestString(),
         );
         root.k1.setStyle(3, 5, { i: '1' });
         assert.equal(
           '[0:00:0:0 ][1:00:2:0 Hel][1:00:2:3 lo][1:00:2:5  world]',
-          root.k1.getStructureAsString(),
+          root.k1.toTestString(),
         );
       });
       assert.equal(
@@ -372,7 +372,7 @@ const tests = [
         root.k1.edit(5, 11, ' yorkie');
         assert.equal(
           '[0:00:0:0 ][1:00:2:0 Hel][1:00:2:3 lo][4:00:1:0  yorkie]{1:00:2:5  world}',
-          root.k1.getStructureAsString(),
+          root.k1.toTestString(),
         );
       });
       assert.equal(
@@ -384,7 +384,7 @@ const tests = [
         assert(
           '[0:00:0:0 ][1:00:2:0 Hel][1:00:2:3 lo][5:00:1:0 ]' +
             '[4:00:1:0  yorkie]{1:00:2:5  world}',
-          root.k1.getStructureAsString(),
+          root.k1.toTestString(),
         );
       });
       assert.equal(

--- a/test/integration/gc_test.ts
+++ b/test/integration/gc_test.ts
@@ -84,10 +84,10 @@ describe('Garbage Collection', function () {
 
     const root = (doc.getRootObject().get('list') as CRDTArray)
       .getElements()
-      .getStructureAsString();
+      .toTestString();
     const clone = (doc.getClone()!.get('list') as CRDTArray)
       .getElements()
-      .getStructureAsString();
+      .toTestString();
 
     assert.equal(root, clone);
   });
@@ -100,7 +100,7 @@ describe('Garbage Collection', function () {
 
     assert.equal(
       '[0:00:0:0 ][3:00:1:0 12]{2:00:1:0 AB}[2:00:1:2 CD]',
-      doc.getRoot().text.getStructureAsString(),
+      doc.getRoot().text.toTestString(),
     );
 
     assert.equal(1, doc.getGarbageLen());
@@ -109,14 +109,14 @@ describe('Garbage Collection', function () {
 
     assert.equal(
       '[0:00:0:0 ][3:00:1:0 12][2:00:1:2 CD]',
-      doc.getRoot().text.getStructureAsString(),
+      doc.getRoot().text.toTestString(),
     );
 
     doc.update((root) => root.text.edit(2, 4, ''));
 
     assert.equal(
       '[0:00:0:0 ][3:00:1:0 12]{2:00:1:2 CD}',
-      doc.getRoot().text.getStructureAsString(),
+      doc.getRoot().text.toTestString(),
     );
   });
 

--- a/test/integration/text_test.ts
+++ b/test/integration/text_test.ts
@@ -20,23 +20,23 @@ describe('Text', function () {
     doc.update((root) => {
       assert.equal(
         '[0:00:0:0 ][1:00:2:0 A][1:00:3:0 12]{1:00:2:1 BC}[1:00:2:3 D]',
-        root['k1'].getStructureAsString(),
+        root['k1'].toTestString(),
       );
 
       let range = root['k1'].createRange(0, 0);
-      assert.equal('0:00:0:0:0', range[0].getStructureAsString());
+      assert.equal('0:00:0:0:0', range[0].toTestString());
 
       range = root['k1'].createRange(1, 1);
-      assert.equal('1:00:2:0:1', range[0].getStructureAsString());
+      assert.equal('1:00:2:0:1', range[0].toTestString());
 
       range = root['k1'].createRange(2, 2);
-      assert.equal('1:00:3:0:1', range[0].getStructureAsString());
+      assert.equal('1:00:3:0:1', range[0].toTestString());
 
       range = root['k1'].createRange(3, 3);
-      assert.equal('1:00:3:0:2', range[0].getStructureAsString());
+      assert.equal('1:00:3:0:2', range[0].toTestString());
 
       range = root['k1'].createRange(4, 4);
-      assert.equal('1:00:2:3:1', range[0].getStructureAsString());
+      assert.equal('1:00:2:3:1', range[0].toTestString());
     });
 
     assert.equal(
@@ -61,7 +61,7 @@ describe('Text', function () {
     doc.update((root) => {
       assert.equal(
         '[0:00:0:0 ][1:00:2:0 ABC][1:00:3:0 \n][1:00:2:3 D]',
-        root['k1'].getStructureAsString(),
+        root['k1'].toTestString(),
       );
     });
 
@@ -234,7 +234,7 @@ describe('Text', function () {
     doc.update((root) => {
       assert.equal(
         '[0:00:0:0 ][1:00:2:0 ABC][1:00:3:0 \n][1:00:2:3 D]',
-        root['k1'].getStructureAsString(),
+        root['k1'].toTestString(),
       );
     });
 

--- a/test/unit/document/crdt/root_test.ts
+++ b/test/unit/document/crdt/root_test.ts
@@ -119,10 +119,7 @@ describe('ROOT', function () {
     const text = new Text(change, crdtText);
 
     text.edit(0, 0, 'Hello World');
-    assert.equal(
-      '[0:00:0:0 ][0:00:2:0 Hello World]',
-      text.getStructureAsString(),
-    );
+    assert.equal('[0:00:0:0 ][0:00:2:0 Hello World]', text.toTestString());
     assert.equal(0, root.getGarbageLen());
 
     text.edit(6, 11, 'Yorkie');
@@ -132,7 +129,7 @@ describe('ROOT', function () {
     assert.equal(2, root.getGarbageLen());
 
     assert.equal(2, root.garbageCollect(MaxTimeTicket));
-    assert.equal('[0:00:0:0 ][0:00:3:0 Yorkie]', text.getStructureAsString());
+    assert.equal('[0:00:0:0 ][0:00:3:0 Yorkie]', text.toTestString());
     assert.equal(0, root.getGarbageLen());
   });
 });

--- a/test/unit/document/crdt/tree_test.ts
+++ b/test/unit/document/crdt/tree_test.ts
@@ -89,10 +89,7 @@ const dummyContext = ChangeContext.create(
  * `issuePos` is a helper function that issues a new CRDTTreePos.
  */
 function issuePos(offset = 0): CRDTTreePos {
-  return {
-    createdAt: dummyContext.issueTimeTicket(),
-    offset,
-  };
+  return CRDTTreePos.of(dummyContext.issueTimeTicket(), offset);
 }
 
 /**
@@ -127,8 +124,8 @@ describe('CRDTTreeNode', function () {
 
     assert.equal(left.value, 'hello');
     assert.equal(right!.value, 'yorkie');
-    assert.deepEqual(left.pos, { createdAt: ITT, offset: 0 });
-    assert.deepEqual(right!.pos, { createdAt: ITT, offset: 5 });
+    assert.deepEqual(left.pos, CRDTTreePos.of(ITT, 0));
+    assert.deepEqual(right!.pos, CRDTTreePos.of(ITT, 5));
   });
 });
 
@@ -626,11 +623,11 @@ describe('CRDTTree', function () {
     assert.deepEqual([fromIdx, toIdx], [5, 6]);
     assert.equal(tree.getSize(), 8);
 
-    let range = tree.createRange(0, 5);
-    assert.deepEqual(tree.rangeToIndex(range), [0, 5]);
+    let range = tree.toPosRange([0, 5]);
+    assert.deepEqual(tree.toIndexRange(range), [0, 5]);
 
-    range = tree.createRange(5, 7);
-    assert.deepEqual(tree.rangeToIndex(range), [5, 7]);
+    range = tree.toPosRange([5, 7]);
+    assert.deepEqual(tree.toIndexRange(range), [5, 7]);
   });
 });
 

--- a/test/unit/document/crdt/tree_test.ts
+++ b/test/unit/document/crdt/tree_test.ts
@@ -177,7 +177,7 @@ describe('CRDTTree', function () {
     listEqual(tree, ['text.hello', 'text.!', 'p', 'text.world', 'p', 'r']);
 
     assert.deepEqual(
-      JSON.stringify(tree.toStructure()),
+      JSON.stringify(tree.toTestTreeNode()),
       JSON.stringify({
         type: 'r',
         children: [
@@ -246,10 +246,10 @@ describe('CRDTTree', function () {
     assert.deepEqual(tree.toXML(), /*html*/ `<root><p>ab</p><p>cd</p></root>`);
     listEqual(tree, ['text.ab', 'p', 'text.cd', 'p', 'root']);
 
-    let structure = tree.toStructure();
-    assert.equal(structure.size, 8);
-    assert.equal(structure.children![0].size, 2);
-    assert.equal(structure.children![0].children![0].size, 2);
+    let treeNode = tree.toTestTreeNode();
+    assert.equal(treeNode.size, 8);
+    assert.equal(treeNode.children![0].size, 2);
+    assert.equal(treeNode.children![0].children![0].size, 2);
 
     // 02. delete b from first paragraph
     //       0   1 2    3   4 5 6    7
@@ -258,10 +258,10 @@ describe('CRDTTree', function () {
     assert.deepEqual(tree.toXML(), /*html*/ `<root><p>a</p><p>cd</p></root>`);
     listEqual(tree, ['text.a', 'p', 'text.cd', 'p', 'root']);
 
-    structure = tree.toStructure();
-    assert.equal(structure.size, 7);
-    assert.equal(structure.children![0].size, 1);
-    assert.equal(structure.children![0].children![0].size, 1);
+    treeNode = tree.toTestTreeNode();
+    assert.equal(treeNode.size, 7);
+    assert.equal(treeNode.children![0].size, 1);
+    assert.equal(treeNode.children![0].children![0].size, 1);
   });
 
   it('Can delete nodes between element nodes with edit', function () {
@@ -295,11 +295,11 @@ describe('CRDTTree', function () {
 
     // TODO(hackerwins): Uncomment the below line.
     // listEqual(tree, ['text.a', 'text.d', 'p', 'root']);
-    const structure = tree.toStructure();
-    assert.equal(structure.size, 4); // root
-    assert.equal(structure.children![0].size, 2); // p
-    assert.equal(structure.children![0].children![0].size, 1); // a
-    assert.equal(structure.children![0].children![1].size, 1); // d
+    const treeNode = tree.toTestTreeNode();
+    assert.equal(treeNode.size, 4); // root
+    assert.equal(treeNode.children![0].size, 2); // p
+    assert.equal(treeNode.children![0].children![0].size, 1); // a
+    assert.equal(treeNode.children![0].children![1].size, 1); // d
 
     // 03. insert a new text node at the start of the first paragraph.
     tree.editByIndex(

--- a/test/unit/util/splay_tree_test.ts
+++ b/test/unit/util/splay_tree_test.ts
@@ -76,22 +76,16 @@ describe('SplayTree', function () {
     const tree = new SplayTree<string>();
 
     const nodeA = tree.insert(StringNode.create('A2'));
-    assert.equal('[2,2]A2', tree.getStructureAsString());
+    assert.equal('[2,2]A2', tree.toTestString());
     const nodeB = tree.insert(StringNode.create('B23'));
-    assert.equal('[2,2]A2[5,3]B23', tree.getStructureAsString());
+    assert.equal('[2,2]A2[5,3]B23', tree.toTestString());
     const nodeC = tree.insert(StringNode.create('C234'));
-    assert.equal('[2,2]A2[5,3]B23[9,4]C234', tree.getStructureAsString());
+    assert.equal('[2,2]A2[5,3]B23[9,4]C234', tree.toTestString());
     const nodeD = tree.insert(StringNode.create('D2345'));
-    assert.equal(
-      '[2,2]A2[5,3]B23[9,4]C234[14,5]D2345',
-      tree.getStructureAsString(),
-    );
+    assert.equal('[2,2]A2[5,3]B23[9,4]C234[14,5]D2345', tree.toTestString());
 
     tree.splayNode(nodeB);
-    assert.equal(
-      '[2,2]A2[14,3]B23[9,4]C234[5,5]D2345',
-      tree.getStructureAsString(),
-    );
+    assert.equal('[2,2]A2[14,3]B23[9,4]C234[5,5]D2345', tree.toTestString());
 
     assert.equal(tree.indexOf(nodeA), 0);
     assert.equal(tree.indexOf(nodeB), 2);
@@ -105,16 +99,16 @@ describe('SplayTree', function () {
     const tree = new SplayTree<string>();
 
     const nodeH = tree.insert(StringNode.create('H'));
-    assert.equal('[1,1]H', tree.getStructureAsString());
+    assert.equal('[1,1]H', tree.toTestString());
     const nodeE = tree.insert(StringNode.create('E'));
-    assert.equal('[1,1]H[2,1]E', tree.getStructureAsString());
+    assert.equal('[1,1]H[2,1]E', tree.toTestString());
     const nodeL = tree.insert(StringNode.create('LL'));
-    assert.equal('[1,1]H[2,1]E[4,2]LL', tree.getStructureAsString());
+    assert.equal('[1,1]H[2,1]E[4,2]LL', tree.toTestString());
     const nodeO = tree.insert(StringNode.create('O'));
-    assert.equal('[1,1]H[2,1]E[4,2]LL[5,1]O', tree.getStructureAsString());
+    assert.equal('[1,1]H[2,1]E[4,2]LL[5,1]O', tree.toTestString());
 
     tree.delete(nodeE);
-    assert.equal('[4,1]H[3,2]LL[1,1]O', tree.getStructureAsString());
+    assert.equal('[4,1]H[3,2]LL[1,1]O', tree.toTestString());
 
     assert.equal(tree.indexOf(nodeH), 0);
     assert.equal(tree.indexOf(nodeE), -1);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

In the ProseMirror example, to represent tree selection, we use `createRange` and `converter.treePosToBytes` to convert it into bytes. (#544)

To simplify convert between index and position, we can use `toPosRange`, `toIndexRange`. The `TreeRangeStruct` from `toPosRange` is serializable.

```js
// as-is
// index -> pos 
const range = tree.createRange(from, to);
const fromBytes = yorkie.converter.treePosToBytes(range[0]);
const toBytes = yorkie.converter.treePosToBytes(range[1]);
root.selection = [ fromBytes, toBytes ];

// pos -> index 
const selection = doc.getRoot().selection;  
const from = yorkie.converter.bytesToTreePos(selection[0]);
const to = yorkie.converter.bytesToTreePos(selection[1]);
const [fromIndex, toIndex] = tree.rangeToIndex([from, to]);

// to-be 
// index -> pos 
root.selection = root.tree.toPosRange([from, to]); 

// pos -> index 
const selection = doc.getRoot().selection;
const [fromIndex, toIndex] = tree.toIndexRange(selection);
```

#### Any background context you want to provide?

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
