### PR TITLE
Disable realtime sync in gc test

### DIFF
--- a/test/integration/gc_test.ts
+++ b/test/integration/gc_test.ts
@@ -32,22 +32,22 @@ describe('Garbage Collection', function () {
       2?: Array<number>;
       3: number;
     }>('test-doc');
-    assert.equal('{}', doc.toSortedJSON());
+    assert.equal(doc.toSortedJSON(), '{}');
 
     doc.update((root) => {
       root['1'] = 1;
       root['2'] = [1, 2, 3];
       root['3'] = 3;
     }, 'set 1, 2, 3');
-    assert.equal('{"1":1,"2":[1,2,3],"3":3}', doc.toSortedJSON());
+    assert.equal(doc.toSortedJSON(), '{"1":1,"2":[1,2,3],"3":3}');
 
     doc.update((root) => {
       delete root['2'];
     }, 'deletes 2');
-    assert.equal('{"1":1,"3":3}', doc.toSortedJSON());
-    assert.equal(4, doc.getGarbageLen());
-    assert.equal(4, doc.garbageCollect(MaxTimeTicket));
-    assert.equal(0, doc.getGarbageLen());
+    assert.equal(doc.toSortedJSON(), '{"1":1,"3":3}');
+    assert.equal(doc.getGarbageLen(), 4);
+    assert.equal(doc.garbageCollect(MaxTimeTicket), 4);
+    assert.equal(doc.getGarbageLen(), 0);
   });
 
   it('disable GC test', function () {
@@ -62,15 +62,15 @@ describe('Garbage Collection', function () {
       root['2'] = [1, 2, 3];
       root['3'] = 3;
     }, 'set 1, 2, 3');
-    assert.equal('{"1":1,"2":[1,2,3],"3":3}', doc.toSortedJSON());
+    assert.equal(doc.toSortedJSON(), '{"1":1,"2":[1,2,3],"3":3}');
 
     doc.update((root) => {
       delete root['2'];
     }, 'deletes 2');
-    assert.equal('{"1":1,"3":3}', doc.toSortedJSON());
-    assert.equal(4, doc.getGarbageLen());
-    assert.equal(0, doc.garbageCollect(MaxTimeTicket));
-    assert.equal(4, doc.getGarbageLen());
+    assert.equal(doc.toSortedJSON(), '{"1":1,"3":3}');
+    assert.equal(doc.getGarbageLen(), 4);
+    assert.equal(doc.garbageCollect(MaxTimeTicket), 0);
+    assert.equal(doc.getGarbageLen(), 4);
   });
 
   it('garbage collection test2', function () {
@@ -84,26 +84,26 @@ describe('Garbage Collection', function () {
       delete root['1'];
     }, 'deletes the array');
 
-    assert.equal(size + 1, doc.garbageCollect(MaxTimeTicket));
+    assert.equal(doc.garbageCollect(MaxTimeTicket), size + 1);
   });
 
   it('garbage collection test3', function () {
     const doc = new yorkie.Document<{ list: Array<number> }>('test-doc');
-    assert.equal('{}', doc.toSortedJSON());
+    assert.equal(doc.toSortedJSON(), '{}');
 
     doc.update((root) => {
       root['list'] = [1, 2, 3];
     }, 'set 1, 2, 3');
-    assert.equal('{"list":[1,2,3]}', doc.toSortedJSON());
+    assert.equal(doc.toSortedJSON(), '{"list":[1,2,3]}');
 
     doc.update((root) => {
       delete root['list'][1];
     }, 'deletes 2');
-    assert.equal('{"list":[1,3]}', doc.toSortedJSON());
+    assert.equal(doc.toSortedJSON(), '{"list":[1,3]}');
 
-    assert.equal(1, doc.getGarbageLen());
-    assert.equal(1, doc.garbageCollect(MaxTimeTicket));
-    assert.equal(0, doc.getGarbageLen());
+    assert.equal(doc.getGarbageLen(), 1);
+    assert.equal(doc.garbageCollect(MaxTimeTicket), 1);
+    assert.equal(doc.getGarbageLen(), 0);
 
     const root = (doc.getRootObject().get('list') as CRDTArray)
       .getElements()
@@ -122,40 +122,40 @@ describe('Garbage Collection', function () {
     doc.update((root) => root.text.edit(0, 2, '12'));
 
     assert.equal(
-      '[0:00:0:0 ][3:00:1:0 12]{2:00:1:0 AB}[2:00:1:2 CD]',
       doc.getRoot().text.toTestString(),
+      '[0:00:0:0 ][3:00:1:0 12]{2:00:1:0 AB}[2:00:1:2 CD]',
     );
 
-    assert.equal(1, doc.getGarbageLen());
+    assert.equal(doc.getGarbageLen(), 1);
     doc.garbageCollect(MaxTimeTicket);
-    assert.equal(0, doc.getGarbageLen());
+    assert.equal(doc.getGarbageLen(), 0);
 
     assert.equal(
-      '[0:00:0:0 ][3:00:1:0 12][2:00:1:2 CD]',
       doc.getRoot().text.toTestString(),
+      '[0:00:0:0 ][3:00:1:0 12][2:00:1:2 CD]',
     );
 
     doc.update((root) => root.text.edit(2, 4, ''));
 
     assert.equal(
-      '[0:00:0:0 ][3:00:1:0 12]{2:00:1:2 CD}',
       doc.getRoot().text.toTestString(),
+      '[0:00:0:0 ][3:00:1:0 12]{2:00:1:2 CD}',
     );
   });
 
   it('garbage collection test for text', function () {
     const doc = new yorkie.Document<{ k1: Text }>('test-doc');
-    assert.equal('{}', doc.toSortedJSON());
+    assert.equal(doc.toSortedJSON(), '{}');
 
     let expectedMessage = '{"k1":[{"val":"Hello "},{"val":"mario"}]}';
     doc.update((root) => {
       root.k1 = new Text();
       root.k1.edit(0, 0, 'Hello world');
       root.k1.edit(6, 11, 'mario');
-      assert.equal(expectedMessage, root.toJSON!());
+      assert.equal(root.toJSON!(), expectedMessage);
     }, 'edit text k1');
-    assert.equal(expectedMessage, doc.toSortedJSON());
-    assert.equal(1, doc.getGarbageLen());
+    assert.equal(doc.toSortedJSON(), expectedMessage);
+    assert.equal(doc.getGarbageLen(), 1);
 
     expectedMessage =
       '{"k1":[{"val":"Hi"},{"val":" "},{"val":"j"},{"val":"ane"}]}';
@@ -165,21 +165,21 @@ describe('Garbage Collection', function () {
       text.edit(0, 5, 'Hi');
       text.edit(3, 4, 'j');
       text.edit(4, 8, 'ane');
-      assert.equal(expectedMessage, root.toJSON!());
+      assert.equal(root.toJSON!(), expectedMessage);
     }, 'deletes 2');
-    assert.equal(expectedMessage, doc.toSortedJSON());
+    assert.equal(doc.toSortedJSON(), expectedMessage);
 
     const expectedGarbageLen = 4;
-    assert.equal(expectedGarbageLen, doc.getGarbageLen());
-    assert.equal(expectedGarbageLen, doc.garbageCollect(MaxTimeTicket));
+    assert.equal(doc.getGarbageLen(), expectedGarbageLen);
+    assert.equal(doc.garbageCollect(MaxTimeTicket), expectedGarbageLen);
 
     const empty = 0;
-    assert.equal(empty, doc.getGarbageLen());
+    assert.equal(doc.getGarbageLen(), empty);
   });
 
   it('garbage collection test for text with attributes', function () {
     const doc = new yorkie.Document<{ k1: Text }>('test-doc');
-    assert.equal('{}', doc.toSortedJSON());
+    assert.equal(doc.toSortedJSON(), '{}');
 
     let expectedMessage =
       '{"k1":[{"attrs":{"b":"1"},"val":"Hello "},{"val":"mario"}]}';
@@ -188,10 +188,10 @@ describe('Garbage Collection', function () {
       root.k1 = new Text();
       root.k1.edit(0, 0, 'Hello world', { b: '1' });
       root.k1.edit(6, 11, 'mario');
-      assert.equal(expectedMessage, root.toJSON!());
+      assert.equal(root.toJSON!(), expectedMessage);
     }, 'edit text k1');
-    assert.equal(expectedMessage, doc.toSortedJSON());
-    assert.equal(1, doc.getGarbageLen());
+    assert.equal(doc.toSortedJSON(), expectedMessage);
+    assert.equal(doc.getGarbageLen(), 1);
 
     expectedMessage =
       '{"k1":[{"attrs":{"b":"1"},"val":"Hi"},{"attrs":{"b":"1"},"val":" "},{"val":"j"},{"attrs":{"b":"1"},"val":"ane"}]}';
@@ -201,21 +201,21 @@ describe('Garbage Collection', function () {
       text.edit(0, 5, 'Hi', { b: '1' });
       text.edit(3, 4, 'j');
       text.edit(4, 8, 'ane', { b: '1' });
-      assert.equal(expectedMessage, root.toJSON!());
+      assert.equal(root.toJSON!(), expectedMessage);
     }, 'edit text k1');
-    assert.equal(expectedMessage, doc.toSortedJSON());
+    assert.equal(doc.toSortedJSON(), expectedMessage);
 
     const expectedGarbageLen = 4;
-    assert.equal(expectedGarbageLen, doc.getGarbageLen());
-    assert.equal(expectedGarbageLen, doc.garbageCollect(MaxTimeTicket));
+    assert.equal(doc.getGarbageLen(), expectedGarbageLen);
+    assert.equal(doc.garbageCollect(MaxTimeTicket), expectedGarbageLen);
 
     const empty = 0;
-    assert.equal(empty, doc.getGarbageLen());
+    assert.equal(doc.getGarbageLen(), empty);
   });
 
   it('garbage collection test for tree', function () {
     const doc = new yorkie.Document<{ t: Tree }>('test-doc');
-    assert.equal('{}', doc.toSortedJSON());
+    assert.equal(doc.toSortedJSON(), '{}');
 
     doc.update((root) => {
       root.t = new Tree({
@@ -300,8 +300,8 @@ describe('Garbage Collection', function () {
     await client1.activate();
     await client2.activate();
 
-    await client1.attach(doc1);
-    await client2.attach(doc2);
+    await client1.attach(doc1, { isRealtimeSync: false });
+    await client2.attach(doc2, { isRealtimeSync: false });
 
     doc1.update((root) => {
       root.t = new Tree({
@@ -324,8 +324,8 @@ describe('Garbage Collection', function () {
       });
     });
 
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(0, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 0);
 
     // (0, 0) -> (1, 0): syncedseqs:(0, 0)
     await client1.sync();
@@ -336,33 +336,33 @@ describe('Garbage Collection', function () {
     doc2.update((root) => {
       root.t.editByPath([0, 0, 0], [0, 0, 2], { type: 'text', value: 'gh' });
     }, 'removes 2');
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(2, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 2);
 
     // (1, 1) -> (1, 2): syncedseqs:(0, 1)
     await client2.sync();
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(2, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 2);
 
     // (1, 2) -> (2, 2): syncedseqs:(1, 1)
     await client1.sync();
-    assert.equal(2, doc1.getGarbageLen());
-    assert.equal(2, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 2);
+    assert.equal(doc2.getGarbageLen(), 2);
 
     // (2, 2) -> (2, 2): syncedseqs:(1, 2)
     await client2.sync();
-    assert.equal(2, doc1.getGarbageLen());
-    assert.equal(2, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 2);
+    assert.equal(doc2.getGarbageLen(), 2);
 
     // (2, 2) -> (2, 2): syncedseqs:(2, 2): meet GC condition
     await client1.sync();
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(2, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 2);
 
     // (2, 2) -> (2, 2): syncedseqs:(2, 2): meet GC condition
     await client2.sync();
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(0, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 0);
 
     await client1.detach(doc1);
     await client2.detach(doc2);
@@ -383,8 +383,8 @@ describe('Garbage Collection', function () {
     await client1.activate();
     await client2.activate();
 
-    await client1.attach(doc1);
-    await client2.attach(doc2);
+    await client1.attach(doc1, { isRealtimeSync: false });
+    await client2.attach(doc2, { isRealtimeSync: false });
 
     doc1.update((root) => {
       root['1'] = 1;
@@ -392,8 +392,8 @@ describe('Garbage Collection', function () {
       root['3'] = 3;
     }, 'sets 1, 2, 3');
 
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(0, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 0);
 
     // (0, 0) -> (1, 0): syncedseqs:(0, 0)
     await client1.sync();
@@ -404,33 +404,33 @@ describe('Garbage Collection', function () {
     doc2.update((root) => {
       delete root['2'];
     }, 'removes 2');
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(4, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 4);
 
     // (1, 1) -> (1, 2): syncedseqs:(0, 1)
     await client2.sync();
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(4, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 4);
 
     // (1, 2) -> (2, 2): syncedseqs:(1, 1)
     await client1.sync();
-    assert.equal(4, doc1.getGarbageLen());
-    assert.equal(4, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 4);
+    assert.equal(doc2.getGarbageLen(), 4);
 
     // (2, 2) -> (2, 2): syncedseqs:(1, 2)
     await client2.sync();
-    assert.equal(4, doc1.getGarbageLen());
-    assert.equal(4, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 4);
+    assert.equal(doc2.getGarbageLen(), 4);
 
     // (2, 2) -> (2, 2): syncedseqs:(2, 2): meet GC condition
     await client1.sync();
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(4, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 4);
 
     // (2, 2) -> (2, 2): syncedseqs:(2, 2): meet GC condition
     await client2.sync();
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(0, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 0);
 
     await client1.detach(doc1);
     await client2.detach(doc2);
@@ -451,8 +451,8 @@ describe('Garbage Collection', function () {
     await client1.activate();
     await client2.activate();
 
-    await client1.attach(doc1);
-    await client2.attach(doc2);
+    await client1.attach(doc1, { isRealtimeSync: false });
+    await client2.attach(doc2, { isRealtimeSync: false });
 
     doc1.update((root) => {
       root.text = new Text();
@@ -461,8 +461,8 @@ describe('Garbage Collection', function () {
       root.textWithAttr.edit(0, 0, 'Hello World');
     }, 'sets text');
 
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(0, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 0);
 
     // (0, 0) -> (1, 0): syncedseqs:(0, 0)
     await client1.sync();
@@ -475,33 +475,33 @@ describe('Garbage Collection', function () {
       root.text.edit(1, 2, 'b');
       root.textWithAttr.edit(0, 1, 'a', { b: '1' });
     }, 'edit text type elements');
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(3, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 3);
 
     // (1, 1) -> (1, 2): syncedseqs:(0, 1)
     await client2.sync();
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(3, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 3);
 
     // (1, 2) -> (2, 2): syncedseqs:(1, 1)
     await client1.sync();
-    assert.equal(3, doc1.getGarbageLen());
-    assert.equal(3, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 3);
+    assert.equal(doc2.getGarbageLen(), 3);
 
     // (2, 2) -> (2, 2): syncedseqs:(1, 2)
     await client2.sync();
-    assert.equal(3, doc1.getGarbageLen());
-    assert.equal(3, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 3);
+    assert.equal(doc2.getGarbageLen(), 3);
 
     // (2, 2) -> (2, 2): syncedseqs:(2, 2): meet GC condition
     await client1.sync();
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(3, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 3);
 
     // (2, 2) -> (2, 2): syncedseqs:(2, 2): meet GC condition
     await client2.sync();
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(0, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 0);
 
     await client1.detach(doc1);
     await client2.detach(doc2);
@@ -528,8 +528,8 @@ describe('Garbage Collection', function () {
     await client1.activate();
     await client2.activate();
 
-    await client1.attach(doc1);
-    await client2.attach(doc2);
+    await client1.attach(doc1, { isRealtimeSync: false });
+    await client2.attach(doc2, { isRealtimeSync: false });
 
     doc1.update((root) => {
       root['1'] = 1;
@@ -541,8 +541,8 @@ describe('Garbage Collection', function () {
       root['5'].edit(0, 0, 'hi');
     }, 'sets 1, 2, 3, 4, 5');
 
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(0, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 0);
 
     // (0, 0) -> (1, 0): syncedseqs:(0, 0)
     await client1.sync();
@@ -555,25 +555,25 @@ describe('Garbage Collection', function () {
       root['4'].edit(0, 1, 'h');
       root['5'].edit(0, 1, 'h', { b: '1' });
     }, 'removes 2 and edit text type elements');
-    assert.equal(6, doc1.getGarbageLen());
-    assert.equal(0, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 6);
+    assert.equal(doc2.getGarbageLen(), 0);
 
     // (1, 1) -> (2, 1): syncedseqs:(1, 0)
     await client1.sync();
-    assert.equal(6, doc1.getGarbageLen());
-    assert.equal(0, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 6);
+    assert.equal(doc2.getGarbageLen(), 0);
 
     await client2.detach(doc2);
 
     // (2, 1) -> (2, 2): syncedseqs:(1, x)
     await client2.sync();
-    assert.equal(6, doc1.getGarbageLen());
-    assert.equal(6, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 6);
+    assert.equal(doc2.getGarbageLen(), 6);
 
     // (2, 2) -> (2, 2): syncedseqs:(2, x): meet GC condition
     await client1.sync();
-    assert.equal(0, doc1.getGarbageLen());
-    assert.equal(6, doc2.getGarbageLen());
+    assert.equal(doc1.getGarbageLen(), 0);
+    assert.equal(doc2.getGarbageLen(), 6);
 
     await client1.detach(doc1);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR disables real-time sync in the GC test by using the `{ isRealtimeSync: false }` option. 
While the test has luckily passed under ideal conditions, occasional failures could occur due to external factors, such as network latency. 
Additionally, I've updated the equality assertion functions to align with the JS interface, which follows the pattern `assert.equal(actual, expected)`. These changes should improve code consistency and make debugging easier.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
