### PR TITLE
Generate correct TreeChange in concurrent edits

### DIFF
--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -1370,16 +1370,17 @@ export class CRDTTree extends CRDTGCElement {
         ];
       }
       return [node, TokenType.End];
-    } else {
-      const parent = node.parent!;
-      const siblings = parent.allChildren;
-      const offset = siblings.indexOf(node);
-      if (parent && offset === siblings.length - 1) {
-        return [parent, TokenType.End];
-      }
-      const next = siblings[offset + 1];
-      return [next, next.isText ? TokenType.Text : TokenType.Start];
     }
+
+    const parent = node.parent!;
+    const siblings = parent.allChildren;
+    const offset = siblings.indexOf(node);
+    if (parent && offset === siblings.length - 1) {
+      return [parent, TokenType.End];
+    }
+
+    const next = siblings[offset + 1];
+    return [next, next.isText ? TokenType.Text : TokenType.Start];
   }
 
   /**
@@ -1395,16 +1396,18 @@ export class CRDTTree extends CRDTGCElement {
         const lastChild = children[children.length - 1];
         return [lastChild, lastChild.isText ? TokenType.Text : TokenType.End];
       }
+
       return [node, TokenType.Start];
-    } else {
-      const parent = node.parent!;
-      const siblings = parent.allChildren;
-      const offset = siblings.indexOf(node);
-      if (parent && offset === 0) {
-        return [parent, TokenType.Start];
-      }
-      const prev = siblings[offset - 1];
-      return [prev, prev.isText ? TokenType.Text : TokenType.End];
     }
+
+    const parent = node.parent!;
+    const siblings = parent.allChildren;
+    const offset = siblings.indexOf(node);
+    if (parent && offset === 0) {
+      return [parent, TokenType.Start];
+    }
+
+    const prev = siblings[offset - 1];
+    return [prev, prev.isText ? TokenType.Text : TokenType.End];
   }
 }

--- a/src/util/index_tree.ts
+++ b/src/util/index_tree.ts
@@ -498,23 +498,37 @@ function ancestorOf<T extends IndexTreeNode<T>>(ancestor: T, node: T): boolean {
   return false;
 }
 
-// TokenType represents the type of the selected token.
+/**
+ * `TokenType` represents the type of token in XML representation.
+ */
 export enum TokenType {
-  // Start represents that the start token type.
+  /**
+   * `Start` represents that the start token type.
+   */
   Start = 'Start',
-  // End represents that the end token type.
+
+  /**
+   * `End` represents that the end token type.
+   */
   End = 'End',
-  // Text represents that the text token type.
+
+  /**
+   * `Text` represents that the text token type.
+   */
   Text = 'Text',
 }
 
 /**
- * `TreeToken` represents a token in XML-like string.
+ * `TreeToken` represents the token of the tree in XML representation.
  */
 export type TreeToken<T> = [T, TokenType];
 
 /**
  * `tokensBetween` iterates the tokens between the given range.
+ *
+ * For example, if the tree is <p><i>abc</i></p>, the tokens are
+ * [p, Start], [i, Start], [abc, Text], [i, End], [p, End].
+ *
  * If the given range is collapsed, the callback is not called.
  * It traverses the tree based on the concept of token.
  * NOTE(sejongk): Nodes should not be removed in callback, because it leads wrong behaviors.

--- a/test/unit/util/index_tree_test.ts
+++ b/test/unit/util/index_tree_test.ts
@@ -37,14 +37,14 @@ function toDiagnostic(node: CRDTTreeNode): string {
  * `betweenEqual` is a helper function that checks the nodes between the given
  * indexes.
  */
