### PR TITLE
feat: remove vitest single thread config

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,6 @@ export default defineConfig({
     },
     environment: 'custom-jsdom',
     globals: true,
-    singleThread: true,
     testTimeout: isCI ? 5000 : Infinity,
   },
   plugins: [tsconfigPaths()],


### PR DESCRIPTION
#### What this PR does / why we need it?

Let vitest use multi threads to reduce the time it takes.

The test took about 20% less time(~90s to ~70s) in my local environment.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #654 #665


### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
