### PR TITLE
Fix for ensuring synchronization on resume

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -615,6 +615,13 @@ export class Client implements Observable<ClientEvent> {
     }
 
     if (isRealtimeSync) {
+      // NOTE(chacha912): When re-establishing real-time sync, there might have been
+      // changes while the connection was off. Therefore, syncing needs to be performed
+      // once. Currently, if syncing is called here, it overlaps with `syncInternal`,
+      // causing the issue of the response being applied twice. (Ref: issues#603)
+      // Therefore, we set `remoteChangeEventReceived` to true, allowing syncing to
+      // occur in `syncInternal`.
+      attachment.remoteChangeEventReceived = true;
       await this.runWatchLoop(doc.getKey());
       return doc;
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Previously, when using `resume`, remote changes made during the `pause` were not being applied. After resuming, if there have been any local or remote changes, a sync is triggered, and previous changes are applied.
 This PR addresses this issue by triggering a sync during resume.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
