### PR TITLE
Remove InternalOpInfo

### DIFF
--- a/public/multi.html
+++ b/public/multi.html
@@ -252,6 +252,7 @@
 
           // 05. Quill example
           doc.subscribe('$.content', (event) => {
+            console.log('🔵 quill event', event);
             if (event.type === 'remote-change') {
               const { actor, message, operations } = event.value;
               handleOperations(operations, actor);

--- a/src/document/change/change.ts
+++ b/src/document/change/change.ts
@@ -17,7 +17,7 @@
 import { ActorID } from '@yorkie-js-sdk/src/document/time/actor_id';
 import {
   Operation,
-  InternalOpInfo,
+  OperationInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import { ChangeID } from '@yorkie-js-sdk/src/document/change/change_id';
@@ -86,8 +86,8 @@ export class Change {
   /**
    * `execute` executes the operations of this change to the given root.
    */
-  public execute(root: CRDTRoot): Array<InternalOpInfo> {
-    const opInfos: Array<InternalOpInfo> = [];
+  public execute(root: CRDTRoot): Array<OperationInfo> {
+    const opInfos: Array<OperationInfo> = [];
     for (const operation of this.operations) {
       const infos = operation.execute(root);
       opInfos.push(...infos);

--- a/src/document/operation/add_operation.ts
+++ b/src/document/operation/add_operation.ts
@@ -21,7 +21,7 @@ import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';
 import {
   Operation,
-  InternalOpInfo,
+  OperationInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 
 /**
@@ -57,7 +57,7 @@ export class AddOperation extends Operation {
   /**
    * `execute` executes this operation on the given `CRDTRoot`.
    */
-  public execute(root: CRDTRoot): Array<InternalOpInfo> {
+  public execute(root: CRDTRoot): Array<OperationInfo> {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
@@ -72,7 +72,7 @@ export class AddOperation extends Operation {
     return [
       {
         type: 'add',
-        element: this.getParentCreatedAt(),
+        path: root.createPath(this.getParentCreatedAt()),
         index: Number(array.subPathOf(this.getEffectedCreatedAt())),
       },
     ];

--- a/src/document/operation/edit_operation.ts
+++ b/src/document/operation/edit_operation.ts
@@ -21,7 +21,7 @@ import { RGATreeSplitNodePos } from '@yorkie-js-sdk/src/document/crdt/rga_tree_s
 import { CRDTText } from '@yorkie-js-sdk/src/document/crdt/text';
 import {
   Operation,
-  InternalOpInfo,
+  OperationInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { Indexable } from '../document';
 
@@ -79,7 +79,7 @@ export class EditOperation extends Operation {
   /**
    * `execute` executes this operation on the given `CRDTRoot`.
    */
-  public execute<A extends Indexable>(root: CRDTRoot): Array<InternalOpInfo> {
+  public execute<A extends Indexable>(root: CRDTRoot): Array<OperationInfo> {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
@@ -105,15 +105,15 @@ export class EditOperation extends Operation {
             from,
             to,
             value,
-            element: this.getParentCreatedAt(),
+            path: root.createPath(this.getParentCreatedAt()),
           }
         : {
             type: 'select',
             from,
             to,
-            element: this.getParentCreatedAt(),
+            path: root.createPath(this.getParentCreatedAt()),
           };
-    }) as Array<InternalOpInfo>;
+    }) as Array<OperationInfo>;
   }
 
   /**

--- a/src/document/operation/increase_operation.ts
+++ b/src/document/operation/increase_operation.ts
@@ -16,7 +16,7 @@
 
 import {
   Operation,
-  InternalOpInfo,
+  OperationInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
@@ -55,7 +55,7 @@ export class IncreaseOperation extends Operation {
   /**
    * `execute` executes this operation on the given `CRDTRoot`.
    */
-  public execute(root: CRDTRoot): Array<InternalOpInfo> {
+  public execute(root: CRDTRoot): Array<OperationInfo> {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
@@ -69,7 +69,7 @@ export class IncreaseOperation extends Operation {
     return [
       {
         type: 'increase',
-        element: this.getEffectedCreatedAt(),
+        path: root.createPath(this.getParentCreatedAt()),
         value: value.getValue() as number,
       },
     ];

--- a/src/document/operation/move_operation.ts
+++ b/src/document/operation/move_operation.ts
@@ -20,7 +20,7 @@ import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';
 import {
   Operation,
-  InternalOpInfo,
+  OperationInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 
 /**
@@ -61,7 +61,7 @@ export class MoveOperation extends Operation {
   /**
    * `execute` executes this operation on the given `CRDTRoot`.
    */
-  public execute(root: CRDTRoot): Array<InternalOpInfo> {
+  public execute(root: CRDTRoot): Array<OperationInfo> {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
@@ -76,7 +76,7 @@ export class MoveOperation extends Operation {
     return [
       {
         type: 'move',
-        element: this.getParentCreatedAt(),
+        path: root.createPath(this.getParentCreatedAt()),
         index,
         previousIndex,
       },

--- a/src/document/operation/operation.ts
+++ b/src/document/operation/operation.ts
@@ -147,25 +147,6 @@ export type TreeStyleOpInfo = {
 };
 
 /**
- * `InternalOpInfo` represents the information of the operation. It is used to
- * internally and can be converted to `OperationInfo` to inform to the user.
- */
-export type InternalOpInfo =
-  | ToInternalOpInfo<AddOpInfo>
-  | ToInternalOpInfo<IncreaseOpInfo>
-  | ToInternalOpInfo<RemoveOpInfo>
-  | ToInternalOpInfo<SetOpInfo>
-  | ToInternalOpInfo<MoveOpInfo>
-  | ToInternalOpInfo<EditOpInfo>
-  | ToInternalOpInfo<StyleOpInfo>
-  | ToInternalOpInfo<SelectOpInfo>
-  | ToInternalOpInfo<TreeEditOpInfo>
-  | ToInternalOpInfo<TreeStyleOpInfo>;
-type ToInternalOpInfo<T extends OperationInfo> = Omit<T, 'path'> & {
-  element: TimeTicket;
-};
-
-/**
  * `Operation` represents an operation to be executed on a document.
  */
 export abstract class Operation {
@@ -212,5 +193,5 @@ export abstract class Operation {
   /**
    * `execute` executes this operation on the given `CRDTRoot`.
    */
-  public abstract execute(root: CRDTRoot): Array<InternalOpInfo>;
+  public abstract execute(root: CRDTRoot): Array<OperationInfo>;
 }

--- a/src/document/operation/remove_operation.ts
+++ b/src/document/operation/remove_operation.ts
@@ -19,7 +19,7 @@ import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import {
   Operation,
-  InternalOpInfo,
+  OperationInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { CRDTContainer } from '@yorkie-js-sdk/src/document/crdt/element';
 import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';
@@ -53,7 +53,7 @@ export class RemoveOperation extends Operation {
   /**
    * `execute` executes this operation on the given `CRDTRoot`.
    */
-  public execute(root: CRDTRoot): Array<InternalOpInfo> {
+  public execute(root: CRDTRoot): Array<OperationInfo> {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
@@ -70,14 +70,14 @@ export class RemoveOperation extends Operation {
       ? [
           {
             type: 'remove',
-            element: this.getEffectedCreatedAt(),
+            path: root.createPath(this.getParentCreatedAt()),
             index: Number(key),
           },
         ]
       : [
           {
             type: 'remove',
-            element: this.getEffectedCreatedAt(),
+            path: root.createPath(this.getParentCreatedAt()),
             key,
           },
         ];

--- a/src/document/operation/select_operation.ts
+++ b/src/document/operation/select_operation.ts
@@ -21,7 +21,7 @@ import { RGATreeSplitNodePos } from '@yorkie-js-sdk/src/document/crdt/rga_tree_s
 import { CRDTText } from '@yorkie-js-sdk/src/document/crdt/text';
 import {
   Operation,
-  InternalOpInfo,
+  OperationInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { Indexable } from '../document';
 
@@ -58,7 +58,7 @@ export class SelectOperation extends Operation {
   /**
    * `execute` executes this operation on the given `CRDTRoot`.
    */
-  public execute<A extends Indexable>(root: CRDTRoot): Array<InternalOpInfo> {
+  public execute<A extends Indexable>(root: CRDTRoot): Array<OperationInfo> {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
@@ -78,7 +78,7 @@ export class SelectOperation extends Operation {
             from: change.from,
             to: change.to,
             type: 'select',
-            element: this.getParentCreatedAt(),
+            path: root.createPath(this.getParentCreatedAt()),
           },
         ]
       : [];

--- a/src/document/operation/set_operation.ts
+++ b/src/document/operation/set_operation.ts
@@ -21,7 +21,7 @@ import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import { CRDTObject } from '@yorkie-js-sdk/src/document/crdt/object';
 import {
   Operation,
-  InternalOpInfo,
+  OperationInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 
 /**
@@ -58,7 +58,7 @@ export class SetOperation extends Operation {
   /**
    * `execute` executes this operation on the given `CRDTRoot`.
    */
-  public execute(root: CRDTRoot): Array<InternalOpInfo> {
+  public execute(root: CRDTRoot): Array<OperationInfo> {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
@@ -73,7 +73,7 @@ export class SetOperation extends Operation {
     return [
       {
         type: 'set',
-        element: this.getParentCreatedAt(),
+        path: root.createPath(this.getParentCreatedAt()),
         key: this.key,
       },
     ];

--- a/src/document/operation/style_operation.ts
+++ b/src/document/operation/style_operation.ts
@@ -21,7 +21,7 @@ import { RGATreeSplitNodePos } from '@yorkie-js-sdk/src/document/crdt/rga_tree_s
 import { CRDTText } from '@yorkie-js-sdk/src/document/crdt/text';
 import {
   Operation,
-  InternalOpInfo,
+  OperationInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { Indexable } from '../document';
 
@@ -68,7 +68,7 @@ export class StyleOperation extends Operation {
   /**
    * `execute` executes this operation on the given `CRDTRoot`.
    */
-  public execute<A extends Indexable>(root: CRDTRoot): Array<InternalOpInfo> {
+  public execute<A extends Indexable>(root: CRDTRoot): Array<OperationInfo> {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
@@ -88,9 +88,9 @@ export class StyleOperation extends Operation {
         from,
         to,
         value,
-        element: this.getParentCreatedAt(),
+        path: root.createPath(this.getParentCreatedAt()),
       };
-    }) as Array<InternalOpInfo>;
+    }) as Array<OperationInfo>;
   }
 
   /**

--- a/src/document/operation/tree_edit_operation.ts
+++ b/src/document/operation/tree_edit_operation.ts
@@ -24,7 +24,7 @@ import {
 } from '@yorkie-js-sdk/src/document/crdt/tree';
 import {
   Operation,
-  InternalOpInfo,
+  OperationInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 
 /**
@@ -70,7 +70,7 @@ export class TreeEditOperation extends Operation {
   /**
    * `execute` executes this operation on the given `CRDTRoot`.
    */
-  public execute(root: CRDTRoot): Array<InternalOpInfo> {
+  public execute(root: CRDTRoot): Array<OperationInfo> {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
@@ -99,9 +99,9 @@ export class TreeEditOperation extends Operation {
         value,
         fromPath,
         toPath,
-        element: this.getParentCreatedAt(),
+        path: root.createPath(this.getParentCreatedAt()),
       };
-    }) as Array<InternalOpInfo>;
+    }) as Array<OperationInfo>;
   }
 
   /**

--- a/src/document/operation/tree_style_operation.ts
+++ b/src/document/operation/tree_style_operation.ts
@@ -20,7 +20,7 @@ import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import { CRDTTree, CRDTTreePos } from '@yorkie-js-sdk/src/document/crdt/tree';
 import {
   Operation,
-  InternalOpInfo,
+  OperationInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 
 /**
@@ -67,7 +67,7 @@ export class TreeStyleOperation extends Operation {
   /**
    * `execute` executes this operation on the given `CRDTRoot`.
    */
-  public execute(root: CRDTRoot): Array<InternalOpInfo> {
+  public execute(root: CRDTRoot): Array<OperationInfo> {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
@@ -93,9 +93,9 @@ export class TreeStyleOperation extends Operation {
         to,
         value,
         fromPath,
-        element: this.getParentCreatedAt(),
+        path: root.createPath(this.getParentCreatedAt()),
       };
-    }) as Array<InternalOpInfo>;
+    }) as Array<OperationInfo>;
   }
 
   /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

The `InternalOpInfo` is unnecessary since we can get the path from the root.
This was referenced from the https://github.com/yorkie-team/yorkie-ios-sdk/pull/78

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
