### PR TITLE
Fix event-related tests to be deterministic

### DIFF
--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -23,14 +23,6 @@ import { OperationInfo } from '@yorkie-js-sdk/src/document/operation/operation';
 
 export type Indexable = Record<string, any>;
 
-export async function sleep(interval = 1000): Promise<void> {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      resolve();
-    }, interval);
-  });
-}
-
 export async function waitStubCallCount(
   stub: sinon.SinonStub,
   callCount: number,

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -41,6 +41,42 @@ export async function waitStubCallCount(
   });
 }
 
+/**
+ * EventCollector provides a utility to collect and manage events.
+ * It can be used in tests to wait for events to be collected.
+ */
+export class EventCollector {
+  private events: Array<string>;
+
+  constructor() {
+    this.events = [];
+  }
+
+  public add(event: string) {
+    this.events.push(event);
+  }
+
+  /**
+   * `waitFor` waits for the specified event to be collected.
+   */
+  public waitFor(event: string) {
+    return new Promise((resolve) => {
+      const doLoop = () => {
+        if (this.events.includes(event)) {
+          resolve(event);
+          return;
+        }
+        setTimeout(doLoop, 0);
+      };
+      doLoop();
+    });
+  }
+
+  public reset() {
+    this.events = [];
+  }
+}
+
 export function deepSort(target: any): any {
   if (Array.isArray(target)) {
     return target.map(deepSort).sort(compareFunction);

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -23,47 +23,57 @@ import { OperationInfo } from '@yorkie-js-sdk/src/document/operation/operation';
 
 export type Indexable = Record<string, any>;
 
-export async function waitStubCallCount(
-  stub: sinon.SinonStub,
-  callCount: number,
-) {
-  return new Promise<void>((resolve) => {
-    const doLoop = () => {
-      if (stub.callCount >= callCount) {
-        resolve();
-        return;
-      }
-
-      setTimeout(doLoop, 0);
-    };
-
-    doLoop();
-  });
-}
-
 /**
  * EventCollector provides a utility to collect and manage events.
  * It can be used in tests to wait for events to be collected.
  */
-export class EventCollector {
-  private events: Array<string>;
+export class EventCollector<E = string> {
+  private events: Array<E>;
 
   constructor() {
     this.events = [];
   }
 
-  public add(event: string) {
+  public add(event: E) {
     this.events.push(event);
   }
 
   /**
-   * `waitFor` waits for the specified event to be collected.
+   * `waitAndVerifyNthEvent` waits for the nth event to occur and then
+   * verifies whether the event matches the expected event.
    */
-  public waitFor(event: string) {
-    return new Promise((resolve) => {
+  public waitAndVerifyNthEvent(count: number, event: E) {
+    return new Promise<void>((resolve, reject) => {
       const doLoop = () => {
-        if (this.events.includes(event)) {
-          resolve(event);
+        if (this.events.length >= count) {
+          if (deepEqual(this.events[count - 1], event)) {
+            resolve();
+          } else {
+            reject(
+              new Error(`event is not equal -
+                expected: ${JSON.stringify(event)},
+                actual: ${JSON.stringify(this.events[count - 1])}`),
+            );
+          }
+          return;
+        }
+        setTimeout(doLoop, 0);
+      };
+      doLoop();
+    });
+  }
+
+  /**
+   * `waitFor` waits for the specified event to be collected.
+   *
+   * Note(chacha912): Before calling `waitFor`, it's recommended to use `reset` to clear the events array.
+   * If the event was previously present in the events array, it may not be accurately detected.
+   */
+  public waitFor(event: E) {
+    return new Promise<void>((resolve) => {
+      const doLoop = () => {
+        if (this.events.some((e) => deepEqual(e, event))) {
+          resolve();
           return;
         }
         setTimeout(doLoop, 0);
@@ -74,6 +84,10 @@ export class EventCollector {
 
   public reset() {
     this.events = [];
+  }
+
+  public getLength() {
+    return this.events.length;
   }
 }
 
@@ -90,6 +104,36 @@ export function deepSort(target: any): any {
       }, {} as Record<string, any>);
   }
   return target;
+}
+
+function deepEqual(actual: any, expected: any) {
+  if (actual === expected) {
+    return true;
+  }
+
+  if (
+    typeof actual !== 'object' ||
+    actual === null ||
+    typeof expected !== 'object' ||
+    expected === null
+  ) {
+    return false;
+  }
+
+  const keysA = Object.keys(actual);
+  const keysB = Object.keys(expected);
+
+  if (keysA.length !== keysB.length) {
+    return false;
+  }
+
+  for (const key of keysA) {
+    if (!keysB.includes(key) || !deepEqual(actual[key], expected[key])) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 function compareFunction(a: any, b: any): number {

--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -6,13 +6,12 @@ import {
   toDocKey,
 } from '@yorkie-js-sdk/test/integration/integration_helper';
 import {
-  waitStubCallCount,
+  EventCollector,
   assertThrowsAsync,
 } from '@yorkie-js-sdk/test/helper/helper';
 import type { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
 import {
   DocumentStatus,
-  DocEvent,
   DocEventType,
 } from '@yorkie-js-sdk/src/document/document';
 import { OperationInfo } from '@yorkie-js-sdk/src/document/operation/operation';
@@ -65,13 +64,14 @@ describe('Document', function () {
     const d2 = new yorkie.Document<{ k1: string }>(docKey);
     await c1.attach(d1);
     await c2.attach(d2);
-    const d1Events: Array<string> = [];
-    const d2Events: Array<string> = [];
+
+    const eventCollectorD1 = new EventCollector();
+    const eventCollectorD2 = new EventCollector();
     const stub1 = sinon.stub().callsFake((event) => {
-      d1Events.push(event.type);
+      eventCollectorD1.add(event.type);
     });
     const stub2 = sinon.stub().callsFake((event) => {
-      d2Events.push(event.type);
+      eventCollectorD2.add(event.type);
     });
     const unsub1 = d1.subscribe(stub1);
     const unsub2 = d2.subscribe(stub2);
@@ -80,10 +80,8 @@ describe('Document', function () {
       root['k1'] = 'v1';
     });
 
-    await waitStubCallCount(stub2, 1); // c2 local-change
-    assert.equal(d2Events[0], DocEventType.LocalChange);
-    await waitStubCallCount(stub1, 1); // c2 remote-change
-    assert.equal(d1Events[0], DocEventType.RemoteChange);
+    await eventCollectorD2.waitAndVerifyNthEvent(1, DocEventType.LocalChange);
+    await eventCollectorD1.waitAndVerifyNthEvent(1, DocEventType.RemoteChange);
     assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
     unsub1();
@@ -117,17 +115,20 @@ describe('Document', function () {
     const d2 = new yorkie.Document<TestDoc>(docKey);
     await c1.attach(d1);
     await c2.attach(d2);
-    const events1: Array<OperationInfo> = [];
-    let expectedEvents1: Array<OperationInfo> = [];
-    const events2: Array<OperationInfo> = [];
-    let expectedEvents2: Array<OperationInfo> = [];
-    const pushEvent = (event: DocEvent, events: Array<OperationInfo>) => {
-      if (event.type !== DocEventType.RemoteChange) return;
-      const { operations } = event.value;
-      events.push(...operations);
+
+    type EventForTest = {
+      type: DocEventType;
+      value: Array<OperationInfo>;
     };
-    const stub1 = sinon.stub().callsFake((event) => pushEvent(event, events1));
-    const stub2 = sinon.stub().callsFake((event) => pushEvent(event, events2));
+    let expectedEventValue: Array<OperationInfo>;
+    const eventCollectorD1 = new EventCollector<EventForTest>();
+    const eventCollectorD2 = new EventCollector<EventForTest>();
+    const stub1 = sinon.stub().callsFake((event) => {
+      eventCollectorD1.add({ type: event.type, value: event.value.operations });
+    });
+    const stub2 = sinon.stub().callsFake((event) => {
+      eventCollectorD2.add({ type: event.type, value: event.value.operations });
+    });
     const unsub1 = d1.subscribe(stub1);
     const unsub2 = d2.subscribe(stub2);
 
@@ -150,40 +151,45 @@ describe('Document', function () {
       };
       root.obj.score = { science: 100 };
       delete root.obj.food;
-      expectedEvents2 = [
-        { type: 'set', path: '$', key: 'counter' },
-        { type: 'set', path: '$', key: 'todos' },
-        { type: 'add', path: '$.todos', index: 0 },
-        { type: 'add', path: '$.todos', index: 1 },
-        { type: 'add', path: '$.todos', index: 2 },
-        { type: 'set', path: '$', key: 'content' },
-        {
-          type: 'edit',
-          from: 0,
-          to: 0,
-          value: {
-            attributes: { italic: true, objAttr: { key1: { key2: 'value' } } },
-            content: 'hello world',
-          },
-          path: '$.content',
-        },
-        { type: 'set', path: '$', key: 'obj' },
-        { type: 'set', path: '$.obj', key: 'name' },
-        { type: 'set', path: '$.obj', key: 'age' },
-        { type: 'set', path: '$.obj', key: 'food' },
-        { type: 'add', path: '$.obj.food', index: 0 },
-        { type: 'add', path: '$.obj.food', index: 1 },
-        { type: 'set', path: '$.obj', key: 'score' },
-        { type: 'set', path: '$.obj.score', key: 'english' },
-        { type: 'set', path: '$.obj.score', key: 'math' },
-        { type: 'set', path: '$.obj', key: 'score' },
-        { type: 'set', path: '$.obj.score', key: 'science' },
-        { type: 'remove', path: '$.obj', key: 'food' },
-      ];
     });
-
-    await waitStubCallCount(stub1, 1); // c1 local-change
-    await waitStubCallCount(stub2, 1); // c1 remote-change
+    expectedEventValue = [
+      { type: 'set', path: '$', key: 'counter' },
+      { type: 'set', path: '$', key: 'todos' },
+      { type: 'add', path: '$.todos', index: 0 },
+      { type: 'add', path: '$.todos', index: 1 },
+      { type: 'add', path: '$.todos', index: 2 },
+      { type: 'set', path: '$', key: 'content' },
+      {
+        type: 'edit',
+        from: 0,
+        to: 0,
+        value: {
+          attributes: { italic: true, objAttr: { key1: { key2: 'value' } } },
+          content: 'hello world',
+        },
+        path: '$.content',
+      },
+      { type: 'set', path: '$', key: 'obj' },
+      { type: 'set', path: '$.obj', key: 'name' },
+      { type: 'set', path: '$.obj', key: 'age' },
+      { type: 'set', path: '$.obj', key: 'food' },
+      { type: 'add', path: '$.obj.food', index: 0 },
+      { type: 'add', path: '$.obj.food', index: 1 },
+      { type: 'set', path: '$.obj', key: 'score' },
+      { type: 'set', path: '$.obj.score', key: 'english' },
+      { type: 'set', path: '$.obj.score', key: 'math' },
+      { type: 'set', path: '$.obj', key: 'score' },
+      { type: 'set', path: '$.obj.score', key: 'science' },
+      { type: 'remove', path: '$.obj', key: 'food' },
+    ];
+    await eventCollectorD1.waitAndVerifyNthEvent(1, {
+      type: DocEventType.LocalChange,
+      value: expectedEventValue,
+    });
+    await eventCollectorD2.waitAndVerifyNthEvent(1, {
+      type: DocEventType.RemoteChange,
+      value: expectedEventValue,
+    });
 
     d2.update((root) => {
       root.counter.increase(1);
@@ -192,41 +198,33 @@ describe('Document', function () {
       const currItem = root.todos.getElementByIndex!(0);
       root.todos.moveAfter!(prevItem.getID!(), currItem.getID!());
       root.content.setStyle(0, 5, { bold: true });
-      expectedEvents1 = [
-        { type: 'increase', path: '$.counter', value: 1 },
-        { type: 'add', path: '$.todos', index: 3 },
-        {
-          type: 'move',
-          path: '$.todos',
-          index: 1,
-          previousIndex: 0,
-        },
-        {
-          type: 'style',
-          from: 0,
-          to: 5,
-          value: { attributes: { bold: true } },
-          path: '$.content',
-        },
-      ];
     });
-    await waitStubCallCount(stub1, 2); // c2 remote-change
-    await waitStubCallCount(stub2, 2); // c2 local-change
+    expectedEventValue = [
+      { type: 'increase', path: '$.counter', value: 1 },
+      { type: 'add', path: '$.todos', index: 3 },
+      {
+        type: 'move',
+        path: '$.todos',
+        index: 1,
+        previousIndex: 0,
+      },
+      {
+        type: 'style',
+        from: 0,
+        to: 5,
+        value: { attributes: { bold: true } },
+        path: '$.content',
+      },
+    ];
+    await eventCollectorD1.waitAndVerifyNthEvent(2, {
+      type: DocEventType.RemoteChange,
+      value: expectedEventValue,
+    });
+    await eventCollectorD2.waitAndVerifyNthEvent(2, {
+      type: DocEventType.LocalChange,
+      value: expectedEventValue,
+    });
     assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-    assert.deepEqual(
-      events1,
-      expectedEvents1,
-      `d1 event actual: ${JSON.stringify(
-        events1,
-      )} \n expected: ${JSON.stringify(expectedEvents1)}`,
-    );
-    assert.deepEqual(
-      events2,
-      expectedEvents2,
-      `d2 event actual: ${JSON.stringify(
-        events2,
-      )} \n expected: ${JSON.stringify(expectedEvents2)}`,
-    );
     unsub1();
     unsub2();
 
@@ -251,21 +249,20 @@ describe('Document', function () {
     const d2 = new yorkie.Document<TestDoc>(docKey);
     await c1.attach(d1);
     await c2.attach(d2);
-    let events: Array<OperationInfo> = [];
-    let todoEvents: Array<OperationInfo> = [];
-    let counterEvents: Array<OperationInfo> = [];
-    const pushEvent = (event: DocEvent, events: Array<OperationInfo>) => {
-      if (event.type !== DocEventType.RemoteChange) return;
-      const { operations } = event.value;
-      events.push(...operations);
-    };
-    const stub = sinon.stub().callsFake((event) => pushEvent(event, events));
-    const stubTodo = sinon
-      .stub()
-      .callsFake((event) => pushEvent(event, todoEvents));
-    const stubCounter = sinon
-      .stub()
-      .callsFake((event) => pushEvent(event, counterEvents));
+
+    type EventForTest = Array<OperationInfo>;
+    const eventCollector = new EventCollector<EventForTest>();
+    const eventCollectorForTodos = new EventCollector<EventForTest>();
+    const eventCollectorForCounter = new EventCollector<EventForTest>();
+    const stub = sinon.stub().callsFake((event) => {
+      eventCollector.add(event.value.operations);
+    });
+    const stubTodo = sinon.stub().callsFake((event) => {
+      eventCollectorForTodos.add(event.value.operations);
+    });
+    const stubCounter = sinon.stub().callsFake((event) => {
+      eventCollectorForCounter.add(event.value.operations);
+    });
     const unsub = d1.subscribe(stub);
     const unsubTodo = d1.subscribe('$.todos', stubTodo);
     const unsubCounter = d1.subscribe('$.counter', stubCounter);
@@ -274,63 +271,54 @@ describe('Document', function () {
       root.counter = new yorkie.Counter(yorkie.IntType, 0);
       root.todos = ['todo1', 'todo2'];
     });
-    await waitStubCallCount(stub, 1);
-    await waitStubCallCount(stubTodo, 1);
-    assert.deepEqual(events, [
+    await eventCollector.waitAndVerifyNthEvent(1, [
       { type: 'set', path: '$', key: 'counter' },
       { type: 'set', path: '$', key: 'todos' },
       { type: 'add', path: '$.todos', index: 0 },
       { type: 'add', path: '$.todos', index: 1 },
     ]);
-    assert.deepEqual(todoEvents, [
+    await eventCollectorForTodos.waitAndVerifyNthEvent(1, [
       { type: 'add', path: '$.todos', index: 0 },
       { type: 'add', path: '$.todos', index: 1 },
     ]);
-    events = [];
-    todoEvents = [];
 
     d2.update((root) => {
       root.counter.increase(10);
     });
-    await waitStubCallCount(stub, 2);
-    await waitStubCallCount(stubCounter, 1);
-    assert.deepEqual(events, [
+    await eventCollector.waitAndVerifyNthEvent(2, [
       { type: 'increase', path: '$.counter', value: 10 },
     ]);
-    assert.deepEqual(counterEvents, [
+    await eventCollectorForCounter.waitAndVerifyNthEvent(1, [
       { type: 'increase', path: '$.counter', value: 10 },
     ]);
-    events = [];
-    counterEvents = [];
 
     d2.update((root) => {
       root.todos.push('todo3');
     });
-    await waitStubCallCount(stub, 3);
-    await waitStubCallCount(stubTodo, 2);
-    assert.deepEqual(events, [{ type: 'add', path: '$.todos', index: 2 }]);
-    assert.deepEqual(todoEvents, [{ type: 'add', path: '$.todos', index: 2 }]);
-    events = [];
-    todoEvents = [];
+    await eventCollector.waitAndVerifyNthEvent(3, [
+      { type: 'add', path: '$.todos', index: 2 },
+    ]);
+    await eventCollectorForTodos.waitAndVerifyNthEvent(2, [
+      { type: 'add', path: '$.todos', index: 2 },
+    ]);
 
     unsubTodo();
     d2.update((root) => {
       root.todos.push('todo4');
     });
-    await waitStubCallCount(stub, 4);
-    assert.deepEqual(events, [{ type: 'add', path: '$.todos', index: 3 }]);
-    assert.deepEqual(todoEvents, []);
-    events = [];
+    await eventCollector.waitAndVerifyNthEvent(4, [
+      { type: 'add', path: '$.todos', index: 3 },
+    ]);
+    assert.equal(eventCollectorForTodos.getLength(), 2); // No events after unsubscribing `$.todos`
 
     unsubCounter();
     d2.update((root) => {
       root.counter.increase(10);
     });
-    await waitStubCallCount(stub, 5);
-    assert.deepEqual(events, [
+    await eventCollector.waitAndVerifyNthEvent(5, [
       { type: 'increase', path: '$.counter', value: 10 },
     ]);
-    assert.deepEqual(counterEvents, []);
+    assert.equal(eventCollectorForCounter.getLength(), 1); // No events after unsubscribing `$.counter`
 
     unsub();
     await c1.detach(d1);
@@ -357,21 +345,20 @@ describe('Document', function () {
     const d2 = new yorkie.Document<TestDoc>(docKey);
     await c1.attach(d1);
     await c2.attach(d2);
-    let events: Array<OperationInfo> = [];
-    let todoEvents: Array<OperationInfo> = [];
-    let objEvents: Array<OperationInfo> = [];
-    const pushEvent = (event: DocEvent, events: Array<OperationInfo>) => {
-      if (event.type !== DocEventType.RemoteChange) return;
-      const { operations } = event.value;
-      events.push(...operations);
-    };
-    const stub = sinon.stub().callsFake((event) => pushEvent(event, events));
-    const stubTodo = sinon
-      .stub()
-      .callsFake((event) => pushEvent(event, todoEvents));
-    const stubObj = sinon
-      .stub()
-      .callsFake((event) => pushEvent(event, objEvents));
+
+    type EventForTest = Array<OperationInfo>;
+    const eventCollector = new EventCollector<EventForTest>();
+    const eventCollectorForTodos0 = new EventCollector<EventForTest>();
+    const eventCollectorForObjC1 = new EventCollector<EventForTest>();
+    const stub = sinon.stub().callsFake((event) => {
+      eventCollector.add(event.value.operations);
+    });
+    const stubTodo = sinon.stub().callsFake((event) => {
+      eventCollectorForTodos0.add(event.value.operations);
+    });
+    const stubObj = sinon.stub().callsFake((event) => {
+      eventCollectorForObjC1.add(event.value.operations);
+    });
     const unsub = d1.subscribe(stub);
     const unsubTodo = d1.subscribe('$.todos.0', stubTodo);
     const unsubObj = d1.subscribe('$.obj.c1', stubObj);
@@ -382,10 +369,7 @@ describe('Document', function () {
         c1: { name: 'josh', age: 14 },
       };
     });
-    await waitStubCallCount(stub, 1);
-    await waitStubCallCount(stubTodo, 1);
-    await waitStubCallCount(stubObj, 1);
-    assert.deepEqual(events, [
+    await eventCollector.waitAndVerifyNthEvent(1, [
       { type: 'set', path: '$', key: 'todos' },
       { type: 'add', path: '$.todos', index: 0 },
       { type: 'set', path: '$.todos.0', key: 'text' },
@@ -395,60 +379,52 @@ describe('Document', function () {
       { type: 'set', path: '$.obj.c1', key: 'name' },
       { type: 'set', path: '$.obj.c1', key: 'age' },
     ]);
-    assert.deepEqual(todoEvents, [
+    await eventCollectorForTodos0.waitAndVerifyNthEvent(1, [
       { type: 'set', path: '$.todos.0', key: 'text' },
       { type: 'set', path: '$.todos.0', key: 'completed' },
     ]);
-    assert.deepEqual(objEvents, [
+    await eventCollectorForObjC1.waitAndVerifyNthEvent(1, [
       { type: 'set', path: '$.obj.c1', key: 'name' },
       { type: 'set', path: '$.obj.c1', key: 'age' },
     ]);
-    events = [];
-    todoEvents = [];
-    objEvents = [];
 
     d2.update((root) => {
       root.obj.c1.name = 'john';
     });
-    await waitStubCallCount(stub, 2);
-    await waitStubCallCount(stubObj, 1);
-    assert.deepEqual(events, [{ type: 'set', path: '$.obj.c1', key: 'name' }]);
-    assert.deepEqual(objEvents, [
+    await eventCollector.waitAndVerifyNthEvent(2, [
       { type: 'set', path: '$.obj.c1', key: 'name' },
     ]);
-    events = [];
-    objEvents = [];
+    await eventCollectorForObjC1.waitAndVerifyNthEvent(2, [
+      { type: 'set', path: '$.obj.c1', key: 'name' },
+    ]);
 
     d2.update((root) => {
       root.todos[0].completed = true;
     });
-    await waitStubCallCount(stub, 3);
-    await waitStubCallCount(stubTodo, 2);
-    assert.deepEqual(events, [
+    await eventCollector.waitAndVerifyNthEvent(3, [
       { type: 'set', path: '$.todos.0', key: 'completed' },
     ]);
-    assert.deepEqual(todoEvents, [
+    await eventCollectorForTodos0.waitAndVerifyNthEvent(2, [
       { type: 'set', path: '$.todos.0', key: 'completed' },
     ]);
-    events = [];
-    todoEvents = [];
 
     unsubTodo();
     d2.update((root) => {
       root.todos[0].text = 'todo_1';
     });
-    await waitStubCallCount(stub, 4);
-    assert.deepEqual(events, [{ type: 'set', path: '$.todos.0', key: 'text' }]);
-    assert.deepEqual(todoEvents, []);
-    events = [];
+    await eventCollector.waitAndVerifyNthEvent(4, [
+      { type: 'set', path: '$.todos.0', key: 'text' },
+    ]);
+    assert.equal(eventCollectorForTodos0.getLength(), 2); // No events after unsubscribing `$.todos.0`
 
     unsubObj();
     d2.update((root) => {
       root.obj.c1.age = 15;
     });
-    await waitStubCallCount(stub, 5);
-    assert.deepEqual(events, [{ type: 'set', path: '$.obj.c1', key: 'age' }]);
-    assert.deepEqual(objEvents, []);
+    await eventCollector.waitAndVerifyNthEvent(5, [
+      { type: 'set', path: '$.obj.c1', key: 'age' },
+    ]);
+    assert.equal(eventCollectorForObjC1.getLength(), 2); // No events after unsubscribing `$.obj.c1`
 
     unsub();
     await c1.detach(d1);

--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -80,10 +80,10 @@ describe('Document', function () {
       root['k1'] = 'v1';
     });
 
-    await waitStubCallCount(stub2, 1);
-    assert.equal(d2Events.pop(), DocEventType.LocalChange);
-    await waitStubCallCount(stub1, 1);
-    assert.equal(d1Events.pop(), DocEventType.RemoteChange);
+    await waitStubCallCount(stub2, 1); // c2 local-change
+    assert.equal(d2Events[0], DocEventType.LocalChange);
+    await waitStubCallCount(stub1, 1); // c2 remote-change
+    assert.equal(d1Events[0], DocEventType.RemoteChange);
     assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
 
     unsub1();
@@ -182,8 +182,8 @@ describe('Document', function () {
       ];
     });
 
-    await waitStubCallCount(stub1, 1);
-    await waitStubCallCount(stub2, 1);
+    await waitStubCallCount(stub1, 1); // c1 local-change
+    await waitStubCallCount(stub2, 1); // c1 remote-change
 
     d2.update((root) => {
       root.counter.increase(1);
@@ -210,8 +210,8 @@ describe('Document', function () {
         },
       ];
     });
-    await waitStubCallCount(stub1, 2);
-    await waitStubCallCount(stub2, 2);
+    await waitStubCallCount(stub1, 2); // c2 remote-change
+    await waitStubCallCount(stub2, 2); // c2 local-change
     assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
     assert.deepEqual(
       events1,

--- a/test/integration/presence_test.ts
+++ b/test/integration/presence_test.ts
@@ -5,11 +5,7 @@ import {
   testRPCAddr,
   toDocKey,
 } from '@yorkie-js-sdk/test/integration/integration_helper';
-import {
-  waitStubCallCount,
-  sleep,
-  deepSort,
-} from '@yorkie-js-sdk/test/helper/helper';
+import { waitStubCallCount, deepSort } from '@yorkie-js-sdk/test/helper/helper';
 
 describe('Presence', function () {
   it('Can be built from a snapshot', async function () {
@@ -504,15 +500,9 @@ describe(`Document.Subscribe('presence')`, function () {
     await waitStubCallCount(stub1, 7); // c3 unwatched
 
     // 06. c2 performs manual sync and then resumes(switches to realtime sync).
-    //     After applying all changes, only the watched event is triggered.
-
-    // TODO(hackerwins): This is workaround for some non-deterministic behavior.
-    // We need to fix this issue.
-    await sleep();
     await c2.sync();
-    await sleep();
+    await c1.sync(); // After c1 applied c2's changes, only the watched event will be triggered.
     await c2.resume(doc2);
-    await sleep();
     await waitStubCallCount(stub1, 8); // c2 watched
 
     assert.deepEqual(stub1.args, [

--- a/test/integration/presence_test.ts
+++ b/test/integration/presence_test.ts
@@ -1,11 +1,11 @@
 import { assert } from 'chai';
 import * as sinon from 'sinon';
-import yorkie, { DocEventType } from '@yorkie-js-sdk/src/yorkie';
+import yorkie, { DocEvent, DocEventType } from '@yorkie-js-sdk/src/yorkie';
 import {
   testRPCAddr,
   toDocKey,
 } from '@yorkie-js-sdk/test/integration/integration_helper';
-import { waitStubCallCount, deepSort } from '@yorkie-js-sdk/test/helper/helper';
+import { EventCollector, deepSort } from '@yorkie-js-sdk/test/helper/helper';
 
 describe('Presence', function () {
   it('Can be built from a snapshot', async function () {
@@ -111,57 +111,46 @@ describe('Presence', function () {
     const c2ID = c2.getID()!;
 
     const docKey = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
+    const eventCollectorP1 = new EventCollector<DocEvent>();
+    const eventCollectorP2 = new EventCollector<DocEvent>();
     type PresenceType = { name: string };
     const doc1 = new yorkie.Document<{}, PresenceType>(docKey);
     await c1.attach(doc1, { initialPresence: { name: 'a' } });
-    const stub1 = sinon.stub();
+    const stub1 = sinon.stub().callsFake((event) => {
+      eventCollectorP1.add(event);
+    });
     const unsub1 = doc1.subscribe('presence', stub1);
 
     const doc2 = new yorkie.Document<{}, PresenceType>(docKey);
     await c2.attach(doc2, { initialPresence: { name: 'b' } });
-    const stub2 = sinon.stub();
+    const stub2 = sinon.stub().callsFake((event) => {
+      eventCollectorP2.add(event);
+    });
     const unsub2 = doc2.subscribe('presence', stub2);
-    await waitStubCallCount(stub1, 1); // c2 watched
+    await eventCollectorP1.waitAndVerifyNthEvent(1, {
+      type: DocEventType.Watched,
+      value: { clientID: c2ID, presence: { name: 'b' } },
+    });
 
     doc1.update((root, p) => p.set({ name: 'A' }));
     doc2.update((root, p) => p.set({ name: 'B' }));
 
-    await waitStubCallCount(stub1, 3); // c1 prsence-changed, c2 presence-changed
-    await waitStubCallCount(stub2, 2); // c1 prsence-changed, c2 presence-changed
-    assert.deepEqual(stub1.args, [
-      [
-        {
-          type: DocEventType.Watched,
-          value: { clientID: c2ID, presence: { name: 'b' } },
-        },
-      ],
-      [
-        {
-          type: DocEventType.PresenceChanged,
-          value: { clientID: c1ID, presence: { name: 'A' } },
-        },
-      ],
-      [
-        {
-          type: DocEventType.PresenceChanged,
-          value: { clientID: c2ID, presence: { name: 'B' } },
-        },
-      ],
-    ]);
-    assert.deepEqual(stub2.args, [
-      [
-        {
-          type: DocEventType.PresenceChanged,
-          value: { clientID: c2ID, presence: { name: 'B' } },
-        },
-      ],
-      [
-        {
-          type: DocEventType.PresenceChanged,
-          value: { clientID: c1ID, presence: { name: 'A' } },
-        },
-      ],
-    ]);
+    await eventCollectorP1.waitAndVerifyNthEvent(2, {
+      type: DocEventType.PresenceChanged,
+      value: { clientID: c1ID, presence: { name: 'A' } },
+    });
+    await eventCollectorP1.waitAndVerifyNthEvent(3, {
+      type: DocEventType.PresenceChanged,
+      value: { clientID: c2ID, presence: { name: 'B' } },
+    });
+    await eventCollectorP2.waitAndVerifyNthEvent(1, {
+      type: DocEventType.PresenceChanged,
+      value: { clientID: c2ID, presence: { name: 'B' } },
+    });
+    await eventCollectorP2.waitAndVerifyNthEvent(2, {
+      type: DocEventType.PresenceChanged,
+      value: { clientID: c1ID, presence: { name: 'A' } },
+    });
     assert.deepEqual(
       deepSort(doc2.getPresences()),
       deepSort([
@@ -171,7 +160,10 @@ describe('Presence', function () {
     );
     assert.deepEqual(
       deepSort(doc1.getPresences()),
-      deepSort(doc2.getPresences()),
+      deepSort([
+        { clientID: c2ID, presence: { name: 'B' } },
+        { clientID: c1ID, presence: { name: 'A' } },
+      ]),
     );
 
     await c1.deactivate();
@@ -232,8 +224,12 @@ describe('Presence', function () {
     await c1.attach(doc1, {
       initialPresence: { name: 'a1', cursor: { x: 0, y: 0 } },
     });
-    const stub1 = sinon.stub();
-    const unsub1 = doc1.subscribe('presence', stub1);
+
+    const eventCollector = new EventCollector<DocEvent>();
+    const stub = sinon.stub().callsFake((event) => {
+      eventCollector.add(event);
+    });
+    const unsub = doc1.subscribe('presence', stub);
 
     // 01. c2 attaches doc in realtime sync, and c3 attached doc in manual sync.
     const doc2 = new yorkie.Document<{}, PresenceType>(docKey);
@@ -245,8 +241,10 @@ describe('Presence', function () {
       initialPresence: { name: 'c1', cursor: { x: 0, y: 0 } },
       isRealtimeSync: false,
     });
-    await waitStubCallCount(stub1, 1); // c2 watched
-
+    await eventCollector.waitAndVerifyNthEvent(1, {
+      type: DocEventType.Watched,
+      value: { clientID: c2ID, presence: doc2.getMyPresence() },
+    });
     assert.deepEqual(doc1.getPresences(), [
       { clientID: c1ID, presence: doc1.getMyPresence() },
       { clientID: c2ID, presence: doc2.getMyPresence() },
@@ -255,17 +253,22 @@ describe('Presence', function () {
 
     // 02. c2 pauses the document (in manual sync), c3 resumes the document (in realtime sync).
     await c2.pause(doc2);
-    await waitStubCallCount(stub1, 2); // c2 unwatched
+    await eventCollector.waitAndVerifyNthEvent(2, {
+      type: DocEventType.Unwatched,
+      value: { clientID: c2ID, presence: doc2.getMyPresence() },
+    });
     await c3.resume(doc3);
-    await waitStubCallCount(stub1, 3); // c3 watched
-
+    await eventCollector.waitAndVerifyNthEvent(3, {
+      type: DocEventType.Watched,
+      value: { clientID: c3ID, presence: doc3.getMyPresence() },
+    });
     assert.deepEqual(doc1.getPresences(), [
       { clientID: c1ID, presence: doc1.getMyPresence() },
       { clientID: c3ID, presence: doc3.getMyPresence() },
     ]);
     assert.deepEqual(doc1.getPresence(c2ID), undefined);
 
-    unsub1();
+    unsub();
     await c1.deactivate();
     await c2.deactivate();
     await c3.deactivate();
@@ -313,20 +316,30 @@ describe(`Document.Subscribe('presence')`, function () {
     const c2ID = c2.getID()!;
 
     const docKey = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
+    const eventCollectorP1 = new EventCollector<DocEvent>();
+    const eventCollectorP2 = new EventCollector<DocEvent>();
     type PresenceType = { name: string; cursor: { x: number; y: number } };
     const doc1 = new yorkie.Document<{}, PresenceType>(docKey);
     await c1.attach(doc1, {
       initialPresence: { name: 'a', cursor: { x: 0, y: 0 } },
     });
-    const stub1 = sinon.stub();
+    const stub1 = sinon.stub().callsFake((event) => {
+      eventCollectorP1.add(event);
+    });
     const unsub1 = doc1.subscribe('presence', stub1);
 
     const doc2 = new yorkie.Document<{}, PresenceType>(docKey);
     await c2.attach(doc2, {
       initialPresence: { name: 'b', cursor: { x: 0, y: 0 } },
     });
-    const stub2 = sinon.stub();
+    const stub2 = sinon.stub().callsFake((event) => {
+      eventCollectorP2.add(event);
+    });
     const unsub2 = doc2.subscribe('presence', stub2);
+    await eventCollectorP1.waitAndVerifyNthEvent(1, {
+      type: DocEventType.Watched,
+      value: { clientID: c2ID, presence: doc2.getMyPresence() },
+    });
 
     doc1.update((root, p) => {
       p.set({ name: 'A' });
@@ -334,39 +347,14 @@ describe(`Document.Subscribe('presence')`, function () {
       p.set({ name: 'X' });
     });
 
-    await waitStubCallCount(stub1, 2); // c1 presence-changed, c2 watched
-    await waitStubCallCount(stub2, 1); // c1 presence-changed
-    assert.deepEqual(stub1.args, [
-      [
-        {
-          type: DocEventType.PresenceChanged,
-          value: {
-            clientID: c1ID,
-            presence: { name: 'X', cursor: { x: 1, y: 1 } },
-          },
-        },
-      ],
-      [
-        {
-          type: DocEventType.Watched,
-          value: {
-            clientID: c2ID,
-            presence: { name: 'b', cursor: { x: 0, y: 0 } },
-          },
-        },
-      ],
-    ]);
-    assert.deepEqual(stub2.args, [
-      [
-        {
-          type: DocEventType.PresenceChanged,
-          value: {
-            clientID: c1ID,
-            presence: { name: 'X', cursor: { x: 1, y: 1 } },
-          },
-        },
-      ],
-    ]);
+    await eventCollectorP1.waitAndVerifyNthEvent(2, {
+      type: DocEventType.PresenceChanged,
+      value: { clientID: c1ID, presence: doc1.getMyPresence() },
+    });
+    await eventCollectorP2.waitAndVerifyNthEvent(1, {
+      type: DocEventType.PresenceChanged,
+      value: { clientID: c1ID, presence: doc1.getMyPresence() },
+    });
 
     await c1.deactivate();
     await c2.deactivate();
@@ -385,40 +373,31 @@ describe(`Document.Subscribe('presence')`, function () {
 
     const docKey = toDocKey(`${this.test!.title}-${new Date().getTime()}`);
     type PresenceType = { name: string };
+    const eventCollector = new EventCollector<DocEvent>();
     const doc1 = new yorkie.Document<{}, PresenceType>(docKey);
     await c1.attach(doc1, {
-      initialPresence: {
-        name: 'a',
-      },
+      initialPresence: { name: 'a' },
     });
-    const stub1 = sinon.stub();
+    const stub1 = sinon.stub().callsFake((event) => {
+      eventCollector.add(event);
+    });
     const unsub1 = doc1.subscribe('presence', stub1);
 
     const doc2 = new yorkie.Document<{}, PresenceType>(docKey);
     await c2.attach(doc2, {
-      initialPresence: {
-        name: 'b',
-      },
+      initialPresence: { name: 'b' },
     });
-    await waitStubCallCount(stub1, 1); // c2 watched
+    await eventCollector.waitAndVerifyNthEvent(1, {
+      type: DocEventType.Watched,
+      value: { clientID: c2ID, presence: { name: 'b' } },
+    });
 
     await c2.detach(doc2);
-    await waitStubCallCount(stub1, 2); // c2 unwatched
+    await eventCollector.waitAndVerifyNthEvent(2, {
+      type: DocEventType.Unwatched,
+      value: { clientID: c2ID, presence: { name: 'b' } },
+    });
 
-    assert.deepEqual(stub1.args, [
-      [
-        {
-          type: DocEventType.Watched,
-          value: { clientID: c2ID, presence: { name: 'b' } },
-        },
-      ],
-      [
-        {
-          type: DocEventType.Unwatched,
-          value: { clientID: c2ID, presence: { name: 'b' } },
-        },
-      ],
-    ]);
     assert.deepEqual(
       deepSort(doc1.getPresences()),
       deepSort([{ clientID: c1ID, presence: { name: 'a' } }]),
@@ -450,8 +429,11 @@ describe(`Document.Subscribe('presence')`, function () {
     await c1.attach(doc1, {
       initialPresence: { name: 'a1', cursor: { x: 0, y: 0 } },
     });
-    const stub1 = sinon.stub();
-    const unsub1 = doc1.subscribe('presence', stub1);
+    const eventCollector = new EventCollector<DocEvent>();
+    const stub = sinon.stub().callsFake((event) => {
+      eventCollector.add(event);
+    });
+    const unsub = doc1.subscribe('presence', stub);
 
     // 01. c2 attaches doc in realtime sync, and c3 attached doc in manual sync.
     //     c1 receives the watched event from c2.
@@ -464,7 +446,13 @@ describe(`Document.Subscribe('presence')`, function () {
       initialPresence: { name: 'c1', cursor: { x: 0, y: 0 } },
       isRealtimeSync: false,
     });
-    await waitStubCallCount(stub1, 1); // c2 watched
+    await eventCollector.waitAndVerifyNthEvent(1, {
+      type: DocEventType.Watched,
+      value: {
+        clientID: c2ID,
+        presence: { cursor: { x: 0, y: 0 }, name: 'b1' },
+      },
+    });
 
     // 02. c2 and c3 update the presence.
     //     c1 receives the presence-changed event from c2.
@@ -474,14 +462,38 @@ describe(`Document.Subscribe('presence')`, function () {
     doc3.update((_, presence) => {
       presence.set({ name: 'c2' });
     });
-    await waitStubCallCount(stub1, 2); // c2 presence-changed
+    await eventCollector.waitAndVerifyNthEvent(2, {
+      type: DocEventType.PresenceChanged,
+      value: {
+        clientID: c2ID,
+        presence: { cursor: { x: 0, y: 0 }, name: 'b2' },
+      },
+    });
 
-    // 03. c2 pauses the document (in manual sync), c3 resumes the document (in realtime sync).
-    //     c1 receives an unwatched event from c2 and a watched event from c3.
+    // 03-1. c2 pauses the document, c1 receives an unwatched event from c2.
     await c2.pause(doc2);
-    await waitStubCallCount(stub1, 3); // c2 unwatched
+    await eventCollector.waitAndVerifyNthEvent(3, {
+      type: DocEventType.Unwatched,
+      value: {
+        clientID: c2ID,
+        presence: { cursor: { x: 0, y: 0 }, name: 'b2' },
+      },
+    });
+    // 03-2. c3 resumes the document, c1 receives a watched event from c3.
+    // NOTE(chacha912): The events are influenced by the timing of realtime sync
+    // and watch stream resolution. For deterministic testing, the resume is performed
+    // after the sync. Since the sync updates c1 with all previous presence changes
+    // from c3, only the watched event is triggered.
+    await c3.sync();
+    await c1.sync();
     await c3.resume(doc3);
-    await waitStubCallCount(stub1, 5); // c3 watched, c3 presence-changed
+    await eventCollector.waitAndVerifyNthEvent(4, {
+      type: DocEventType.Watched,
+      value: {
+        clientID: c3ID,
+        presence: { cursor: { x: 0, y: 0 }, name: 'c2' },
+      },
+    });
 
     // 04. c2 and c3 update the presence.
     //     c1 receives the presence-changed event from c3.
@@ -491,94 +503,37 @@ describe(`Document.Subscribe('presence')`, function () {
     doc3.update((_, presence) => {
       presence.set({ name: 'c3' });
     });
-    await waitStubCallCount(stub1, 6); // c3 presence-changed
+    await eventCollector.waitAndVerifyNthEvent(5, {
+      type: DocEventType.PresenceChanged,
+      value: {
+        clientID: c3ID,
+        presence: { cursor: { x: 0, y: 0 }, name: 'c3' },
+      },
+    });
 
-    // 05. c3 pauses the document (in manual sync),
-    //     c1 receives an unwatched event from c3.
+    // 05-1. c3 pauses the document, c1 receives an unwatched event from c3.
     await c3.pause(doc3);
-    await waitStubCallCount(stub1, 7); // c3 unwatched
+    await eventCollector.waitAndVerifyNthEvent(6, {
+      type: DocEventType.Unwatched,
+      value: {
+        clientID: c3ID,
+        presence: { cursor: { x: 0, y: 0 }, name: 'c3' },
+      },
+    });
 
-    // 06. c2 performs manual sync and then resumes(switches to realtime sync).
+    // 05-2. c2 resumes the document, c1 receives a watched event from c2.
     await c2.sync();
-    await c1.sync(); // After c1 applied c2's changes, only the watched event will be triggered.
+    await c1.sync();
     await c2.resume(doc2);
-    await waitStubCallCount(stub1, 8); // c2 watched
+    await eventCollector.waitAndVerifyNthEvent(7, {
+      type: DocEventType.Watched,
+      value: {
+        clientID: c2ID,
+        presence: { cursor: { x: 0, y: 0 }, name: 'b3' },
+      },
+    });
 
-    assert.deepEqual(stub1.args, [
-      [
-        {
-          type: DocEventType.Watched,
-          value: {
-            clientID: c2ID,
-            presence: { cursor: { x: 0, y: 0 }, name: 'b1' },
-          },
-        },
-      ],
-      [
-        {
-          type: DocEventType.PresenceChanged,
-          value: {
-            clientID: c2ID,
-            presence: { cursor: { x: 0, y: 0 }, name: 'b2' },
-          },
-        },
-      ],
-      [
-        {
-          type: DocEventType.Unwatched,
-          value: {
-            clientID: c2ID,
-            presence: { cursor: { x: 0, y: 0 }, name: 'b2' },
-          },
-        },
-      ],
-      [
-        {
-          type: DocEventType.Watched,
-          value: {
-            clientID: c3ID,
-            presence: { cursor: { x: 0, y: 0 }, name: 'c1' },
-          },
-        },
-      ],
-      [
-        {
-          type: DocEventType.PresenceChanged,
-          value: {
-            clientID: c3ID,
-            presence: { cursor: { x: 0, y: 0 }, name: 'c2' },
-          },
-        },
-      ],
-      [
-        {
-          type: DocEventType.PresenceChanged,
-          value: {
-            clientID: c3ID,
-            presence: { cursor: { x: 0, y: 0 }, name: 'c3' },
-          },
-        },
-      ],
-      [
-        {
-          type: DocEventType.Unwatched,
-          value: {
-            clientID: c3ID,
-            presence: { cursor: { x: 0, y: 0 }, name: 'c3' },
-          },
-        },
-      ],
-      [
-        {
-          type: DocEventType.Watched,
-          value: {
-            clientID: c2ID,
-            presence: { cursor: { x: 0, y: 0 }, name: 'b3' },
-          },
-        },
-      ],
-    ]);
-    unsub1();
+    unsub();
     await c1.deactivate();
     await c2.deactivate();
     await c3.deactivate();

--- a/test/integration/presence_test.ts
+++ b/test/integration/presence_test.ts
@@ -334,8 +334,8 @@ describe(`Document.Subscribe('presence')`, function () {
       p.set({ name: 'X' });
     });
 
-    await waitStubCallCount(stub1, 2);
-    await waitStubCallCount(stub2, 1);
+    await waitStubCallCount(stub1, 2); // c1 presence-changed, c2 watched
+    await waitStubCallCount(stub2, 1); // c1 presence-changed
     assert.deepEqual(stub1.args, [
       [
         {
@@ -400,10 +400,10 @@ describe(`Document.Subscribe('presence')`, function () {
         name: 'b',
       },
     });
-    await waitStubCallCount(stub1, 1);
+    await waitStubCallCount(stub1, 1); // c2 watched
 
     await c2.detach(doc2);
-    await waitStubCallCount(stub1, 2);
+    await waitStubCallCount(stub1, 2); // c2 unwatched
 
     assert.deepEqual(stub1.args, [
       [

--- a/test/unit/document/document_test.ts
+++ b/test/unit/document/document_test.ts
@@ -16,14 +16,10 @@
 
 import { assert } from 'chai';
 import * as sinon from 'sinon';
-import { waitStubCallCount } from '@yorkie-js-sdk/test/helper/helper';
+import { EventCollector } from '@yorkie-js-sdk/test/helper/helper';
 
 import { MaxTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import {
-  Document,
-  DocEvent,
-  DocEventType,
-} from '@yorkie-js-sdk/src/document/document';
+import { Document } from '@yorkie-js-sdk/src/document/document';
 import { OperationInfo } from '@yorkie-js-sdk/src/document/operation/operation';
 import { JSONArray, Text, Counter, Tree } from '@yorkie-js-sdk/src/yorkie';
 import { CounterType } from '@yorkie-js-sdk/src/document/crdt/counter';
@@ -944,116 +940,92 @@ describe('Document', function () {
 
   it('changeInfo test for object', async function () {
     const doc = new Document<any>('test-doc');
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    const expectedOps: Array<OperationInfo> = [];
-    const ops: Array<OperationInfo> = [];
-    const stub1 = sinon.stub().callsFake((event: DocEvent) => {
-      if (event.type !== DocEventType.LocalChange) return;
-      const { operations } = event.value;
-      ops.push(...operations);
+
+    type EventForTest = Array<OperationInfo>;
+    const eventCollector = new EventCollector<EventForTest>();
+    const stub = sinon.stub().callsFake((event) => {
+      eventCollector.add(event.value.operations);
     });
-    const unsub1 = doc.subscribe(stub1);
+    const unsub = doc.subscribe(stub);
 
     doc.update((root) => {
       root[''] = {};
-      expectedOps.push({ type: 'set', path: '$', key: '' });
       root.obj = {};
-      expectedOps.push({ type: 'set', path: '$', key: 'obj' });
       root.obj.a = 1;
-      expectedOps.push({ type: 'set', path: '$.obj', key: 'a' });
       delete root.obj.a;
-      expectedOps.push({ type: 'remove', path: '$.obj', key: 'a' });
       root.obj['$hello'] = 1;
-      expectedOps.push({ type: 'set', path: '$.obj', key: '$hello' });
       delete root.obj['$hello'];
-      expectedOps.push({ type: 'remove', path: '$.obj', key: '$hello' });
       delete root.obj;
-      expectedOps.push({ type: 'remove', path: '$', key: 'obj' });
     });
-    await waitStubCallCount(stub1, 1);
-    assert.deepEqual(
-      ops,
-      expectedOps,
-      `actual: ${JSON.stringify(ops)} \n expected: ${JSON.stringify(
-        expectedOps,
-      )}`,
-    );
 
-    unsub1();
+    await eventCollector.waitAndVerifyNthEvent(1, [
+      { type: 'set', path: '$', key: '' },
+      { type: 'set', path: '$', key: 'obj' },
+      { type: 'set', path: '$.obj', key: 'a' },
+      { type: 'remove', path: '$.obj', key: 'a' },
+      { type: 'set', path: '$.obj', key: '$hello' },
+      { type: 'remove', path: '$.obj', key: '$hello' },
+      { type: 'remove', path: '$', key: 'obj' },
+    ]);
+
+    unsub();
   });
 
   it('changeInfo test for array', async function () {
     const doc = new Document<any>('test-doc');
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    const expectedOps: Array<OperationInfo> = [];
-    const ops: Array<OperationInfo> = [];
-    const stub1 = sinon.stub().callsFake((event: DocEvent) => {
-      if (event.type !== DocEventType.LocalChange) return;
-      const { operations } = event.value;
-      ops.push(...operations);
+    type EventForTest = Array<OperationInfo>;
+    const eventCollector = new EventCollector<EventForTest>();
+    const stub = sinon.stub().callsFake((event) => {
+      eventCollector.add(event.value.operations);
     });
-    const unsub1 = doc.subscribe(stub1);
+    const unsub = doc.subscribe(stub);
 
     doc.update((root) => {
       root.arr = [];
-      expectedOps.push({ type: 'set', path: '$', key: 'arr' });
       root.arr.push(0);
-      expectedOps.push({ type: 'add', path: '$.arr', index: 0 });
       root.arr.push(1);
-      expectedOps.push({ type: 'add', path: '$.arr', index: 1 });
       delete root.arr[1];
-      expectedOps.push({ type: 'remove', path: '$.arr', index: 1 });
       root['$$hello'] = [];
-      expectedOps.push({ type: 'set', path: '$', key: '$$hello' });
       root['$$hello'].push(0);
-      expectedOps.push({ type: 'add', path: '$.$$hello', index: 0 });
     });
-    await waitStubCallCount(stub1, 1);
-    assert.deepEqual(
-      ops,
-      expectedOps,
-      `actual: ${JSON.stringify(ops)} \n expected: ${JSON.stringify(
-        expectedOps,
-      )}`,
-    );
 
-    unsub1();
+    await eventCollector.waitAndVerifyNthEvent(1, [
+      { type: 'set', path: '$', key: 'arr' },
+      { type: 'add', path: '$.arr', index: 0 },
+      { type: 'add', path: '$.arr', index: 1 },
+      { type: 'remove', path: '$.arr', index: 1 },
+      { type: 'set', path: '$', key: '$$hello' },
+      { type: 'add', path: '$.$$hello', index: 0 },
+    ]);
+
+    unsub();
   });
 
   it('changeInfo test for counter', async function () {
     type TestDoc = { cnt: Counter };
     const doc = new Document<TestDoc>('test-doc');
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    const expectedOps: Array<OperationInfo> = [];
-    const ops: Array<OperationInfo> = [];
-
-    const stub1 = sinon.stub().callsFake((event: DocEvent) => {
-      if (event.type !== DocEventType.LocalChange) return;
-      const { operations } = event.value;
-      ops.push(...operations);
+    type EventForTest = Array<OperationInfo>;
+    const eventCollector = new EventCollector<EventForTest>();
+    const stub = sinon.stub().callsFake((event) => {
+      eventCollector.add(event.value.operations);
     });
-    const unsub1 = doc.subscribe(stub1);
+    const unsub = doc.subscribe(stub);
 
     doc.update((root) => {
       root.cnt = new Counter(CounterType.IntegerCnt, 0);
-      expectedOps.push({ type: 'set', path: '$', key: 'cnt' });
       root.cnt.increase(1);
-      expectedOps.push({ type: 'increase', path: '$.cnt', value: 1 });
       root.cnt.increase(10);
-      expectedOps.push({ type: 'increase', path: '$.cnt', value: 10 });
       root.cnt.increase(-3);
-      expectedOps.push({ type: 'increase', path: '$.cnt', value: -3 });
     });
-    await waitStubCallCount(stub1, 1);
-    assert.deepEqual(
-      ops,
-      expectedOps,
-      `actual: ${JSON.stringify(ops)} \n expected: ${JSON.stringify(
-        expectedOps,
-      )}`,
-    );
 
-    unsub1();
+    await eventCollector.waitAndVerifyNthEvent(1, [
+      { type: 'set', path: '$', key: 'cnt' },
+      { type: 'increase', path: '$.cnt', value: 1 },
+      { type: 'increase', path: '$.cnt', value: 10 },
+      { type: 'increase', path: '$.cnt', value: -3 },
+    ]);
+
+    unsub();
   });
 
   it('support TypeScript', function () {
@@ -1072,85 +1044,68 @@ describe('Document', function () {
 
   it('changeInfo test for text', async function () {
     type TestDoc = { text: Text };
-
     const doc = new Document<TestDoc>('test-doc');
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    const expectedOps: Array<OperationInfo> = [];
-    const ops: Array<OperationInfo> = [];
-    const stub1 = sinon.stub().callsFake((event: DocEvent) => {
-      if (event.type !== DocEventType.LocalChange) return;
-      const { operations } = event.value;
-      ops.push(...operations);
+    type EventForTest = Array<OperationInfo>;
+    const eventCollector = new EventCollector<EventForTest>();
+    const stub = sinon.stub().callsFake((event) => {
+      eventCollector.add(event.value.operations);
     });
-    const unsub1 = doc.subscribe(stub1);
+    const unsub = doc.subscribe(stub);
 
     doc.update((root) => {
       root.text = new Text();
-      expectedOps.push({ type: 'set', path: '$', key: 'text' });
       root.text.edit(0, 0, 'hello world');
-      expectedOps.push({
+    });
+
+    await eventCollector.waitAndVerifyNthEvent(1, [
+      { type: 'set', path: '$', key: 'text' },
+      {
         type: 'edit',
         path: '$.text',
         from: 0,
         to: 0,
         value: { attributes: {}, content: 'hello world' },
-      });
-    });
-    await waitStubCallCount(stub1, 1);
-    assert.deepEqual(
-      ops,
-      expectedOps,
-      `actual: ${JSON.stringify(ops)} \n expected: ${JSON.stringify(
-        expectedOps,
-      )}`,
-    );
+      },
+    ]);
 
-    unsub1();
+    unsub();
   });
 
   it('changeInfo test for text with attributes', async function () {
     type TestDoc = { textWithAttr: Text };
     const doc = new Document<TestDoc>('test-doc');
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    const expectedOps: Array<OperationInfo> = [];
-    const ops: Array<OperationInfo> = [];
-    const stub1 = sinon.stub().callsFake((event: DocEvent) => {
-      if (event.type !== DocEventType.LocalChange) return;
-      const { operations } = event.value;
-      ops.push(...operations);
+    type EventForTest = Array<OperationInfo>;
+    const eventCollector = new EventCollector<EventForTest>();
+    const stub = sinon.stub().callsFake((event) => {
+      eventCollector.add(event.value.operations);
     });
-    const unsub1 = doc.subscribe(stub1);
+    const unsub = doc.subscribe(stub);
 
     doc.update((root) => {
       root.textWithAttr = new Text();
-      expectedOps.push({ type: 'set', path: '$', key: 'textWithAttr' });
       root.textWithAttr.edit(0, 0, 'hello world');
-      expectedOps.push({
+      root.textWithAttr.setStyle(0, 1, { bold: 'true' });
+    });
+
+    await eventCollector.waitAndVerifyNthEvent(1, [
+      { type: 'set', path: '$', key: 'textWithAttr' },
+      {
         type: 'edit',
         path: '$.textWithAttr',
         from: 0,
         to: 0,
         value: { attributes: {}, content: 'hello world' },
-      });
-      root.textWithAttr.setStyle(0, 1, { bold: 'true' });
-      expectedOps.push({
+      },
+      {
         type: 'style',
         path: '$.textWithAttr',
         from: 0,
         to: 1,
         value: { attributes: { bold: 'true' } },
-      });
-    });
-    await waitStubCallCount(stub1, 1);
-    assert.deepEqual(
-      ops,
-      expectedOps,
-      `actual: ${JSON.stringify(ops)} \n expected: ${JSON.stringify(
-        expectedOps,
-      )}`,
-    );
+      },
+    ]);
 
-    unsub1();
+    unsub();
   });
 
   it('insert elements before a specific node of array', function () {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This is a follow-up to the work in https://github.com/yorkie-team/yorkie-js-sdk/pull/599/commits/b2eb6d45ef35e9b7300d8ac653538eda80479566. I modified the event-related tests to ensure deterministic behavior.

There are two ways to test events:
- When the count and order of events are known:
  - Use `EventCollector.waitAndVerifyNthEvent()` to wait for the nth event to occur and verify it.
- When the count and order of events are unclear, but we need to check if certain events are received:
  - Use `EventCollector.waitFor()` to verify the occurrence of specific events.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
