### PR TITLE
Fix missing collection of removed elements from the root

### DIFF
--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -978,6 +978,13 @@ export class Document<T, P extends Indexable = Indexable> {
   }
 
   /**
+   * `getGarbageLenFromClone` returns the length of elements should be purged from clone.
+   */
+  public getGarbageLenFromClone(): number {
+    return this.clone!.root.getGarbageLen();
+  }
+
+  /**
    * `toJSON` returns the JSON encoding of this document.
    */
   public toJSON(): string {

--- a/src/document/operation/set_operation.ts
+++ b/src/document/operation/set_operation.ts
@@ -68,8 +68,12 @@ export class SetOperation extends Operation {
     }
     const obj = parentObject as CRDTObject;
     const value = this.value.deepcopy();
-    obj.set(this.key, value);
+    const removed = obj.set(this.key, value);
     root.registerElement(value, obj);
+    if (removed) {
+      root.registerRemovedElement(removed);
+    }
+
     return {
       opInfos: [
         {

--- a/test/integration/gc_test.ts
+++ b/test/integration/gc_test.ts
@@ -586,4 +586,27 @@ describe('Garbage Collection', function () {
     await client1.deactivate();
     await client2.deactivate();
   });
+
+  it('Can collect removed elements from both root and clone', async function ({
+    task,
+  }) {
+    type TestDoc = { point: { x: number; y: number } };
+    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
+    const doc = new yorkie.Document<TestDoc>(docKey);
+    const cli = new yorkie.Client(testRPCAddr);
+    await cli.activate();
+
+    await cli.attach(doc, { isRealtimeSync: false });
+    doc.update((root) => {
+      root.point = { x: 0, y: 0 };
+    });
+    doc.update((root) => {
+      root.point = { x: 1, y: 1 };
+    });
+    doc.update((root) => {
+      root.point = { x: 2, y: 2 };
+    });
+    assert.equal(doc.getGarbageLen(), 6);
+    assert.equal(doc.getGarbageLenFromClone(), 6);
+  });
 });

--- a/test/unit/document/document_test.ts
+++ b/test/unit/document/document_test.ts
@@ -1189,7 +1189,7 @@ describe.sequential('Document', function () {
       delete root.a;
     });
     assert.equal('{}', doc.toSortedJSON());
-    assert.equal(1, doc.getGarbageLen());
+    assert.equal(2, doc.getGarbageLen());
 
     doc.garbageCollect(MaxTimeTicket);
     assert.equal('{}', doc.toSortedJSON());


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fix missing collection of removed elements from the root.

A document has two structures representing the user data: clone and root. When elements are removed by `document.update`, they are collected to `removedElementMapByCreatedAt` for garbage collection.

However, we found a bug in that the collection is missing in the root. So this commit fixes it.

#### Any background context you want to provide?

A. Luckily, the collection is not missing in Yorkie.

https://github.com/yorkie-team/yorkie/blob/a000a29d81d7e6557edfbe3cb5f2ce17b203c634/pkg/document/operations/set.go#L68-L72

B. Remove `Clone` from `Document`.

We've added `clone` to protect the root from unintended updates caused by document.update. However, keeping the clone and the root in sync is challenging and consumes twice as much memory. Therefore, it is better to remove the clone after introducing reverse operations from `Document.history`.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
