### PR TITLE
Add `presence.get()` to get presence value in doc.update()

### DIFF
--- a/src/document/presence/presence.ts
+++ b/src/document/presence/presence.ts
@@ -51,9 +51,6 @@ export class Presence<P extends Indexable> {
    * `set` updates the presence based on the partial presence.
    */
   public set(presence: Partial<P>) {
-    if (!this.presence) {
-      throw new Error(`presence is not initialized`);
-    }
     for (const [key, value] of Object.entries(presence)) {
       this.presence[key as keyof P] = value as any;
     }
@@ -62,6 +59,13 @@ export class Presence<P extends Indexable> {
       type: PresenceChangeType.Put,
       presence: deepcopy(this.presence),
     });
+  }
+
+  /**
+   * `get` returns the presence value of the given key.
+   */
+  public get<K extends keyof P>(key: K): P[K] {
+    return this.presence[key];
   }
 
   /**

--- a/test/integration/presence_test.ts
+++ b/test/integration/presence_test.ts
@@ -221,6 +221,37 @@ describe('Presence', function () {
       cursor: { x: 1, y: 1 },
     });
   });
+
+  it('Can get presence value using p.get() within doc.update function', async function () {
+    const c1 = new yorkie.Client(testRPCAddr);
+    const c2 = new yorkie.Client(testRPCAddr);
+    await c1.activate();
+    await c2.activate();
+
+    const docKey = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
+    type PresenceType = { counter: number };
+    const doc1 = new yorkie.Document<{}, PresenceType>(docKey);
+    await c1.attach(doc1, {
+      initialPresence: { counter: 0 },
+      isRealtimeSync: false,
+    });
+
+    const doc2 = new yorkie.Document<{}, PresenceType>(docKey);
+    await c2.attach(doc2, {
+      initialPresence: { counter: 0 },
+      isRealtimeSync: false,
+    });
+
+    doc1.update((root, p) => {
+      const counter = p.get('counter');
+      p.set({ counter: counter + 1 });
+    });
+    assert.deepEqual(doc1.getPresence(c1.getID()!), { counter: 1 });
+
+    await c1.sync();
+    await c2.sync();
+    assert.deepEqual(doc2.getPresence(c1.getID()!), { counter: 1 });
+  });
 });
 
 describe(`Document.Subscribe('presence')`, function () {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

The presence value can be obtained using the `presence.get()` function within the `doc.update` function

```js
client.attach(doc, {
    initialPresence: { counter: 0 },
});

// as-is
doc.update((root, p) => {
    const counter = doc.getMyPresence().counter;
    p.set({ counter: counter + 1 });
});

// to-be
doc.update((root, p) => {
    const counter = p.get('counter');
    p.set({ counter: counter + 1 });
});
```


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
