### PR TITLE
Add client deactivation before unmount

### DIFF
--- a/examples/vuejs-kanban/src/App.vue
+++ b/examples/vuejs-kanban/src/App.vue
@@ -52,6 +52,9 @@ export default {
   created() {
     this.fetchDoc();
   },
+  beforeUnmount(){
+    this.disconnect();
+  },
   watch: {
     opened(index) {
       this.$nextTick(function () {
@@ -83,6 +86,10 @@ export default {
       await client.sync();
 
       this.lists = doc.getRoot().lists;
+    },
+
+    async disconnect(){
+      await client.deactivate();
     },
 
     isOpened(index) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
When hot reloading occurs multiple times, the 'client.attach' request becomes pending.
So, it needs to deactivate the client when the component is unmounted.

#### Any background context you want to provide?
Nope

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/yorkie-js-sdk/issues/594

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
