### PR TITLE
Export types related to OperationInfo

### DIFF
--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -60,6 +60,11 @@ export {
 export { ActorID } from '@yorkie-js-sdk/src/document/time/actor_id';
 export type {
   OperationInfo,
+  TextOperationInfo,
+  CounterOperationInfo,
+  ArrayOperationInfo,
+  ObjectOperationInfo,
+  TreeOperationInfo,
   AddOpInfo,
   IncreaseOpInfo,
   RemoveOpInfo,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

I have added types for OperationInfo that was missing from https://yorkie.dev/yorkie-js-sdk/api-reference/yorkie-js-sdk.operationinfo.html.

| as-is | to-be| 
| :--: | :--: | 
| ![image](https://github.com/yorkie-team/yorkie-js-sdk/assets/81357083/748d39bd-675b-4915-8ba4-daa75047ff5c) | ![image](https://github.com/yorkie-team/yorkie-js-sdk/assets/81357083/3ec863c2-29ae-4e2d-974d-1e44fcb5a07b) | 


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
