### PR TITLE
Publish npm package with provenance

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,6 +17,6 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm run build && npm run publish:prepare
-      - run: cd bundle && npm publish
+      - run: cd bundle && npm publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

To increase supply chain security, we should publish npm package with provenance.

Provenance data gives consumers a verifiable way to link a package back to its source repository and the specific build instructions used to publish it (see [example on npmjs.com](https://www.npmjs.com/package/@jongwooo/prism-theme-github#provenance)).

See [this page](https://github.blog/2023-04-19-introducing-npm-package-provenance/) to learn more.

#### Any background context you want to provide?

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #664 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
