### PR TITLE
Fix `getGarbageLen` to retrun correct size

### DIFF
--- a/src/document/crdt/root.ts
+++ b/src/document/crdt/root.ts
@@ -233,17 +233,20 @@ export class CRDTRoot {
    */
   public getGarbageLen(): number {
     let count = 0;
+    const seen = new Set<string>();
 
     for (const createdAt of this.removedElementSetByCreatedAt) {
-      count++;
+      seen.add(createdAt);
       const pair = this.elementPairMapByCreatedAt.get(createdAt)!;
       if (pair.element instanceof CRDTContainer) {
-        pair.element.getDescendants(() => {
-          count++;
+        pair.element.getDescendants((el) => {
+          seen.add(el.getCreatedAt().toIDString());
           return false;
         });
       }
     }
+
+    count += seen.size;
 
     for (const createdAt of this.elementHasRemovedNodesSetByCreatedAt) {
       const pair = this.elementPairMapByCreatedAt.get(createdAt)!;

--- a/src/document/crdt/root.ts
+++ b/src/document/crdt/root.ts
@@ -239,6 +239,7 @@ export class CRDTRoot {
     ).sort();
 
     for (const createdAt of sortedRemovedElementSetByCreatedAt) {
+      if (seen.has(createdAt)) continue;
       seen.add(createdAt);
       const pair = this.elementPairMapByCreatedAt.get(createdAt)!;
       if (pair.element instanceof CRDTContainer) {

--- a/src/document/crdt/root.ts
+++ b/src/document/crdt/root.ts
@@ -234,20 +234,12 @@ export class CRDTRoot {
   public getGarbageLen(): number {
     let count = 0;
     const seen = new Set<string>();
-    const sortedRemovedElementSetByCreatedAt = Array.from(
-      this.removedElementSetByCreatedAt,
-    ).sort();
 
-    for (const createdAt of sortedRemovedElementSetByCreatedAt) {
-      if (seen.has(createdAt)) continue;
+    for (const createdAt of this.removedElementSetByCreatedAt) {
       seen.add(createdAt);
       const pair = this.elementPairMapByCreatedAt.get(createdAt)!;
       if (pair.element instanceof CRDTContainer) {
         pair.element.getDescendants((el) => {
-          const idString = el.getCreatedAt().toIDString();
-          if (seen.has(idString)) {
-            return true;
-          }
           seen.add(el.getCreatedAt().toIDString());
           return false;
         });

--- a/src/document/crdt/root.ts
+++ b/src/document/crdt/root.ts
@@ -234,12 +234,19 @@ export class CRDTRoot {
   public getGarbageLen(): number {
     let count = 0;
     const seen = new Set<string>();
+    const sortedRemovedElementSetByCreatedAt = Array.from(
+      this.removedElementSetByCreatedAt,
+    ).sort();
 
-    for (const createdAt of this.removedElementSetByCreatedAt) {
+    for (const createdAt of sortedRemovedElementSetByCreatedAt) {
       seen.add(createdAt);
       const pair = this.elementPairMapByCreatedAt.get(createdAt)!;
       if (pair.element instanceof CRDTContainer) {
         pair.element.getDescendants((el) => {
+          const idString = el.getCreatedAt().toIDString();
+          if (seen.has(idString)) {
+            return true;
+          }
           seen.add(el.getCreatedAt().toIDString());
           return false;
         });

--- a/test/integration/gc_test.ts
+++ b/test/integration/gc_test.ts
@@ -114,7 +114,7 @@ describe('Garbage Collection', function () {
     assert.equal(root, clone);
   });
 
-  it('getGarbageLen should equal the actual number of elements garbage-collected', async function ({ task }) {
+  it('getGarbageLen should return the actual number of elements garbage-collected', async function ({ task }) {
     type TestDoc = { point?: { x?: number; y?: number } };
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc1 = new yorkie.Document<TestDoc>(docKey);

--- a/test/integration/gc_test.ts
+++ b/test/integration/gc_test.ts
@@ -148,13 +148,13 @@ describe('Garbage Collection', function () {
     await client2.sync();
     await client1.sync();
 
-    const gcNodeLen = 3;
-    assert.equal(doc1.getGarbageLen(), gcNodeLen); // point, x, y, x
-    assert.equal(doc2.getGarbageLen(), gcNodeLen); // x, point, x, y
+    const gcNodeLen = 3; // point, x, y
+    assert.equal(doc1.getGarbageLen(), gcNodeLen);
+    assert.equal(doc2.getGarbageLen(), gcNodeLen);
 
     // Actual garbage-collected nodes
-    assert.equal(doc1.garbageCollect(MaxTimeTicket), gcNodeLen); // point, x, y
-    assert.equal(doc2.garbageCollect(MaxTimeTicket), gcNodeLen); // point, x, y
+    assert.equal(doc1.garbageCollect(MaxTimeTicket), gcNodeLen);
+    assert.equal(doc2.garbageCollect(MaxTimeTicket), gcNodeLen);
 
     await client1.deactivate();
     await client2.deactivate();

--- a/test/integration/gc_test.ts
+++ b/test/integration/gc_test.ts
@@ -114,6 +114,92 @@ describe('Garbage Collection', function () {
     assert.equal(root, clone);
   });
 
+  it('garbage collection test4', async function ({ task }) {
+    type TestDoc = { point?: { x?: number } };
+    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
+    const doc1 = new yorkie.Document<TestDoc>(docKey);
+    const doc2 = new yorkie.Document<TestDoc>(docKey);
+
+    const client1 = new yorkie.Client(testRPCAddr);
+    const client2 = new yorkie.Client(testRPCAddr);
+
+    await client1.activate();
+    await client2.activate();
+
+    await client1.attach(doc1, { isRealtimeSync: false });
+    doc1.update((root) => (root.point = { x: 0 }));
+    await client1.sync();
+    await client2.attach(doc2, { isRealtimeSync: false });
+
+    doc1.update((root) => {
+      delete root.point;
+    });
+    assert.equal(doc1.getGarbageLen(), 2);
+
+    doc2.update((root) => {
+      delete root.point?.x;
+    });
+    assert.equal(doc2.getGarbageLen(), 1);
+
+    await client1.sync();
+    await client2.sync();
+    await client1.sync();
+
+    assert.equal(doc1.getGarbageLen(), 2);
+    assert.equal(doc2.getGarbageLen(), 2);
+
+    assert.equal(doc1.garbageCollect(MaxTimeTicket), 2);
+    assert.equal(doc2.garbageCollect(MaxTimeTicket), 2);
+
+    await client1.deactivate();
+    await client2.deactivate();
+  });
+
+  it('garbage collection test5', async function ({ task }) {
+    type TestDoc = { point?: { x?: number; y?: number } };
+    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
+    const doc1 = new yorkie.Document<TestDoc>(docKey);
+    const doc2 = new yorkie.Document<TestDoc>(docKey);
+
+    const client1 = new yorkie.Client(testRPCAddr);
+    const client2 = new yorkie.Client(testRPCAddr);
+
+    await client1.activate();
+    await client2.activate();
+
+    // 1. initial state
+    await client1.attach(doc1, { isRealtimeSync: false });
+    doc1.update((root) => (root.point = { x: 0, y: 0 }));
+    await client1.sync();
+    await client2.attach(doc2, { isRealtimeSync: false });
+
+    // 2. client1 updates doc
+    doc1.update((root) => {
+      delete root.point;
+    });
+    assert.equal(doc1.getGarbageLen(), 3); // point, x, y
+
+    // 3. client2 updates doc
+    doc2.update((root) => {
+      delete root.point?.x;
+    });
+    assert.equal(doc2.getGarbageLen(), 1); // x
+
+    await client1.sync();
+    await client2.sync();
+    await client1.sync();
+
+    assert.equal(doc1.getGarbageLen(), 3); // point, x, y, x
+    assert.equal(doc2.getGarbageLen(), 3); // x, point, x, y
+
+    // Actual garbage-collected nodes
+    assert.equal(doc1.garbageCollect(MaxTimeTicket), 3); // point, x, y
+    assert.equal(doc2.garbageCollect(MaxTimeTicket), 3); // point, x, y
+
+    await client1.deactivate();
+    await client2.deactivate();
+  });
+
   it('text garbage collection test', function () {
     const doc = new yorkie.Document<{ text: Text }>('test-doc');
     doc.update((root) => (root.text = new Text()));

--- a/test/integration/gc_test.ts
+++ b/test/integration/gc_test.ts
@@ -115,47 +115,6 @@ describe('Garbage Collection', function () {
   });
 
   it('garbage collection test4', async function ({ task }) {
-    type TestDoc = { point?: { x?: number } };
-    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
-    const doc1 = new yorkie.Document<TestDoc>(docKey);
-    const doc2 = new yorkie.Document<TestDoc>(docKey);
-
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
-
-    await client1.activate();
-    await client2.activate();
-
-    await client1.attach(doc1, { isRealtimeSync: false });
-    doc1.update((root) => (root.point = { x: 0 }));
-    await client1.sync();
-    await client2.attach(doc2, { isRealtimeSync: false });
-
-    doc1.update((root) => {
-      delete root.point;
-    });
-    assert.equal(doc1.getGarbageLen(), 2);
-
-    doc2.update((root) => {
-      delete root.point?.x;
-    });
-    assert.equal(doc2.getGarbageLen(), 1);
-
-    await client1.sync();
-    await client2.sync();
-    await client1.sync();
-
-    assert.equal(doc1.getGarbageLen(), 2);
-    assert.equal(doc2.getGarbageLen(), 2);
-
-    assert.equal(doc1.garbageCollect(MaxTimeTicket), 2);
-    assert.equal(doc2.garbageCollect(MaxTimeTicket), 2);
-
-    await client1.deactivate();
-    await client2.deactivate();
-  });
-
-  it('garbage collection test5', async function ({ task }) {
     type TestDoc = { point?: { x?: number; y?: number } };
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc1 = new yorkie.Document<TestDoc>(docKey);

--- a/test/integration/gc_test.ts
+++ b/test/integration/gc_test.ts
@@ -114,7 +114,7 @@ describe('Garbage Collection', function () {
     assert.equal(root, clone);
   });
 
-  it('garbage collection test4', async function ({ task }) {
+  it('getGarbageLen should equal the actual number of elements garbage-collected', async function ({ task }) {
     type TestDoc = { point?: { x?: number; y?: number } };
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc1 = new yorkie.Document<TestDoc>(docKey);

--- a/test/integration/gc_test.ts
+++ b/test/integration/gc_test.ts
@@ -148,12 +148,13 @@ describe('Garbage Collection', function () {
     await client2.sync();
     await client1.sync();
 
-    assert.equal(doc1.getGarbageLen(), 3); // point, x, y, x
-    assert.equal(doc2.getGarbageLen(), 3); // x, point, x, y
+    const gcNodeLen = 3;
+    assert.equal(doc1.getGarbageLen(), gcNodeLen); // point, x, y, x
+    assert.equal(doc2.getGarbageLen(), gcNodeLen); // x, point, x, y
 
     // Actual garbage-collected nodes
-    assert.equal(doc1.garbageCollect(MaxTimeTicket), 3); // point, x, y
-    assert.equal(doc2.garbageCollect(MaxTimeTicket), 3); // point, x, y
+    assert.equal(doc1.garbageCollect(MaxTimeTicket), gcNodeLen); // point, x, y
+    assert.equal(doc2.garbageCollect(MaxTimeTicket), gcNodeLen); // point, x, y
 
     await client1.deactivate();
     await client2.deactivate();


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

- To ensure that the `getGarbageLen` function returns the correct length, I used a Set to eliminate duplicate counting
- Add test case for `getGarbageLen`

#### Any background context you want to provide?

Refer to issue [yorkie/#688](https://github.com/yorkie-team/yorkie/issues/688) for details.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes # https://github.com/yorkie-team/yorkie/issues/688

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
