### PR TITLE
Clean up methods related to presence

### DIFF
--- a/public/quill.html
+++ b/public/quill.html
@@ -110,8 +110,8 @@
           });
           doc.subscribe('others', (event) => {
             if (event.type === 'unwatched') {
-              const { clientID } = event.value;
-              cursors.removeCursor(doc.getPresence(clientID).username);
+              const { clientID, presence } = event.value;
+              cursors.removeCursor(presence.username);
             } else if (event.type === 'presence-changed') {
               const { clientID, presence } = event.value;
               const range = doc
@@ -222,8 +222,13 @@
                   to = from + op.delete;
                   console.log(`%c local: ${from}-${to}: ''`, 'color: green');
 
-                  doc.update((root) => {
-                    root.content.edit(from, to, '');
+                  doc.update((root, presence) => {
+                    const range = root.content.edit(from, to, '');
+                    if (range) {
+                      presence.set({
+                        selection: root.content.indexRangeToPosRange(range),
+                      });
+                    }
                   }, `update content by ${client.getID()}`);
                 } else if (op.retain !== undefined) {
                   from = to + op.retain;

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -24,7 +24,6 @@ import {
   CompleteFn,
   NextFn,
 } from '@yorkie-js-sdk/src/util/observable';
-import { deepcopy } from '@yorkie-js-sdk/src/util/object';
 import {
   ActivateClientRequest,
   DeactivateClientRequest,
@@ -909,7 +908,7 @@ export class Client implements Observable<ClientEvent> {
         if (presence) {
           attachment.doc.publish({
             type: DocEventType.Unwatched,
-            value: { clientID: publisher, presence: deepcopy(presence) },
+            value: { clientID: publisher, presence },
           });
         }
         break;

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -24,6 +24,7 @@ import {
   CompleteFn,
   NextFn,
 } from '@yorkie-js-sdk/src/util/observable';
+import { deepcopy } from '@yorkie-js-sdk/src/util/object';
 import {
   ActivateClientRequest,
   DeactivateClientRequest,
@@ -903,11 +904,14 @@ export class Client implements Observable<ClientEvent> {
         }
         break;
       case PbDocEventType.DOC_EVENT_TYPE_DOCUMENTS_UNWATCHED: {
+        const presence = attachment.doc.getPresence(publisher);
         attachment.doc.removeOnlineClient(publisher);
-        attachment.doc.publish({
-          type: DocEventType.Unwatched,
-          value: { clientID: publisher },
-        });
+        if (presence) {
+          attachment.doc.publish({
+            type: DocEventType.Unwatched,
+            value: { clientID: publisher, presence: deepcopy(presence) },
+          });
+        }
         break;
       }
     }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -892,6 +892,8 @@ export class Client implements Observable<ClientEvent> {
         break;
       case PbDocEventType.DOC_EVENT_TYPE_DOCUMENTS_WATCHED:
         attachment.doc.addOnlineClient(publisher);
+        // NOTE(chacha912): We added to onlineClients, but we won't trigger watched event
+        // unless we also know their initial presence data at this point.
         if (attachment.doc.hasPresence(publisher)) {
           attachment.doc.publish({
             type: DocEventType.Watched,
@@ -905,6 +907,8 @@ export class Client implements Observable<ClientEvent> {
       case PbDocEventType.DOC_EVENT_TYPE_DOCUMENTS_UNWATCHED: {
         const presence = attachment.doc.getPresence(publisher);
         attachment.doc.removeOnlineClient(publisher);
+        // NOTE(chacha912): There is no presence, when PresenceChange(clear) is applied before unwatching.
+        // In that case, the 'unwatched' event is triggered while handling the PresenceChange.
         if (presence) {
           attachment.doc.publish({
             type: DocEventType.Unwatched,

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -977,6 +977,9 @@ export class Document<T, P extends Indexable = Indexable> {
         const presenceChange = change.getPresenceChange()!;
         switch (presenceChange.type) {
           case PresenceChangeType.Put:
+            // NOTE(chacha912): When the user exists in onlineClients, but
+            // their presence was initially absent, we can consider that we have
+            // received their initial presence, so trigger the 'watched' event.
             docEvent = {
               type: this.presences.has(actorID)
                 ? DocEventType.PresenceChanged
@@ -988,6 +991,11 @@ export class Document<T, P extends Indexable = Indexable> {
             };
             break;
           case PresenceChangeType.Clear:
+            // NOTE(chacha912): When the user exists in onlineClients, but
+            // PresenceChange(clear) is received, we can consider it as detachment
+            // occurring before unwatching.
+            // Detached user is no longer participating in the document, we remove
+            // them from the online clients and trigger the 'unwatched' event.
             docEvent = {
               type: DocEventType.Unwatched,
               value: {

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -1056,6 +1056,8 @@ export class Document<T, P extends Indexable = Indexable> {
 
   /**
    * `setOnlineClients` sets the given online client set.
+   *
+   * @internal
    */
   public setOnlineClients(onlineClients: Set<ActorID>) {
     this.onlineClients = onlineClients;
@@ -1063,6 +1065,8 @@ export class Document<T, P extends Indexable = Indexable> {
 
   /**
    * `addOnlineClient` adds the given clientID into the online client set.
+   *
+   * @internal
    */
   public addOnlineClient(clientID: ActorID) {
     this.onlineClients.add(clientID);
@@ -1070,6 +1074,8 @@ export class Document<T, P extends Indexable = Indexable> {
 
   /**
    * `removeOnlineClient` removes the clientID from the online client set.
+   *
+   * @internal
    */
   public removeOnlineClient(clientID: ActorID) {
     this.onlineClients.delete(clientID);
@@ -1077,6 +1083,8 @@ export class Document<T, P extends Indexable = Indexable> {
 
   /**
    * `hasPresence` returns whether the given clientID has a presence or not.
+   *
+   * @internal
    */
   public hasPresence(clientID: ActorID): boolean {
     return this.presences.has(clientID);
@@ -1090,7 +1098,8 @@ export class Document<T, P extends Indexable = Indexable> {
       return {} as P;
     }
 
-    return this.presences.get(this.changeID.getActorID()!)!;
+    const p = this.presences.get(this.changeID.getActorID()!)!;
+    return deepcopy(p);
   }
 
   /**
@@ -1098,15 +1107,19 @@ export class Document<T, P extends Indexable = Indexable> {
    */
   public getPresence(clientID: ActorID): P | undefined {
     if (!this.onlineClients.has(clientID)) return;
-    return this.presences.get(clientID);
+    const p = this.presences.get(clientID);
+    return p ? deepcopy(p) : undefined;
   }
 
   /**
    * `getPresenceForTest` returns the presence of the given clientID
    * regardless of whether the client is online or not.
+   *
+   * @internal
    */
   public getPresenceForTest(clientID: ActorID): P | undefined {
-    return this.presences.get(clientID);
+    const p = this.presences.get(clientID);
+    return p ? deepcopy(p) : undefined;
   }
 
   /**
@@ -1118,7 +1131,7 @@ export class Document<T, P extends Indexable = Indexable> {
       if (this.presences.has(clientID)) {
         presences.push({
           clientID,
-          presence: this.presences.get(clientID)!,
+          presence: deepcopy(this.presences.get(clientID)!),
         });
       }
     }

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -23,6 +23,14 @@ import { OperationInfo } from '@yorkie-js-sdk/src/document/operation/operation';
 
 export type Indexable = Record<string, any>;
 
+export async function sleep(interval = 1000): Promise<void> {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, interval);
+  });
+}
+
 export async function waitStubCallCount(
   stub: sinon.SinonStub,
   callCount: number,
@@ -31,12 +39,13 @@ export async function waitStubCallCount(
     const doLoop = () => {
       if (stub.callCount >= callCount) {
         resolve();
+        return;
       }
-      return false;
+
+      setTimeout(doLoop, 0);
     };
-    if (!doLoop()) {
-      setTimeout(doLoop, 1000);
-    }
+
+    doLoop();
   });
 }
 

--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -589,13 +589,13 @@ describe('Document', function () {
     d1.update((root) => {
       root['k1'] = [1, 2];
     }, 'set array');
-    await c1.attach(d1);
+    await c1.attach(d1, { isRealtimeSync: false });
     assert.equal(d1.toSortedJSON(), '{"k1":[1,2]}');
 
     const c2 = new yorkie.Client(testRPCAddr);
     await c2.activate();
     const d2 = new yorkie.Document<TestDoc>(docKey);
-    await c2.attach(d2);
+    await c2.attach(d2, { isRealtimeSync: false });
     assert.equal(d2.toSortedJSON(), '{"k1":[1,2]}');
 
     // 02. c1 updates d1 and removes it.
@@ -603,12 +603,12 @@ describe('Document', function () {
       root['k1'].push(3);
     });
     await c1.remove(d1);
-    assert.equal(d1.toSortedJSON(), '{"k1":[1,2,3]}');
+    assert.equal(d1.toSortedJSON(), '{"k1":[1,2,3]}', 'd1');
     assert.equal(d1.getStatus(), DocumentStatus.Removed);
 
     // 03. c2 syncs and checks that d2 is removed.
     await c2.sync();
-    assert.equal(d2.toSortedJSON(), '{"k1":[1,2,3]}');
+    assert.equal(d2.toSortedJSON(), '{"k1":[1,2,3]}', 'd2');
     assert.equal(d2.getStatus(), DocumentStatus.Removed);
 
     await c1.deactivate();

--- a/test/integration/presence_test.ts
+++ b/test/integration/presence_test.ts
@@ -302,11 +302,11 @@ describe('Presence', function () {
       const counter = p.get('counter');
       p.set({ counter: counter + 1 });
     });
-    assert.deepEqual(doc1.getPresence(c1.getID()!), { counter: 1 });
+    assert.deepEqual(doc1.getPresenceForTest(c1.getID()!), { counter: 1 });
 
     await c1.sync();
     await c2.sync();
-    assert.deepEqual(doc2.getPresence(c1.getID()!), { counter: 1 });
+    assert.deepEqual(doc2.getPresenceForTest(c1.getID()!), { counter: 1 });
   });
 });
 

--- a/test/integration/presence_test.ts
+++ b/test/integration/presence_test.ts
@@ -30,13 +30,13 @@ describe('Presence', function () {
     for (let i = 0; i < snapshotThreshold; i++) {
       doc1.update((root, p) => p.set({ key: `${i}` }));
     }
-    assert.deepEqual(doc1.getPresence(c1.getID()!), {
+    assert.deepEqual(doc1.getPresenceForTest(c1.getID()!), {
       key: `${snapshotThreshold - 1}`,
     });
 
     await c1.sync();
     await c2.sync();
-    assert.deepEqual(doc2.getPresence(c1.getID()!), {
+    assert.deepEqual(doc2.getPresenceForTest(c1.getID()!), {
       key: `${snapshotThreshold - 1}`,
     });
   });
@@ -61,13 +61,13 @@ describe('Presence', function () {
       isRealtimeSync: false,
     });
 
-    assert.deepEqual(doc1.getPresence(c1.getID()!), { key: 'key1' });
-    assert.deepEqual(doc1.getPresence(c2.getID()!), undefined);
-    assert.deepEqual(doc2.getPresence(c2.getID()!), { key: 'key2' });
-    assert.deepEqual(doc2.getPresence(c1.getID()!), { key: 'key1' });
+    assert.deepEqual(doc1.getPresenceForTest(c1.getID()!), { key: 'key1' });
+    assert.deepEqual(doc1.getPresenceForTest(c2.getID()!), undefined);
+    assert.deepEqual(doc2.getPresenceForTest(c2.getID()!), { key: 'key2' });
+    assert.deepEqual(doc2.getPresenceForTest(c1.getID()!), { key: 'key1' });
 
     await c1.sync();
-    assert.deepEqual(doc1.getPresence(c2.getID()!), { key: 'key2' });
+    assert.deepEqual(doc1.getPresenceForTest(c2.getID()!), { key: 'key2' });
 
     await c2.detach(doc2);
     await c1.sync();
@@ -93,13 +93,13 @@ describe('Presence', function () {
     });
 
     const emptyObject = {} as PresenceType;
-    assert.deepEqual(doc1.getPresence(c1.getID()!), emptyObject);
-    assert.deepEqual(doc1.getPresence(c2.getID()!), undefined);
-    assert.deepEqual(doc2.getPresence(c2.getID()!), emptyObject);
-    assert.deepEqual(doc2.getPresence(c1.getID()!), emptyObject);
+    assert.deepEqual(doc1.getPresenceForTest(c1.getID()!), emptyObject);
+    assert.deepEqual(doc1.getPresenceForTest(c2.getID()!), undefined);
+    assert.deepEqual(doc2.getPresenceForTest(c2.getID()!), emptyObject);
+    assert.deepEqual(doc2.getPresenceForTest(c1.getID()!), emptyObject);
 
     await c1.sync();
-    assert.deepEqual(doc1.getPresence(c2.getID()!), emptyObject);
+    assert.deepEqual(doc1.getPresenceForTest(c2.getID()!), emptyObject);
   });
 
   it('Should be synced eventually', async function () {
@@ -209,14 +209,14 @@ describe('Presence', function () {
     });
 
     doc1.update((root, p) => p.set({ cursor: { x: 1, y: 1 } }));
-    assert.deepEqual(doc1.getPresence(c1.getID()!), {
+    assert.deepEqual(doc1.getPresenceForTest(c1.getID()!), {
       key: 'key1',
       cursor: { x: 1, y: 1 },
     });
 
     await c1.sync();
     await c2.sync();
-    assert.deepEqual(doc2.getPresence(c1.getID()!), {
+    assert.deepEqual(doc2.getPresenceForTest(c1.getID()!), {
       key: 'key1',
       cursor: { x: 1, y: 1 },
     });
@@ -335,7 +335,7 @@ describe(`Document.Subscribe('presence')`, function () {
       [
         {
           type: DocEventType.Unwatched,
-          value: { clientID: c2ID },
+          value: { clientID: c2ID, presence: { name: 'b' } },
         },
       ],
     ]);

--- a/test/integration/presence_test.ts
+++ b/test/integration/presence_test.ts
@@ -589,5 +589,5 @@ describe(`Document.Subscribe('presence')`, function () {
     await c1.deactivate();
     await c2.deactivate();
     await c3.deactivate();
-  }).timeout(10000);
+  });
 });

--- a/test/integration/presence_test.ts
+++ b/test/integration/presence_test.ts
@@ -221,6 +221,62 @@ describe('Presence', function () {
       cursor: { x: 1, y: 1 },
     });
   });
+
+  it(`Should return only online clients`, async function () {
+    const c1 = new yorkie.Client(testRPCAddr);
+    const c2 = new yorkie.Client(testRPCAddr);
+    const c3 = new yorkie.Client(testRPCAddr);
+    await c1.activate();
+    await c2.activate();
+    await c3.activate();
+    const c1ID = c1.getID()!;
+    const c2ID = c2.getID()!;
+    const c3ID = c3.getID()!;
+
+    const docKey = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
+    type PresenceType = { name: string; cursor: { x: number; y: number } };
+    const doc1 = new yorkie.Document<{}, PresenceType>(docKey);
+    await c1.attach(doc1, {
+      initialPresence: { name: 'a1', cursor: { x: 0, y: 0 } },
+    });
+    const stub1 = sinon.stub();
+    const unsub1 = doc1.subscribe('presence', stub1);
+
+    // 01. c2 attaches doc in realtime sync, and c3 attached doc in manual sync.
+    const doc2 = new yorkie.Document<{}, PresenceType>(docKey);
+    await c2.attach(doc2, {
+      initialPresence: { name: 'b1', cursor: { x: 0, y: 0 } },
+    });
+    const doc3 = new yorkie.Document<{}, PresenceType>(docKey);
+    await c3.attach(doc3, {
+      initialPresence: { name: 'c1', cursor: { x: 0, y: 0 } },
+      isRealtimeSync: false,
+    });
+    await waitStubCallCount(stub1, 1); // c2 watched
+
+    assert.deepEqual(doc1.getPresences(), [
+      { clientID: c1ID, presence: doc1.getMyPresence() },
+      { clientID: c2ID, presence: doc2.getMyPresence() },
+    ]);
+    assert.deepEqual(doc1.getPresence(c3ID), undefined);
+
+    // 02. c2 pauses the document (in manual sync), c3 resumes the document (in realtime sync).
+    await c2.pause(doc2);
+    await waitStubCallCount(stub1, 2); // c2 unwatched
+    await c3.resume(doc3);
+    await waitStubCallCount(stub1, 3); // c3 watched
+
+    assert.deepEqual(doc1.getPresences(), [
+      { clientID: c1ID, presence: doc1.getMyPresence() },
+      { clientID: c3ID, presence: doc3.getMyPresence() },
+    ]);
+    assert.deepEqual(doc1.getPresence(c2ID), undefined);
+
+    unsub1();
+    await c1.deactivate();
+    await c2.deactivate();
+    await c3.deactivate();
+  });
 });
 
 describe(`Document.Subscribe('presence')`, function () {
@@ -353,4 +409,154 @@ describe(`Document.Subscribe('presence')`, function () {
 
     unsub1();
   });
+
+  it(`Can receive presence-related event only when using realtime sync`, async function () {
+    const c1 = new yorkie.Client(testRPCAddr);
+    const c2 = new yorkie.Client(testRPCAddr);
+    const c3 = new yorkie.Client(testRPCAddr);
+    await c1.activate();
+    await c2.activate();
+    await c3.activate();
+    const c2ID = c2.getID()!;
+    const c3ID = c3.getID()!;
+
+    const docKey = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
+    type PresenceType = { name: string; cursor: { x: number; y: number } };
+    const doc1 = new yorkie.Document<{}, PresenceType>(docKey);
+    await c1.attach(doc1, {
+      initialPresence: { name: 'a1', cursor: { x: 0, y: 0 } },
+    });
+    const stub1 = sinon.stub();
+    const unsub1 = doc1.subscribe('presence', stub1);
+
+    // 01. c2 attaches doc in realtime sync, and c3 attached doc in manual sync.
+    //     c1 receives the watched event from c2.
+    const doc2 = new yorkie.Document<{}, PresenceType>(docKey);
+    await c2.attach(doc2, {
+      initialPresence: { name: 'b1', cursor: { x: 0, y: 0 } },
+    });
+    const doc3 = new yorkie.Document<{}, PresenceType>(docKey);
+    await c3.attach(doc3, {
+      initialPresence: { name: 'c1', cursor: { x: 0, y: 0 } },
+      isRealtimeSync: false,
+    });
+    await waitStubCallCount(stub1, 1); // c2 watched
+
+    // 02. c2 and c3 update the presence.
+    //     c1 receives the presence-changed event from c2.
+    doc2.update((_, presence) => {
+      presence.set({ name: 'b2' });
+    });
+    doc3.update((_, presence) => {
+      presence.set({ name: 'c2' });
+    });
+    await waitStubCallCount(stub1, 2); // c2 presence-changed
+
+    // 03. c2 pauses the document (in manual sync), c3 resumes the document (in realtime sync).
+    //     c1 receives an unwatched event from c2 and a watched event from c3.
+    await c2.pause(doc2);
+    await waitStubCallCount(stub1, 3); // c2 unwatched
+    await c3.resume(doc3);
+    await waitStubCallCount(stub1, 5); // c3 watched, c3 presence-changed
+
+    // 04. c2 and c3 update the presence.
+    //     c1 receives the presence-changed event from c3.
+    doc2.update((_, presence) => {
+      presence.set({ name: 'b3' });
+    });
+    doc3.update((_, presence) => {
+      presence.set({ name: 'c3' });
+    });
+    await waitStubCallCount(stub1, 6); // c3 presence-changed
+
+    // 05. c3 pauses the document (in manual sync),
+    //     c1 receives an unwatched event from c3.
+    await c3.pause(doc3);
+    await waitStubCallCount(stub1, 7); // c3 unwatched
+
+    // 06. c2 performs manual sync and then resumes(switches to realtime sync).
+    //     After applying all changes, only the watched event is triggered.
+    await c2.sync();
+    await c2.resume(doc2);
+    await waitStubCallCount(stub1, 8); // c2 watched
+
+    assert.deepEqual(stub1.args, [
+      [
+        {
+          type: DocEventType.Watched,
+          value: {
+            clientID: c2ID,
+            presence: { cursor: { x: 0, y: 0 }, name: 'b1' },
+          },
+        },
+      ],
+      [
+        {
+          type: DocEventType.PresenceChanged,
+          value: {
+            clientID: c2ID,
+            presence: { cursor: { x: 0, y: 0 }, name: 'b2' },
+          },
+        },
+      ],
+      [
+        {
+          type: DocEventType.Unwatched,
+          value: {
+            clientID: c2ID,
+            presence: { cursor: { x: 0, y: 0 }, name: 'b2' },
+          },
+        },
+      ],
+      [
+        {
+          type: DocEventType.Watched,
+          value: {
+            clientID: c3ID,
+            presence: { cursor: { x: 0, y: 0 }, name: 'c1' },
+          },
+        },
+      ],
+      [
+        {
+          type: DocEventType.PresenceChanged,
+          value: {
+            clientID: c3ID,
+            presence: { cursor: { x: 0, y: 0 }, name: 'c2' },
+          },
+        },
+      ],
+      [
+        {
+          type: DocEventType.PresenceChanged,
+          value: {
+            clientID: c3ID,
+            presence: { cursor: { x: 0, y: 0 }, name: 'c3' },
+          },
+        },
+      ],
+      [
+        {
+          type: DocEventType.Unwatched,
+          value: {
+            clientID: c3ID,
+            presence: { cursor: { x: 0, y: 0 }, name: 'c3' },
+          },
+        },
+      ],
+      [
+        {
+          type: DocEventType.Watched,
+          value: {
+            clientID: c2ID,
+            presence: { cursor: { x: 0, y: 0 }, name: 'b3' },
+          },
+        },
+      ],
+    ]);
+    unsub1();
+    await c1.deactivate();
+    await c2.deactivate();
+    await c3.deactivate();
+  }).timeout(10000);
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This is a follow-up task of #574  

- Add presence to `unwatched` event
  - We can use it in examples: #581 
- Return presence to user by retrieving only online clients and making a copy

#### Any background context you want to provide?

![image](https://github.com/yorkie-team/yorkie-js-sdk/assets/81357083/9701c88e-b1ad-420e-a7e7-cf5892ee94b6)

When detaching, there are two possible scenarios:

When UserA detaches, a change is made to remove the presence, and the watch stream is canceled.

1) If UserB receives the `unwatched` event first, UserB will remove UserA from onlineClients and trigger the `unwatched` event.

2) If UserB receives the `pushpull` response first, which includes a change to remove presence, UserB will trigger the `unwatched` event beforehand while detaching since it involves unwatching.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
