### PR TITLE
Fix reading wrong .env path

### DIFF
--- a/tools/create-yorkie-app/index.ts
+++ b/tools/create-yorkie-app/index.ts
@@ -163,7 +163,9 @@ async function init() {
     }
 
     if (file === '.env') {
-      const envVariables = fs.readFileSync(file).toString();
+      const envVariables = fs
+        .readFileSync(path.join(templateDir, file))
+        .toString();
 
       write(
         file,

--- a/tools/create-yorkie-app/package.json
+++ b/tools/create-yorkie-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "create-yorkie-app",
-  "version": "0.4.7",
+  "version": "0.4.7-fix.1",
   "bin": {
     "create-yorkie-app": "dist/create-yorkie-app.mjs"
   },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fixes an issue that `create-yorkie-app` reads the wrong path when overwriting the .env.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #690

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
