### PR TITLE
Address duplicate node IDs in Tree.Split

### DIFF
--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -494,11 +494,24 @@ export class CRDTTreeNode extends IndexTreeNode<CRDTTreeNode> {
   }
 
   /**
-   * `clone` clones this node with the given offset.
+   * `cloneText` clones this text node with the given offset.
    */
-  clone(offset: number): CRDTTreeNode {
+  cloneText(offset: number): CRDTTreeNode {
     return new CRDTTreeNode(
       CRDTTreeNodeID.of(this.id.getCreatedAt(), offset),
+      this.type,
+      undefined,
+      undefined,
+      this.removedAt,
+    );
+  }
+
+  /**
+   * `cloneElement` clones this element node with the given issueTimeTicket function.
+   */
+  cloneElement(issueTimeTicket: () => TimeTicket): CRDTTreeNode {
+    return new CRDTTreeNode(
+      CRDTTreeNodeID.of(issueTimeTicket(), 0),
       this.type,
       undefined,
       undefined,
@@ -514,15 +527,11 @@ export class CRDTTreeNode extends IndexTreeNode<CRDTTreeNode> {
     offset: number,
     issueTimeTicket?: () => TimeTicket,
   ): CRDTTreeNode | undefined {
-    const childrenLength = this.children.length;
     const split = this.isText
       ? this.splitText(offset, this.id.getOffset())
-      : this.splitElement(offset, this.id.getOffset());
+      : this.splitElement(offset, issueTimeTicket!);
 
     if (split) {
-      if (!this.isText && (offset === 0 || offset === childrenLength)) {
-        split.id = CRDTTreeNodeID.of(issueTimeTicket!(), 0);
-      }
       split.insPrevID = this.id;
       if (this.insNextID) {
         const insNext = tree.findFloorNode(this.insNextID)!;

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -370,6 +370,7 @@ export class Tree {
         : undefined,
       splitLevel,
       ticket,
+      () => this.context!.issueTimeTicket(),
     );
 
     this.context!.push(

--- a/src/document/operation/tree_edit_operation.ts
+++ b/src/document/operation/tree_edit_operation.ts
@@ -89,12 +89,26 @@ export class TreeEditOperation extends Operation {
     if (!(parentObject instanceof CRDTTree)) {
       logger.fatal(`fail to execute, only Tree can execute edit`);
     }
+    const editedAt = this.getExecutedAt();
     const tree = parentObject as CRDTTree;
     const [changes] = tree.edit(
       [this.fromPos, this.toPos],
       this.contents?.map((content) => content.deepcopy()),
       this.splitLevel,
-      this.getExecutedAt(),
+      editedAt,
+      (() => {
+        let delimiter = editedAt.getDelimiter();
+        if (this.contents !== undefined) {
+          delimiter += this.contents.length;
+        }
+        const issueTimeTicket = () =>
+          TimeTicket.of(
+            editedAt.getLamport(),
+            ++delimiter,
+            editedAt.getActorID(),
+          );
+        return issueTimeTicket;
+      })(),
       this.maxCreatedAtMapByActor,
     );
 

--- a/src/document/operation/tree_edit_operation.ts
+++ b/src/document/operation/tree_edit_operation.ts
@@ -96,6 +96,13 @@ export class TreeEditOperation extends Operation {
       this.contents?.map((content) => content.deepcopy()),
       this.splitLevel,
       editedAt,
+      /**
+       * TODO(sejongk): When splitting element nodes, a new nodeID is assigned with a different timeTicket.
+       * In the same change context, the timeTickets share the same lamport and actorID but have different delimiters,
+       * incremented by one for each.
+       * Therefore, it is possible to simulate later timeTickets using `editedAt` and the length of `contents`.
+       * This logic might be unclear; consider refactoring for multi-level concurrent editing in the Tree implementation.
+       */
       (() => {
         let delimiter = editedAt.getDelimiter();
         if (this.contents !== undefined) {

--- a/src/document/time/ticket.ts
+++ b/src/document/time/ticket.ts
@@ -128,6 +128,13 @@ export class TimeTicket {
   }
 
   /**
+   * `getLamport` returns the lamport.
+   */
+  public getLamport(): Long {
+    return this.lamport;
+  }
+
+  /**
    * `getDelimiter` returns delimiter.
    */
   public getDelimiter(): number {

--- a/src/util/index_tree.ts
+++ b/src/util/index_tree.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { TimeTicket } from '../yorkie';
+
 /**
  * About `index`, `path`, `size` and `TreePos` in crdt.IndexTree.
  *
@@ -186,9 +188,15 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
   abstract get isRemoved(): boolean;
 
   /**
-   * `clone` clones the node with the given id and value.
+   * `cloneText` clones the text node with the given id and value.
    */
-  abstract clone(offset: number): T;
+  abstract cloneText(offset: number): T;
+
+  /**
+   * `cloneElement` clones the element node with the given issueTimeTicket
+   * function and value.
+   */
+  abstract cloneElement(issueTimeTicket: () => TimeTicket): T;
 
   /**
    * `value` returns the value of the node.
@@ -217,7 +225,7 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
 
     this.value = leftValue;
 
-    const rightNode = this.clone(offset + absOffset);
+    const rightNode = this.cloneText(offset + absOffset);
     rightNode.value = rightValue;
 
     this.parent!.insertAfterInternal(rightNode, this as any);
@@ -349,7 +357,10 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
   /**
    * `splitElement` splits the given element at the given offset.
    */
-  splitElement(offset: number, absOffset: number): T | undefined {
+  splitElement(
+    offset: number,
+    issueTimeTicket: () => TimeTicket,
+  ): T | undefined {
     /**
      * TODO(hackerwins): Define ID of split node for concurrent editing.
      * Text has fixed content and its split nodes could have limited offset
@@ -358,7 +369,7 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
      * and its order could be broken when concurrent editing happens.
      * Currently, we use the similar ID of split element with the split text.
      */
-    const clone = this.clone(offset + absOffset);
+    const clone = this.cloneElement(issueTimeTicket);
     this.parent!.insertAfterInternal(clone, this as any);
     clone.updateAncestorsSize();
 

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -2576,7 +2576,43 @@ describe('testing edge cases', () => {
     }, task.name);
   });
 
-  it('can split and merge with empty paragraph', async function ({ task }) {
+  it('can split and merge with empty paragraph: left', async function ({
+    task,
+  }) {
+    await withTwoClientsAndDocuments<{ t: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.t = new Tree({
+          type: 'doc',
+          children: [
+            {
+              type: 'p',
+              children: [
+                { type: 'text', value: 'a' },
+                { type: 'text', value: 'b' },
+              ],
+            },
+          ],
+        });
+      });
+      assert.equal(d1.getRoot().t.toXML(), /*html*/ `<doc><p>ab</p></doc>`);
+
+      d1.update((root) => root.t.edit(1, 1, undefined, 1));
+      assert.equal(
+        d1.getRoot().t.toXML(),
+        /*html*/ `<doc><p></p><p>ab</p></doc>`,
+      );
+      d1.update((root) => root.t.edit(1, 3));
+      assert.equal(d1.getRoot().t.toXML(), /*html*/ `<doc><p>ab</p></doc>`);
+
+      await c1.sync();
+      await c2.sync();
+      assert.equal(d1.getRoot().t.toXML(), d2.getRoot().t.toXML());
+    }, task.name);
+  });
+
+  it('can split and merge with empty paragraph: right', async function ({
+    task,
+  }) {
     await withTwoClientsAndDocuments<{ t: Tree }>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root.t = new Tree({

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -2643,4 +2643,49 @@ describe('testing edge cases', () => {
       assert.equal(d1.getRoot().t.toXML(), d2.getRoot().t.toXML());
     }, task.name);
   });
+
+  it('can split and merge with empty paragraph and multiple split level: left', async function ({
+    task,
+  }) {
+    await withTwoClientsAndDocuments<{ t: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.t = new Tree({
+          type: 'doc',
+          children: [
+            {
+              type: 'p',
+              children: [
+                {
+                  type: 'p',
+                  children: [
+                    { type: 'text', value: 'a' },
+                    { type: 'text', value: 'b' },
+                  ],
+                },
+              ],
+            },
+          ],
+        });
+      });
+      assert.equal(
+        d1.getRoot().t.toXML(),
+        /*html*/ `<doc><p><p>ab</p></p></doc>`,
+      );
+
+      d1.update((root) => root.t.edit(2, 2, undefined, 2));
+      assert.equal(
+        d1.getRoot().t.toXML(),
+        /*html*/ `<doc><p><p></p></p><p><p>ab</p></p></doc>`,
+      );
+      d1.update((root) => root.t.edit(2, 6));
+      assert.equal(
+        d1.getRoot().t.toXML(),
+        /*html*/ `<doc><p><p>ab</p></p></doc>`,
+      );
+
+      await c1.sync();
+      await c2.sync();
+      assert.equal(d1.getRoot().t.toXML(), d2.getRoot().t.toXML());
+    }, task.name);
+  });
 });

--- a/test/unit/document/crdt/tree_test.ts
+++ b/test/unit/document/crdt/tree_test.ts
@@ -102,13 +102,19 @@ describe('CRDTTree.Edit', function () {
 
     //           1
     // <root> <p> </p> </root>
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
     assert.equal(t.toXML(), /*html*/ `<r><p></p></r>`);
     assert.equal(t.getRoot().size, 2);
 
     //           1
     // <root> <p> h e l l o </p> </root>
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'text', 'hello')], 0, timeT());
+    t.editT(
+      [1, 1],
+      [new CRDTTreeNode(posT(), 'text', 'hello')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.equal(t.toXML(), /*html*/ `<r><p>hello</p></r>`);
     assert.equal(t.getRoot().size, 7);
 
@@ -116,13 +122,13 @@ describe('CRDTTree.Edit', function () {
     // <root> <p> h e l l o </p> <p> w  o  r  l  d  </p>  </root>
     const p = new CRDTTreeNode(posT(), 'p', []);
     p.insertAt(new CRDTTreeNode(posT(), 'text', 'world'), 0);
-    t.editT([7, 7], [p], 0, timeT());
+    t.editT([7, 7], [p], 0, timeT(), timeT);
     assert.equal(t.toXML(), /*html*/ `<r><p>hello</p><p>world</p></r>`);
     assert.equal(t.getRoot().size, 14);
 
     //       0   1 2 3 4 5 6 7    8   9 10 11 12 13 14    15
     // <root> <p> h e l l o ! </p> <p> w  o  r  l  d  </p>  </root>
-    t.editT([6, 6], [new CRDTTreeNode(posT(), 'text', '!')], 0, timeT());
+    t.editT([6, 6], [new CRDTTreeNode(posT(), 'text', '!')], 0, timeT(), timeT);
     assert.equal(t.toXML(), /*html*/ `<r><p>hello!</p><p>world</p></r>`);
 
     assert.deepEqual(t.toTestTreeNode(), {
@@ -152,7 +158,7 @@ describe('CRDTTree.Edit', function () {
 
     //       0   1 2 3 4 5 6 7 8    9   10 11 12 13 14 15    16
     // <root> <p> h e l l o ~ ! </p> <p>  w  o  r  l  d  </p>  </root>
-    t.editT([6, 6], [new CRDTTreeNode(posT(), 'text', '~')], 0, timeT());
+    t.editT([6, 6], [new CRDTTreeNode(posT(), 'text', '~')], 0, timeT(), timeT);
     assert.equal(t.toXML(), /*html*/ `<r><p>hello~!</p><p>world</p></r>`);
   });
 
@@ -161,10 +167,22 @@ describe('CRDTTree.Edit', function () {
     //       0   1 2 3    4   5 6 7    8
     // <root> <p> a b </p> <p> c d </p> </root>
     const tree = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    tree.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    tree.editT([1, 1], [new CRDTTreeNode(posT(), 'text', 'ab')], 0, timeT());
-    tree.editT([4, 4], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    tree.editT([5, 5], [new CRDTTreeNode(posT(), 'text', 'cd')], 0, timeT());
+    tree.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    tree.editT(
+      [1, 1],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
+    tree.editT([4, 4], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    tree.editT(
+      [5, 5],
+      [new CRDTTreeNode(posT(), 'text', 'cd')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(tree.toXML(), /*html*/ `<root><p>ab</p><p>cd</p></root>`);
 
     let treeNode = tree.toTestTreeNode();
@@ -175,7 +193,7 @@ describe('CRDTTree.Edit', function () {
     // 02. delete b from first paragraph
     //       0   1 2    3   4 5 6    7
     // <root> <p> a </p> <p> c d </p> </root>
-    tree.editT([2, 3], undefined, 0, timeT());
+    tree.editT([2, 3], undefined, 0, timeT(), timeT);
     assert.deepEqual(tree.toXML(), /*html*/ `<root><p>a</p><p>cd</p></root>`);
 
     treeNode = tree.toTestTreeNode();
@@ -192,14 +210,14 @@ describe('CRDTTree.Edit', function () {
 
     //       0   1 2 3    4
     // <root> <p> a b </p> </root>
-    t.editT([0, 0], [pNode], 0, timeT());
-    t.editT([1, 1], [textNode], 0, timeT());
+    t.editT([0, 0], [pNode], 0, timeT(), timeT);
+    t.editT([1, 1], [textNode], 0, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p>ab</p></root>`);
 
     // Find the closest index.TreePos when leftSiblingNode in crdt.TreePos is removed.
     //       0   1    2
     // <root> <p> </p> </root>
-    t.editT([1, 3], undefined, 0, timeT());
+    t.editT([1, 3], undefined, 0, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p></p></root>`);
 
     let [parent, left] = t.findNodesAndSplitText(
@@ -211,7 +229,7 @@ describe('CRDTTree.Edit', function () {
     // Find the closest index.TreePos when parentNode in crdt.TreePos is removed.
     //       0
     // <root> </root>
-    t.editT([0, 2], undefined, 0, timeT());
+    t.editT([0, 2], undefined, 0, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root></root>`);
 
     [parent, left] = t.findNodesAndSplitText(
@@ -228,12 +246,13 @@ describe('CRDTTree.Split', function () {
     //       0   1     6     11
     // <root> <p> hello world  </p> </root>
     const t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
     t.editT(
       [1, 1],
       [new CRDTTreeNode(posT(), 'text', 'helloworld')],
       0,
       timeT(),
+      timeT,
     );
     const expectedIntial = {
       type: 'root',
@@ -253,15 +272,15 @@ describe('CRDTTree.Split', function () {
     assert.deepEqual(t.toTestTreeNode(), expectedIntial);
 
     // 01. Split left side of 'helloworld'.
-    t.editT([1, 1], undefined, 0, timeT());
+    t.editT([1, 1], undefined, 0, timeT(), timeT);
     assert.deepEqual(t.toTestTreeNode(), expectedIntial);
 
     // 02. Split right side of 'helloworld'.
-    t.editT([11, 11], undefined, 0, timeT());
+    t.editT([11, 11], undefined, 0, timeT(), timeT);
     assert.deepEqual(t.toTestTreeNode(), expectedIntial);
 
     // 03. Split 'helloworld' into 'hello' and 'world'.
-    t.editT([6, 6], undefined, 0, timeT());
+    t.editT([6, 6], undefined, 0, timeT(), timeT);
     assert.deepEqual(t.toTestTreeNode(), {
       type: 'root',
       children: [
@@ -286,28 +305,46 @@ describe('CRDTTree.Split', function () {
 
     // 01. Split position 1.
     let t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'text', 'ab')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT(
+      [1, 1],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(t.toXML(), /*html*/ `<root><p>ab</p></root>`);
-    t.editT([1, 1], undefined, 1, timeT());
+    t.editT([1, 1], undefined, 1, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p></p><p>ab</p></root>`);
     assert.equal(t.getSize(), 6);
 
     // 02. Split position 2.
     t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'text', 'ab')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT(
+      [1, 1],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(t.toXML(), /*html*/ `<root><p>ab</p></root>`);
-    t.editT([2, 2], undefined, 1, timeT());
+    t.editT([2, 2], undefined, 1, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p>a</p><p>b</p></root>`);
     assert.equal(t.getSize(), 6);
 
     // 03. Split position 3.
     t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'text', 'ab')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT(
+      [1, 1],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(t.toXML(), /*html*/ `<root><p>ab</p></root>`);
-    t.editT([3, 3], undefined, 1, timeT());
+    t.editT([3, 3], undefined, 1, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p>ab</p><p></p></root>`);
     assert.equal(t.getSize(), 6);
   });
@@ -318,11 +355,17 @@ describe('CRDTTree.Split', function () {
 
     // 01. Split nodes level 1.
     let t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT());
-    t.editT([2, 2], [new CRDTTreeNode(posT(), 'text', 'ab')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT(), timeT);
+    t.editT(
+      [2, 2],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(t.toXML(), /*html*/ `<root><p><b>ab</b></p></root>`);
-    t.editT([3, 3], undefined, 1, timeT());
+    t.editT([3, 3], undefined, 1, timeT(), timeT);
     assert.deepEqual(
       t.toXML(),
       /*html*/ `<root><p><b>a</b><b>b</b></p></root>`,
@@ -330,11 +373,17 @@ describe('CRDTTree.Split', function () {
 
     // 02. Split nodes level 2.
     t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT());
-    t.editT([2, 2], [new CRDTTreeNode(posT(), 'text', 'ab')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT(), timeT);
+    t.editT(
+      [2, 2],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(t.toXML(), /*html*/ `<root><p><b>ab</b></p></root>`);
-    t.editT([3, 3], undefined, 2, timeT());
+    t.editT([3, 3], undefined, 2, timeT(), timeT);
     assert.deepEqual(
       t.toXML(),
       /*html*/ `<root><p><b>a</b></p><p><b>b</b></p></root>`,
@@ -343,18 +392,24 @@ describe('CRDTTree.Split', function () {
 
   it('Can split and merge element nodes by edit', function () {
     const t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'text', 'abcd')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT(
+      [1, 1],
+      [new CRDTTreeNode(posT(), 'text', 'abcd')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(t.toXML(), /*html*/ `<root><p>abcd</p></root>`);
     assert.equal(t.getSize(), 6);
 
     //       0   1 2 3    4   5 6 7    8
     // <root> <p> a b </p> <p> c d </p> </root>
-    t.editT([3, 3], undefined, 1, timeT());
+    t.editT([3, 3], undefined, 1, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p>ab</p><p>cd</p></root>`);
     assert.equal(t.getSize(), 8);
 
-    t.editT([3, 5], undefined, 0, timeT());
+    t.editT([3, 5], undefined, 0, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p>abcd</p></root>`);
     assert.equal(t.getSize(), 6);
   });
@@ -366,16 +421,28 @@ describe('CRDTTree.Merge', function () {
     //       0   1 2 3    4   5 6 7    8
     // <root> <p> a b </p> <p> c d </p> </root>
     const t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'text', 'ab')], 0, timeT());
-    t.editT([4, 4], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([5, 5], [new CRDTTreeNode(posT(), 'text', 'cd')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT(
+      [1, 1],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
+    t.editT([4, 4], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT(
+      [5, 5],
+      [new CRDTTreeNode(posT(), 'text', 'cd')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(t.toXML(), /*html*/ `<root><p>ab</p><p>cd</p></root>`);
 
     // 02. delete b, c and the second paragraph.
     //       0   1 2 3    4
     // <root> <p> a d </p> </root>
-    t.editT([2, 6], undefined, 0, timeT());
+    t.editT([2, 6], undefined, 0, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p>ad</p></root>`);
 
     const node = t.toTestTreeNode();
@@ -385,7 +452,7 @@ describe('CRDTTree.Merge', function () {
     assert.equal(node.children![0].children![1].size, 1); // d
 
     // 03. insert a new text node at the start of the first paragraph.
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'text', '@')], 0, timeT());
+    t.editT([1, 1], [new CRDTTreeNode(posT(), 'text', '@')], 0, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p>@ad</p></root>`);
   });
 
@@ -394,11 +461,23 @@ describe('CRDTTree.Merge', function () {
     //       0   1   2 3 4    5    6   7 8 9    10
     // <root> <p> <b> a b </b> </p> <p> c d </p>  </root>
     const t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT());
-    t.editT([2, 2], [new CRDTTreeNode(posT(), 'text', 'ab')], 0, timeT());
-    t.editT([6, 6], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([7, 7], [new CRDTTreeNode(posT(), 'text', 'cd')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT(), timeT);
+    t.editT(
+      [2, 2],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
+    t.editT([6, 6], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT(
+      [7, 7],
+      [new CRDTTreeNode(posT(), 'text', 'cd')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(
       t.toXML(),
       /*html*/ `<root><p><b>ab</b></p><p>cd</p></root>`,
@@ -407,7 +486,7 @@ describe('CRDTTree.Merge', function () {
     // 02. delete b, c and second paragraph.
     //       0   1   2 3 4    5
     // <root> <p> <b> a d </b> </root>
-    t.editT([3, 8], undefined, 0, timeT());
+    t.editT([3, 8], undefined, 0, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p><b>ad</b></p></root>`);
   });
 
@@ -417,96 +496,150 @@ describe('CRDTTree.Merge', function () {
     //       0   1   2   3 4 5    6    7    8
     // <root> <p> <b> <i> a b </i> </b> </p> </root>
     let t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT());
-    t.editT([2, 2], [new CRDTTreeNode(posT(), 'i')], 0, timeT());
-    t.editT([3, 3], [new CRDTTreeNode(posT(), 'text', 'ab')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT(), timeT);
+    t.editT([2, 2], [new CRDTTreeNode(posT(), 'i')], 0, timeT(), timeT);
+    t.editT(
+      [3, 3],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(
       t.toXML(),
       /*html*/ `<root><p><b><i>ab</i></b></p></root>`,
     );
-    t.editT([5, 6], undefined, 0, timeT());
+    t.editT([5, 6], undefined, 0, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p><b>ab</b></p></root>`);
 
     // 02. edit between two element nodes in same hierarchy.
     t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT());
-    t.editT([2, 2], [new CRDTTreeNode(posT(), 'i')], 0, timeT());
-    t.editT([3, 3], [new CRDTTreeNode(posT(), 'text', 'ab')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT(), timeT);
+    t.editT([2, 2], [new CRDTTreeNode(posT(), 'i')], 0, timeT(), timeT);
+    t.editT(
+      [3, 3],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(
       t.toXML(),
       /*html*/ `<root><p><b><i>ab</i></b></p></root>`,
     );
-    t.editT([6, 7], undefined, 0, timeT());
+    t.editT([6, 7], undefined, 0, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p><i>ab</i></p></root>`);
 
     // 03. edit between text and element node in same hierarchy.
     t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT());
-    t.editT([2, 2], [new CRDTTreeNode(posT(), 'i')], 0, timeT());
-    t.editT([3, 3], [new CRDTTreeNode(posT(), 'text', 'ab')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT(), timeT);
+    t.editT([2, 2], [new CRDTTreeNode(posT(), 'i')], 0, timeT(), timeT);
+    t.editT(
+      [3, 3],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(
       t.toXML(),
       /*html*/ `<root><p><b><i>ab</i></b></p></root>`,
     );
-    t.editT([4, 6], undefined, 0, timeT());
+    t.editT([4, 6], undefined, 0, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p><b>a</b></p></root>`);
 
     // 04. edit between text and element node in same hierarchy.
     t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT());
-    t.editT([2, 2], [new CRDTTreeNode(posT(), 'i')], 0, timeT());
-    t.editT([3, 3], [new CRDTTreeNode(posT(), 'text', 'ab')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT(), timeT);
+    t.editT([2, 2], [new CRDTTreeNode(posT(), 'i')], 0, timeT(), timeT);
+    t.editT(
+      [3, 3],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(
       t.toXML(),
       /*html*/ `<root><p><b><i>ab</i></b></p></root>`,
     );
-    t.editT([5, 7], undefined, 0, timeT());
+    t.editT([5, 7], undefined, 0, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p>ab</p></root>`);
 
     // 05. edit between text and element node in same hierarchy.
     t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT());
-    t.editT([2, 2], [new CRDTTreeNode(posT(), 'i')], 0, timeT());
-    t.editT([3, 3], [new CRDTTreeNode(posT(), 'text', 'ab')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT(), timeT);
+    t.editT([2, 2], [new CRDTTreeNode(posT(), 'i')], 0, timeT(), timeT);
+    t.editT(
+      [3, 3],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(
       t.toXML(),
       /*html*/ `<root><p><b><i>ab</i></b></p></root>`,
     );
-    t.editT([4, 7], undefined, 0, timeT());
+    t.editT([4, 7], undefined, 0, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p>a</p></root>`);
 
     // 06. edit between text and element node in same hierarchy.
     t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT());
-    t.editT([2, 2], [new CRDTTreeNode(posT(), 'i')], 0, timeT());
-    t.editT([3, 3], [new CRDTTreeNode(posT(), 'text', 'ab')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT([1, 1], [new CRDTTreeNode(posT(), 'b')], 0, timeT(), timeT);
+    t.editT([2, 2], [new CRDTTreeNode(posT(), 'i')], 0, timeT(), timeT);
+    t.editT(
+      [3, 3],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(
       t.toXML(),
       /*html*/ `<root><p><b><i>ab</i></b></p></root>`,
     );
-    t.editT([3, 7], undefined, 0, timeT());
+    t.editT([3, 7], undefined, 0, timeT(), timeT);
     assert.deepEqual(t.toXML(), /*html*/ `<root><p></p></root>`);
 
     // 07. edit between text and element node in same hierarchy.
     t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
-    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([1, 1], [new CRDTTreeNode(posT(), 'text', 'ab')], 0, timeT());
-    t.editT([4, 4], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([5, 5], [new CRDTTreeNode(posT(), 'b')], 0, timeT());
-    t.editT([6, 6], [new CRDTTreeNode(posT(), 'text', 'cd')], 0, timeT());
-    t.editT([10, 10], [new CRDTTreeNode(posT(), 'p')], 0, timeT());
-    t.editT([11, 11], [new CRDTTreeNode(posT(), 'text', 'ef')], 0, timeT());
+    t.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT(
+      [1, 1],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
+    t.editT([4, 4], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT([5, 5], [new CRDTTreeNode(posT(), 'b')], 0, timeT(), timeT);
+    t.editT(
+      [6, 6],
+      [new CRDTTreeNode(posT(), 'text', 'cd')],
+      0,
+      timeT(),
+      timeT,
+    );
+    t.editT([10, 10], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    t.editT(
+      [11, 11],
+      [new CRDTTreeNode(posT(), 'text', 'ef')],
+      0,
+      timeT(),
+      timeT,
+    );
     assert.deepEqual(
       t.toXML(),
       /*html*/ `<root><p>ab</p><p><b>cd</b></p><p>ef</p></root>`,
     );
-    t.editT([9, 10], undefined, 0, timeT());
+    t.editT([9, 10], undefined, 0, timeT(), timeT);
     assert.deepEqual(
       t.toXML(),
       /*html*/ `<root><p>ab</p><b>cd</b><p>ef</p></root>`,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Add test to represent duplicate node IDs in Tree.Split

#### Any background context you want to provide?

https://github.com/yorkie-team/yorkie-js-sdk/blob/5be4296e5924b398003bd8c27fb16f82070445ad/src/util/index_tree.ts#L352-L382

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
