### PR TITLE
Add missing `removedAt` during Primitive deepcopy

### DIFF
--- a/src/document/crdt/primitive.ts
+++ b/src/document/crdt/primitive.ts
@@ -135,6 +135,7 @@ export class Primitive extends CRDTElement {
   public deepcopy(): Primitive {
     const primitive = Primitive.of(this.value, this.getCreatedAt());
     primitive.setMovedAt(this.getMovedAt());
+    primitive.setRemovedAt(this.getRemovedAt());
     return primitive;
   }
 

--- a/src/document/json/object.ts
+++ b/src/document/json/object.ts
@@ -169,7 +169,12 @@ export class ObjectProxy {
       const primitive = Primitive.of(value as PrimitiveValue, ticket);
       setAndRegister(primitive);
       context.push(
-        SetOperation.create(key, primitive, target.getCreatedAt(), ticket),
+        SetOperation.create(
+          key,
+          primitive.deepcopy(),
+          target.getCreatedAt(),
+          ticket,
+        ),
       );
     } else if (Array.isArray(value)) {
       const array = CRDTArray.create(ticket);

--- a/test/integration/object_test.ts
+++ b/test/integration/object_test.ts
@@ -253,7 +253,7 @@ describe('Object', function () {
       assert.equal(doc.toSortedJSON(), `{}`);
       assert.deepEqual(
         doc.getRedoStackForTest().at(-1)?.map(toStringHistoryOp),
-        ['0:00:0.SET.shape={"color":"black"}', '1:00:1.SET.color="black"'],
+        ['0:00:0.SET.shape={}', '1:00:1.SET.color="black"'],
       );
 
       doc.history.redo();

--- a/test/unit/document/document_test.ts
+++ b/test/unit/document/document_test.ts
@@ -229,6 +229,27 @@ describe.sequential('Document', function () {
     assert.equal(doc.toSortedJSON(), '{"list":[{"id":1}]}');
   });
 
+  it('splice array with nested object', function () {
+    const doc = new Document<{
+      list: Array<{ point: { x?: number; y?: number } }>;
+    }>('test-doc');
+
+    doc.update((root) => {
+      root.list = [{ point: { x: 0, y: 0 } }, { point: { x: 1, y: 1 } }];
+      delete root.list[1].point.y;
+    });
+    assert.equal(
+      doc.toSortedJSON(),
+      '{"list":[{"point":{"x":0,"y":0}},{"point":{"x":1}}]}',
+    );
+
+    doc.update((root) => {
+      const res = root.list.splice(1, 1);
+      assert.equal(res.toString(), '{"point":{"x":1}}');
+    });
+    assert.equal(doc.toSortedJSON(), '{"list":[{"point":{"x":0,"y":0}}]}');
+  });
+
   describe('should support standard array read-only operations', () => {
     type TestDoc = {
       empty: [];


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

When performing a Primitive deepcopy, the absence of `removedAt` led to a problem where deleted elements reappeared. This PR addresses the issue by making sure that removedAt is included in the primitive deepcopy.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
