### PR TITLE
Correct typos in the installation command on README.md in the example

### DIFF
--- a/examples/nextjs-scheduler/README.md
+++ b/examples/nextjs-scheduler/README.md
@@ -13,7 +13,7 @@
 At project root, run below command to start Yorkie server and Envoy proxy.
 
 ```bash
-$ docker-compose up -f docker/docker-compose.yml up --build -d
+$ docker-compose -f docker/docker-compose.yml up --build -d
 ```
 
 Then install dependencies and run the demo.

--- a/examples/react-todomvc/README.md
+++ b/examples/react-todomvc/README.md
@@ -13,7 +13,7 @@
 At project root, run below command to start Yorkie server and Envoy proxy.
 
 ```bash
-$ docker-compose up -f docker/docker-compose.yml up --build -d
+$ docker-compose -f docker/docker-compose.yml up --build -d
 ```
 
 Then install dependencies and run the demo.


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR change typo error on example's REAMD.md!
```bash
$ docker-compose up -f docker/docker-compose.yml up 
```
to
```bash
$ docker-compose -f docker/docker-compose.yml up 
```

#### Any background context you want to provide?
Maybe I'm mistaken because I don't know much about docker complex, but when I run it, it runs well when there's no **up** in front of it!


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #701

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
