### PR TITLE
Remove SelectOpInfo

### DIFF
--- a/src/document/operation/edit_operation.ts
+++ b/src/document/operation/edit_operation.ts
@@ -100,21 +100,14 @@ export class EditOperation extends Operation {
     if (!this.fromPos.equals(this.toPos)) {
       root.registerElementHasRemovedNodes(text);
     }
-    return changes.map(({ type, from, to, value }) => {
-      return type === 'content'
-        ? {
-            type: 'edit',
-            from,
-            to,
-            value,
-            path: root.createPath(this.getParentCreatedAt()),
-          }
-        : {
-            type: 'select',
-            from,
-            to,
-            path: root.createPath(this.getParentCreatedAt()),
-          };
+    return changes.map(({ from, to, value }) => {
+      return {
+        type: 'edit',
+        from,
+        to,
+        value,
+        path: root.createPath(this.getParentCreatedAt()),
+      };
     }) as Array<OperationInfo>;
   }
 

--- a/src/document/operation/operation.ts
+++ b/src/document/operation/operation.ts
@@ -34,7 +34,7 @@ export type OperationInfo =
 /**
  * `TextOperationInfo` represents the OperationInfo for the yorkie.Text.
  */
-export type TextOperationInfo = EditOpInfo | StyleOpInfo | SelectOpInfo;
+export type TextOperationInfo = EditOpInfo | StyleOpInfo;
 
 /**
  * `CounterOperationInfo` represents the OperationInfo for the yorkie.Counter.
@@ -128,16 +128,6 @@ export type StyleOpInfo = {
   value: {
     attributes: Indexable;
   };
-};
-
-/**
- * `SelectOpInfo` represents the information of the select operation.
- */
-export type SelectOpInfo = {
-  type: 'select';
-  from: number;
-  to: number;
-  path: string;
 };
 
 /**

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -72,7 +72,6 @@ export type {
   MoveOpInfo,
   EditOpInfo,
   StyleOpInfo,
-  SelectOpInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 
 export {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Remove 'selectOpInfo' as it is no longer needed. (Related https://github.com/yorkie-team/yorkie-js-sdk/pull/622)

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
