### PR TITLE
Define more specific condition to check whether the input is opened

### DIFF
--- a/examples/vuejs-kanban/src/App.vue
+++ b/examples/vuejs-kanban/src/App.vue
@@ -58,10 +58,11 @@ export default {
         if (index === 0) {
           // Open add list form
           this.$refs['addListForm'].querySelector('input').focus();
-        } else {
+        } else if (index) {
           // Or open add card form
           this.$refs['addCardForm'][index - 1].querySelector('input').focus();
         }
+        this.title = ''
       });
     },
   },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
restrict the condition when the kanban board(card) is opened. 

In previous version, there was only two cases , `open` is 0 or not(including null or any other positive integer value). 
So, the codes that correspoding `open` is positive integer value executed also when `open` is null because there's no difference  logically. 
It has to be one more condition to be checked that indicate open is null. 

#### Any background context you want to provide?
- `open` value indicates the index of which kanban card is opend now(focused). 
- When close button is clicked, the `open` variable becomes `null` value. 

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #580

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
