### PR TITLE
Add test for concurrent rich-text editing in the Peritext example

### DIFF
--- a/test/integration/text_test.ts
+++ b/test/integration/text_test.ts
@@ -668,14 +668,14 @@ describe('peri-text example: text concurrent edit', function () {
       }, `add comment by c1`);
       assert.equal(
         d1.toSortedJSON(),
-        `{"k1":[{"attrs":{"comment":"Alice\\\'s comment"},"val":"The fox"},{"val":" jumped."}]}`,
+        `{"k1":[{"attrs":{"comment":"Alice\\'s comment"},"val":"The fox"},{"val":" jumped."}]}`,
       );
       d2.update((root) => {
         root.k1.setStyle(4, 15, { comment: `Bob's comment` });
       }, `add comment by c2`);
       assert.equal(
         d2.toSortedJSON(),
-        `{"k1":[{"val":"The "},{"attrs":{"comment":"Bob\\\'s comment"},"val":"fox jumped."}]}`,
+        `{"k1":[{"val":"The "},{"attrs":{"comment":"Bob\\'s comment"},"val":"fox jumped."}]}`,
       );
       await c1.sync();
       await c2.sync();
@@ -684,7 +684,7 @@ describe('peri-text example: text concurrent edit', function () {
       // so it would be better we can keep both comments.
       assert.equal(
         d1.toSortedJSON(),
-        `{"k1":[{"attrs":{"comment":"Alice\\\'s comment"},"val":"The "},{"attrs":{"comment":"Bob\\\'s comment"},"val":"fox"},{"attrs":{"comment":"Bob\\\'s comment"},"val":" jumped."}]}`,
+        `{"k1":[{"attrs":{"comment":"Alice\\'s comment"},"val":"The "},{"attrs":{"comment":"Bob\\'s comment"},"val":"fox"},{"attrs":{"comment":"Bob\\'s comment"},"val":" jumped."}]}`,
         'd1',
       );
       assert.equal(d2.toSortedJSON(), d1.toSortedJSON(), 'd2');


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Add test for concurrent text editing with [9 examples in Peritext](https://www.inkandswitch.com/peritext/#preserving-the-authors-intent)
Related: https://github.com/yorkie-team/yorkie/issues/672

#### Any background context you want to provide?

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
