### PR TITLE
fix remote cursor to maintain in quill example

### DIFF
--- a/public/quill.html
+++ b/public/quill.html
@@ -275,6 +275,23 @@
                     deltaOp.attributes = attributes;
                   }
                   deltaOperations.push(deltaOp);
+
+                  // fix remote selection maintainance - https://github.com/yorkie-team/yorkie-js-sdk/issues/553
+                  const currentSeletionIndex = quill.getSelection().index;
+                  const currentSeletionLength = quill.getSelection().length;
+
+                  const needToAdjustPresenceSelection = from<=currentSeletionIndex;
+                  
+                  if(needToAdjustPresenceSelection){
+                    doc.update((root, presence) => {
+                      presence.set({
+                        selection: root.content.indexRangeToPosRange([
+                          currentSeletionIndex+insert.length,
+                          currentSeletionIndex+insert.length + currentSeletionLength,
+                        ]),
+                      });
+                    }, `adjust selection by ${client.getID()}`);
+                  }
                 }
               } else if (op.type === 'style') {
                 const { attributes } = toDeltaOperation(op.value);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This is Draft PR to share issues while fixing #553 
so it works incorrect now.

#### Any background context you want to provide?
I added some simple code to set selection in case which needs to adjust remote selection, but it works wrong.
procedure is as follows.

![Aug-12-2023 17-58-50](https://github.com/yorkie-team/yorkie-js-sdk/assets/26531678/24e5fce3-e330-4e65-b97f-34ff52b05ef7)
1. client A selects ``123`` . (selection range is ``{index: 5, length: 3}``)
2. client B places cursor before ``1`` and insert text 'a'
3. since insertPosition(5) is equal to or less than remote cursor position(5), we need to adjust remote selection range ``{index: 5, length: 3}`` to ``{index: 6, length: 3}`` by using ``quill.setSelection``
4. that range which is sent to ``selection-change`` event changes to ``{index: 6, length: 2}`` . this is tricky.
<img width="388" alt="image" src="https://github.com/yorkie-team/yorkie-js-sdk/assets/26531678/fea3f176-e396-4c9c-8824-dda65a5694dc">





#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # 553

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
