### PR TITLE
Handle escape string for strings containing quotes

### DIFF
--- a/src/document/crdt/object.ts
+++ b/src/document/crdt/object.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { escapeString } from '@yorkie-js-sdk/src/document/json/strings';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import {
   CRDTContainer,
@@ -125,7 +126,7 @@ export class CRDTObject extends CRDTContainer {
   public toJSON(): string {
     const json = [];
     for (const [key, value] of this) {
-      json.push(`"${key}":${value.toJSON()}`);
+      json.push(`"${escapeString(key)}":${value.toJSON()}`);
     }
     return `{${json.join(',')}}`;
   }
@@ -182,7 +183,7 @@ export class CRDTObject extends CRDTContainer {
     const json = [];
     for (const key of keys.sort()) {
       const node = this.memberNodes.get(key)?.getValue();
-      json.push(`"${key}":${node!.toSortedJSON()}`);
+      json.push(`"${escapeString(key)}":${node!.toSortedJSON()}`);
     }
 
     return `{${json.join(',')}}`;

--- a/src/document/crdt/rht.ts
+++ b/src/document/crdt/rht.ts
@@ -125,7 +125,7 @@ export class RHT {
   public toJSON(): string {
     const items = [];
     for (const [key, node] of this.nodeMapByKey) {
-      items.push(`"${key}":"${escapeString(node.getValue())}"`);
+      items.push(`"${escapeString(key)}":"${escapeString(node.getValue())}"`);
     }
     return `{${items.join(',')}}`;
   }

--- a/src/document/crdt/text.ts
+++ b/src/document/crdt/text.ts
@@ -131,8 +131,8 @@ export class CRDTTextValue {
       const value = JSON.parse(v);
       const item =
         typeof value === 'string'
-          ? `"${key}":"${escapeString(value)}"`
-          : `"${key}":${String(value)}`;
+          ? `"${escapeString(key)}":"${escapeString(value)}"`
+          : `"${escapeString(key)}":${String(value)}`;
       attrs.push(item);
     }
     attrs.sort();

--- a/src/document/json/strings.ts
+++ b/src/document/json/strings.ts
@@ -5,7 +5,6 @@ export function escapeString(str: string): string {
   return str.replace(/["'\\\n\r\f\b\t\u2028\u2029]/g, function (character) {
     switch (character) {
       case '"':
-      case "'":
       case '\\':
         return '\\' + character;
       case '\n':

--- a/test/integration/text_test.ts
+++ b/test/integration/text_test.ts
@@ -707,14 +707,14 @@ describe('peri-text example: text concurrent edit', function () {
       }, `add comment by c1`);
       assert.equal(
         d1.toSortedJSON(),
-        `{"k1":[{"attrs":{"comment":"Alice\\'s comment"},"val":"The fox"},{"val":" jumped."}]}`,
+        `{"k1":[{"attrs":{"comment":"Alice's comment"},"val":"The fox"},{"val":" jumped."}]}`,
       );
       d2.update((root) => {
         root.k1.setStyle(4, 15, { comment: `Bob's comment` });
       }, `add comment by c2`);
       assert.equal(
         d2.toSortedJSON(),
-        `{"k1":[{"val":"The "},{"attrs":{"comment":"Bob\\'s comment"},"val":"fox jumped."}]}`,
+        `{"k1":[{"val":"The "},{"attrs":{"comment":"Bob's comment"},"val":"fox jumped."}]}`,
       );
       await c1.sync();
       await c2.sync();
@@ -723,7 +723,7 @@ describe('peri-text example: text concurrent edit', function () {
       // so it would be better we can keep both comments.
       assert.equal(
         d1.toSortedJSON(),
-        `{"k1":[{"attrs":{"comment":"Alice\\'s comment"},"val":"The "},{"attrs":{"comment":"Bob\\'s comment"},"val":"fox"},{"attrs":{"comment":"Bob\\'s comment"},"val":" jumped."}]}`,
+        `{"k1":[{"attrs":{"comment":"Alice's comment"},"val":"The "},{"attrs":{"comment":"Bob's comment"},"val":"fox"},{"attrs":{"comment":"Bob's comment"},"val":" jumped."}]}`,
         'd1',
       );
       assert.equal(d2.toSortedJSON(), d1.toSortedJSON(), 'd2');

--- a/test/unit/document/document_test.ts
+++ b/test/unit/document/document_test.ts
@@ -1228,6 +1228,21 @@ describe.sequential('Document', function () {
     assert.equal(0, doc.getGarbageLen());
   });
 
+  it('should handle escape string for strings containing single quotes', function () {
+    const doc = new Document<{ [key: string]: any }>('test-doc');
+    doc.update((root) => (root.str = `I'm yorkie`));
+    assert.equal(doc.toSortedJSON(), `{"str":"I'm yorkie"}`);
+    assert.deepEqual(JSON.parse(doc.toSortedJSON()), {
+      str: `I'm yorkie`,
+    });
+
+    doc.update((root) => (root.str = `I\\'m yorkie`));
+    assert.equal(doc.toSortedJSON(), `{"str":"I\\\\'m yorkie"}`);
+    assert.deepEqual(JSON.parse(doc.toSortedJSON()), {
+      str: `I\\'m yorkie`,
+    });
+  });
+
   it('escapes string for object', function () {
     const doc = new Document<{ a?: string }>('test-doc');
     doc.update((root) => {

--- a/test/unit/document/document_test.ts
+++ b/test/unit/document/document_test.ts
@@ -1243,6 +1243,15 @@ describe.sequential('Document', function () {
     });
   });
 
+  it('should handle escape string for object keys', function () {
+    const doc = new Document<{ [key: string]: any }>('test-doc');
+    doc.update((root) => (root[`it"s`] = `yorkie`));
+    assert.equal(doc.toSortedJSON(), `{"it\\"s":"yorkie"}`);
+    assert.deepEqual(JSON.parse(doc.toSortedJSON()), {
+      [`it"s`]: `yorkie`,
+    });
+  });
+
   it('escapes string for object', function () {
     const doc = new Document<{ a?: string }>('test-doc');
     doc.update((root) => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

In pull request #330, when implementing the escape string function, it referred to the [js-string-escape](https://github.com/joliss/js-string-escape) library. However, we missed a point mentioned in its documentation:

> Note that the returned string is not necessarily valid JSON, since JSON disallows control characters, and `\'` is illegal in JSON.

This caused an error due to the mishandling of single quotes during the escape string process. Since we don't need to handle single quotes specially, we removed that part. (Reference: [Chromium implementation](https://github.com/chromium/chromium/blob/fc0cb60674643692171a84bb94a92c8bf5781031/base/json/string_escape.cc#L33-L79)).

We also fixed a missing part in handling escape string for object keys.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #699

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
