### PR TITLE
Fit Next.js example style to the yorkie homepage

### DIFF
--- a/examples/nextjs-scheduler/app/styles/globals.css
+++ b/examples/nextjs-scheduler/app/styles/globals.css
@@ -1,6 +1,6 @@
 body {
   display: flex;
-  padding: 5rem;
+  padding: 1rem;
   justify-content: center;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
@@ -9,6 +9,7 @@ body {
   -moz-osx-font-smoothing: grayscale;
   font-size: 17px;
   color: #2f2f2f;
+  background-color: #cccccc;
 }
 
 input {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

It's hard to see the Next.js example in dark mode on the homepage.

<img width="510" alt="image" src="https://github.com/yorkie-team/yorkie-js-sdk/assets/2173789/ddc9af74-72cc-41b7-8be0-8a18c2a698ad">

This PR change the above screen to look like the one below.

<img width="442" alt="image" src="https://github.com/yorkie-team/yorkie-js-sdk/assets/2173789/6896604e-1d43-4569-a352-65cb8225d6e0">


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
