### PR TITLE
Move "Building & Testing" Guide to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,5 @@
+# Contributing
+
 ## How to contribute
 
 Yorkie is Apache 2.0 licensed and accepts contributions via GitHub pull requests. This document outlines some of the conventions on commit message formatting, contact points for developers, and other resources to help get contributions into Yorkie.
@@ -5,12 +7,13 @@ Yorkie is Apache 2.0 licensed and accepts contributions via GitHub pull requests
 ### Contacts
 
 If you have any questions along the way, please don’t hesitate to ask us
+
 - Discord: [Yorkie Discord](https://discord.com/invite/MVEAwz9sBy).
 
 ### Getting started
 
 - Fork the repository on GitHub
-- Read the README.md for build instructions
+- Read the [CONTRIBUTING.md](https://github.com/yorkie-team/yorkie-js-sdk/blob/main/CONTRIBUTING.md#building-yorkie-js-sdk) for build instructions
 
 ## Contribution flow
 
@@ -24,6 +27,75 @@ This is a rough outline of what a contributor's workflow looks like:
 - The PR must receive a LGTM from maintainers
 
 Thanks for contributing!
+
+## Building and Testing the SDK
+
+### Building yorkie-js-sdk
+
+For building yorkie-js-sdk, You'll first need Node.js installed(Node.js version 16+ and npm version 7.10+ are required).
+
+- [Node.js](https://nodejs.org/en) (version 16+)
+- [npm](https://www.npmjs.com/) (version 7.10+)
+
+```bash
+# install packages
+$ npm install
+
+# build
+$ npm run build
+```
+
+For generating proto messages and the service client stub classes with protoc and the protoc-gen-grpc-web.
+
+How to install protoc-gen-grpc-web: https://github.com/grpc/grpc-web#code-generator-plugin
+
+```bash
+# generate proto messages and the service client stub classes
+$ npm run build:proto
+```
+
+> Primary "source of truth" location of protobuf message is in [yorkie](https://github.com/yorkie-team/yorkie/tree/main/api). We manage the messages in the repository.
+
+### Testing yorkie-js-sdk with Envoy, Yorkie and MongoDB.
+
+Start MongoDB, Yorkie and Envoy proxy in a terminal session.
+
+```bash
+$ docker-compose -f docker/docker-compose.yml up --build -d
+```
+
+Start the test in another terminal session.
+
+```bash
+$ npm run test
+```
+
+To get the latest server locally, run the command below then restart containers again:
+
+```bash
+$ docker pull yorkieteam/yorkie:latest
+$ docker-compose -f docker/docker-compose.yml up --build -d
+```
+
+### Starting co-editing example with CodeMirror
+
+Start MongoDB, Yorkie and Envoy proxy in a terminal session.
+
+```bash
+$ docker-compose -f docker/docker-compose.yml up --build -d
+```
+
+Start the webpack-dev-server in another terminal session.
+
+```bash
+$ npm run dev
+```
+
+Open the co-editing example page served by webpack-dev-server in your browser.
+
+```bash
+$ open http://0.0.0.0:9000/
+```
 
 ### Code style
 

--- a/README.md
+++ b/README.md
@@ -22,75 +22,9 @@ yorkie-js-sdk uses gRPC-web for communicating with Yorkie Server built on gRPC.
 
 For more details: https://grpc.io/blog/state-of-grpc-web/
 
-## Building and Testing the SDK
-
-### Building yorkie-js-sdk
-
-For building yorkie-js-sdk, You'll first need Node.js installed(Node.js version 16+ and npm version 7.10+ are required).
-
-```bash
-# install packages
-$ npm install
-
-# build
-$ npm run build
-```
-
-For generating proto messages and the service client stub classes with protoc and the protoc-gen-grpc-web.
-
-How to install protoc-gen-grpc-web: https://github.com/grpc/grpc-web#code-generator-plugin
-
-```bash
-# generate proto messages and the service client stub classes
-$ npm run build:proto
-```
-> Primary "source of truth" location of protobuf message is in [yorkie](https://github.com/yorkie-team/yorkie/tree/main/api). We manage the messages in the repository.
-
-### Testing yorkie-js-sdk with Envoy, Yorkie and MongoDB.
-
-Start MongoDB, Yorkie and Envoy proxy in a terminal session.
-
-```bash
-$ docker-compose -f docker/docker-compose.yml up --build -d
-```
-
-Start the test in another terminal session.
-
-```bash
-$ npm run test
-```
-
-To get the latest server locally, run the command below then restart containers again:
-
-```bash
-$ docker pull yorkieteam/yorkie:latest
-$ docker-compose -f docker/docker-compose.yml up --build -d
-```
-
-### Starting co-editing example with CodeMirror
-
-Start MongoDB, Yorkie and Envoy proxy in a terminal session.
-
-```bash
-$ docker-compose -f docker/docker-compose.yml up --build -d
-```
-
-Start the webpack-dev-server in another terminal session.
-
-```bash
-$ npm run dev
-```
-
-Open the co-editing example page served by webpack-dev-server in your browser.
-
-```bash
-$ open http://0.0.0.0:9000/
-```
-
 ## Contributing
 
 See [CONTRIBUTING](CONTRIBUTING.md) for details on submitting patches and the contribution workflow.
-
 
 ## Contributors ✨
 


### PR DESCRIPTION
#### What this PR does / why we need it?
This pull request addresses Issue #588 by moving the "Building & Testing" guide from README.md to CONTRIBUTING.md. The primary objective is to enhance the project's contribution guidelines and improve the developer experience for potential contributors.

- The "Building & Testing" guide content has been relocated from README.md to CONTRIBUTING.md.

- The CONTRIBUTING.md file now includes comprehensive instructions on how to build, test, and contribute effectively to the project.

#### Any background context you want to provide?

#### What are the relevant tickets?
- Fixes  #588 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
