### PR TITLE
Add `removeIfNotAttached` to `client.detach()` options

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -508,6 +508,9 @@ export class Client implements Observable<ClientEvent> {
    */
   public detach<T, P extends Indexable>(
     doc: Document<T, P>,
+    options: {
+      removeIfNotAttached?: boolean;
+    } = {},
   ): Promise<Document<T, P>> {
     if (!this.isActive()) {
       throw new YorkieError(Code.ClientNotActive, `${this.key} is not active`);
@@ -526,6 +529,7 @@ export class Client implements Observable<ClientEvent> {
       req.setClientId(this.id!);
       req.setDocumentId(attachment.docID);
       req.setChangePack(converter.toChangePack(doc.createChangePack()));
+      req.setRemoveIfNotAttached(options.removeIfNotAttached ?? false);
 
       this.rpcClient.detachDocument(
         req,

--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -56,6 +56,56 @@ describe('Document', function () {
     await client2.deactivate();
   });
 
+  it('Can remove document using removeIfNotAttached option when detaching', async function ({
+    task,
+  }) {
+    type TestDoc = { k1: Array<number>; k2: Array<number> };
+    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
+    const doc1 = new yorkie.Document<TestDoc>(docKey);
+    const doc2 = new yorkie.Document<TestDoc>(docKey);
+
+    const client1 = new yorkie.Client(testRPCAddr);
+    const client2 = new yorkie.Client(testRPCAddr);
+    await client1.activate();
+    await client2.activate();
+
+    // 1. client1 attaches and updates the document.
+    await client1.attach(doc1);
+    assert.equal('{}', doc1.toSortedJSON());
+    doc1.update((root) => {
+      root.k1 = [1, 2];
+      root.k2 = [3, 4];
+    });
+    await client1.sync();
+    assert.equal('{"k1":[1,2],"k2":[3,4]}', doc1.toSortedJSON());
+
+    // 2. client2 attaches the document.
+    await client2.attach(doc2);
+    assert.equal('{"k1":[1,2],"k2":[3,4]}', doc2.toSortedJSON());
+
+    // 3. client1 detaches the document.
+    // The document is not removed as client2 is still attached to it.
+    await client1.detach(doc1, { removeIfNotAttached: true });
+    assert.equal(doc1.getStatus(), DocumentStatus.Detached);
+
+    // 4. client2 detaches the document.
+    // Since no client is attached to the document, it gets removed.
+    await client2.detach(doc2, { removeIfNotAttached: true });
+    assert.equal(doc2.getStatus(), DocumentStatus.Removed);
+
+    // 5. client3 attaches the document.
+    // The content of the removed document should not be exposed.
+    const doc3 = new yorkie.Document<TestDoc>(docKey);
+    const client3 = new yorkie.Client(testRPCAddr);
+    await client3.activate();
+    await client3.attach(doc3);
+    assert.equal('{}', doc3.toSortedJSON());
+
+    await client1.deactivate();
+    await client2.deactivate();
+    await client3.deactivate();
+  });
+
   it('Can watch documents', async function ({ task }) {
     const c1 = new yorkie.Client(testRPCAddr);
     const c2 = new yorkie.Client(testRPCAddr);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Add `removeIfNotAttached` to `client.detach()` option
(Ref: Go-SDK https://github.com/yorkie-team/yorkie/pull/560) 


**Does this PR introduce a user-facing change?**: <!-- If no, just write "NONE" in the release-note block below. If yes, a release note is required: Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required". -->

When the `removeIfNotAttached` option is set during detaching, the document will be removed after detaching only if there are no other clients simultaneously editing the document (i.e., no clients are currently attached). The default setting for `removeIfNotAttached` is `false`.

```ts
await client.detach(doc, { removeIfNotAttached: true });
```



#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
