### PR TITLE
Support concurrent insertion and splitting in Tree

### DIFF
--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -687,7 +687,13 @@ export class CRDTTree extends CRDTGCElement {
     const [parent, leftSibling] = pos.toTreeNodes(this);
     let leftNode = leftSibling;
 
-    // 02. Split text node if the left node is a text node.
+    // 02. Determine whether the position is left-most and the exact parent
+    // in the current tree.
+    const isLeftMost = parent === leftNode;
+    const realParent =
+      leftNode.parent && !isLeftMost ? leftNode.parent : parent;
+
+    // 03. Split text node if the left node is a text node.
     if (leftNode.isText) {
       leftNode.split(
         this,
@@ -695,11 +701,11 @@ export class CRDTTree extends CRDTGCElement {
       );
     }
 
-    // 03. Find the appropriate left node. If some nodes are inserted at the
+    // 04. Find the appropriate left node. If some nodes are inserted at the
     // same position concurrently, then we need to find the appropriate left
     // node. This is similar to RGA.
-    const allChildren = parent.allChildren;
-    const index = parent === leftNode ? 0 : allChildren.indexOf(leftNode) + 1;
+    const allChildren = realParent.allChildren;
+    const index = isLeftMost ? 0 : allChildren.indexOf(leftNode) + 1;
 
     for (let i = index; i < parent.allChildren.length; i++) {
       const next = allChildren[i];
@@ -710,7 +716,7 @@ export class CRDTTree extends CRDTGCElement {
       leftNode = next;
     }
 
-    return [parent, leftNode];
+    return [realParent, leftNode];
   }
 
   /**

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -2774,7 +2774,7 @@ describe('testing edge cases', () => {
     }, task.name);
   });
 
-  it.skip('Can concurrently split and insert into split node', async function ({
+  it('Can concurrently split and insert into split node', async function ({
     task,
   }) {
     await withTwoClientsAndDocuments<{ t: Tree }>(async (c1, d1, c2, d2) => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR introduces support for concurrent insertion and splitting in the Tree by utilizing `leftNode.parent` as the `parent` node.

#### Any background context you want to provide?
Currently, the `parentID` and `leftSiblingID` in `CRDTTreePos` represent positions in the Tree. In other words, they help derive the `parentNode` and `leftSiblingNode` in the Tree.

When splitting an element node, the split node receives a new nodeID (#707). This complicates concurrent editing, particularly when a remote operation, unaware of the node's split, refers to child nodes that were previously in the original node but are now in the split node. In such cases, the local cannot locate the target node because the original node no longer contains those child nodes.

Fortunately, the `leftNode.parent` represents the exact parent node in the current tree. Therefore, using this as a `parent` effectively addresses the  above problem.

In summary, the `parentNodeID` in `CRDTTreePos` is now solely used to determine whether the given position is the leftmost. Instead, substantial tree operations utilize `leftNode.parent` as the `parent`.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