-function nodesBetweenEqual(
+function tokenBetweenEqual(
   tree: IndexTree<CRDTTreeNode>,
   from: number,
   to: number,
   expected: Array<string>,
 ) {
   const actual: Array<string> = [];
-  tree.nodesBetween(from, to, (node, contain) => {
+  tree.tokenBetween(from, to, (node, contain) => {
     actual.push(`${toDiagnostic(node)}:${contain}`);
     return true;
   });
@@ -142,24 +142,24 @@ describe('IndexTree', function () {
       ],
     });
 
-    nodesBetweenEqual(tree, 2, 11, [
+    tokenBetweenEqual(tree, 2, 11, [
       'text.b:Text',
-      'p:Closing',
-      'p:All',
+      'p:End',
+      'p:Start',
       'text.cde:Text',
-      'p:Closing',
-      'p:Opening',
+      'p:End',
+      'p:Start',
       'text.fg:Text',
     ]);
-    nodesBetweenEqual(tree, 2, 6, [
+    tokenBetweenEqual(tree, 2, 6, [
       'text.b:Text',
-      'p:Closing',
-      'p:Opening',
+      'p:End',
+      'p:Start',
       'text.cde:Text',
     ]);
-    nodesBetweenEqual(tree, 0, 1, ['p:Opening']);
-    nodesBetweenEqual(tree, 3, 4, ['p:Closing']);
-    nodesBetweenEqual(tree, 3, 5, ['p:Closing', 'p:Opening']);
+    tokenBetweenEqual(tree, 0, 1, ['p:Start']);
+    tokenBetweenEqual(tree, 3, 4, ['p:End']);
+    tokenBetweenEqual(tree, 3, 5, ['p:End', 'p:Start']);
   });
 
   it('Can convert index to pos', function () {

--- a/test/unit/util/index_tree_test.ts
+++ b/test/unit/util/index_tree_test.ts
@@ -28,7 +28,7 @@ import {
  */
 function toDiagnostic(node: CRDTTreeNode): string {
   if (node.isText) {
-    return `${node.type}.${node.value}`;
+    return `${node.value}`;
   }
   return node.type;
 }
@@ -66,17 +66,17 @@ describe('IndexTree', function () {
     let pos = tree.findTreePos(0);
     assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['r', 0]);
     pos = tree.findTreePos(1);
-    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.hello', 0]);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['hello', 0]);
     pos = tree.findTreePos(6);
-    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.hello', 5]);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['hello', 5]);
     pos = tree.findTreePos(6, false);
     assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['p', 1]);
     pos = tree.findTreePos(7);
     assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['r', 1]);
     pos = tree.findTreePos(8);
-    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.world', 0]);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['world', 0]);
     pos = tree.findTreePos(13);
-    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.world', 5]);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['world', 5]);
     pos = tree.findTreePos(14);
     assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['r', 2]);
   });
@@ -119,8 +119,8 @@ describe('IndexTree', function () {
     const nodeAB = tree.findTreePos(3, true).node;
     const nodeCD = tree.findTreePos(7, true).node;
 
-    assert.equal(toDiagnostic(nodeAB), 'text.ab');
-    assert.equal(toDiagnostic(nodeCD), 'text.cd');
+    assert.equal(toDiagnostic(nodeAB), 'ab');
+    assert.equal(toDiagnostic(nodeCD), 'cd');
     assert.equal(findCommonAncestor(nodeAB, nodeCD)!.type, 'p');
   });
 
@@ -143,20 +143,15 @@ describe('IndexTree', function () {
     });
 
     tokensBetweenEqual(tree, 2, 11, [
-      'text.b:Text',
+      'b:Text',
       'p:End',
       'p:Start',
-      'text.cde:Text',
+      'cde:Text',
       'p:End',
       'p:Start',
-      'text.fg:Text',
+      'fg:Text',
     ]);
-    tokensBetweenEqual(tree, 2, 6, [
-      'text.b:Text',
-      'p:End',
-      'p:Start',
-      'text.cde:Text',
-    ]);
+    tokensBetweenEqual(tree, 2, 6, ['b:Text', 'p:End', 'p:Start', 'cde:Text']);
     tokensBetweenEqual(tree, 0, 1, ['p:Start']);
     tokensBetweenEqual(tree, 3, 4, ['p:End']);
     tokensBetweenEqual(tree, 3, 5, ['p:End', 'p:Start']);
@@ -223,40 +218,40 @@ describe('IndexTree', function () {
     assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['root', 0]);
 
     pos = tree.pathToTreePos([0, 0]);
-    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.a', 0]);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['a', 0]);
 
     pos = tree.pathToTreePos([0, 1]);
-    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.a', 1]);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['a', 1]);
 
     pos = tree.pathToTreePos([0, 2]);
-    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.b', 1]);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['b', 1]);
 
     pos = tree.pathToTreePos([1]);
     assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['root', 1]);
 
     pos = tree.pathToTreePos([1, 0]);
-    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.cde', 0]);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['cde', 0]);
 
     pos = tree.pathToTreePos([1, 1]);
-    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.cde', 1]);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['cde', 1]);
 
     pos = tree.pathToTreePos([1, 2]);
-    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.cde', 2]);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['cde', 2]);
 
     pos = tree.pathToTreePos([1, 3]);
-    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.cde', 3]);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['cde', 3]);
 
     pos = tree.pathToTreePos([2]);
     assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['root', 2]);
 
     pos = tree.pathToTreePos([2, 0]);
-    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.fg', 0]);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['fg', 0]);
 
     pos = tree.pathToTreePos([2, 1]);
-    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.fg', 1]);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['fg', 1]);
 
     pos = tree.pathToTreePos([2, 2]);
-    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['text.fg', 2]);
+    assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['fg', 2]);
 
     pos = tree.pathToTreePos([3]);
     assert.deepEqual([toDiagnostic(pos.node), pos.offset], ['root', 3]);

--- a/test/unit/util/index_tree_test.ts
+++ b/test/unit/util/index_tree_test.ts
@@ -143,18 +143,19 @@ describe('IndexTree', function () {
     });
 
     nodesBetweenEqual(tree, 2, 11, [
-      'text.b:All',
+      'text.b:Text',
       'p:Closing',
-      'text.cde:All',
       'p:All',
-      'text.fg:All',
+      'text.cde:Text',
+      'p:Closing',
       'p:Opening',
+      'text.fg:Text',
     ]);
     nodesBetweenEqual(tree, 2, 6, [
-      'text.b:All',
+      'text.b:Text',
       'p:Closing',
-      'text.cde:All',
       'p:Opening',
+      'text.cde:Text',
     ]);
     nodesBetweenEqual(tree, 0, 1, ['p:Opening']);
     nodesBetweenEqual(tree, 3, 4, ['p:Closing']);

--- a/test/unit/util/index_tree_test.ts
+++ b/test/unit/util/index_tree_test.ts
@@ -34,18 +34,18 @@ function toDiagnostic(node: CRDTTreeNode): string {
 }
 
 /**
- * `betweenEqual` is a helper function that checks the nodes between the given
+ * `tokensBetweenEqual` is a helper function that checks the tokens between the given
  * indexes.
  */
-function tokenBetweenEqual(
+function tokensBetweenEqual(
   tree: IndexTree<CRDTTreeNode>,
   from: number,
   to: number,
   expected: Array<string>,
 ) {
   const actual: Array<string> = [];
-  tree.tokenBetween(from, to, (node, contain) => {
-    actual.push(`${toDiagnostic(node)}:${contain}`);
+  tree.tokensBetween(from, to, ([node, tokenType]) => {
+    actual.push(`${toDiagnostic(node)}:${tokenType}`);
     return true;
   });
   assert.deepEqual(actual, expected);
@@ -124,7 +124,7 @@ describe('IndexTree', function () {
     assert.equal(findCommonAncestor(nodeAB, nodeCD)!.type, 'p');
   });
 
-  it('Can traverse nodes between two given positions', function () {
+  it('Can traverse tokens between two given positions', function () {
     //       0   1 2 3    4   5 6 7 8    9   10 11 12   13
     // <root> <p> a b </p> <p> c d e </p> <p>  f  g  </p>  </root>
     const tree = buildIndexTree({
@@ -142,7 +142,7 @@ describe('IndexTree', function () {
       ],
     });
 
-    tokenBetweenEqual(tree, 2, 11, [
+    tokensBetweenEqual(tree, 2, 11, [
       'text.b:Text',
       'p:End',
       'p:Start',
@@ -151,15 +151,15 @@ describe('IndexTree', function () {
       'p:Start',
       'text.fg:Text',
     ]);
-    tokenBetweenEqual(tree, 2, 6, [
+    tokensBetweenEqual(tree, 2, 6, [
       'text.b:Text',
       'p:End',
       'p:Start',
       'text.cde:Text',
     ]);
-    tokenBetweenEqual(tree, 0, 1, ['p:Start']);
-    tokenBetweenEqual(tree, 3, 4, ['p:End']);
-    tokenBetweenEqual(tree, 3, 5, ['p:End', 'p:Start']);
+    tokensBetweenEqual(tree, 0, 1, ['p:Start']);
+    tokensBetweenEqual(tree, 3, 4, ['p:End']);
+    tokensBetweenEqual(tree, 3, 5, ['p:End', 'p:Start']);
   });
 
   it('Can convert index to pos', function () {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR introduces the logic for generating correct TreeChange in concurrent edits.
The main functionalities are collecting nodes to be deleted and creating ranges by accumulating successive nodes in pre-order.

#### Any background context you want to provide?
Unlike the `Text` CRDT, `Tree` has levels and an element node has tags (`Opening`/`Closing`). 
For multi-level `Tree` operations (e.g. merge), the determination of which tag is included is currently important. However, using the existing post-order traversal, it is hard to determine if two nodes are successive and if which tags of the node are included in the range. 
As a result, This PR introduces a new traversal method that visits all kinds of tag, which include `Opening`, `Closing`, and `Text`.

**Alternatives for optimization**
Optimizing by using the linked list (`prev` and `next` pointers) may be possible, but how to manage the links from the `Closing` tag and to the `Closing` tag should be considered.
Like the `Text` CRDT, generating ranges using undeleted nodes for optimization may be also feasible, but this is likely to require to traverse tombstones.
- Restore the previous linked list (prev, next link)
- Renew the `traverseInTreePos` logic to traverse tombstones as well, and generate ranges using undeleted nodes

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/yorkie/issues/732

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
