### PR TITLE
Prevent deregisterElement from deregistering twice in nested object

### DIFF
--- a/src/document/crdt/root.ts
+++ b/src/document/crdt/root.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+
 import { logger } from '@yorkie-js-sdk/src/util/logger';
 import {
   InitialTimeTicket,

--- a/src/document/crdt/root.ts
+++ b/src/document/crdt/root.ts
@@ -169,15 +169,13 @@ export class CRDTRoot {
    * `deregisterElement` deregister the given element and its descendants from hash table.
    */
   public deregisterElement(element: CRDTElement): number {
-    const seen = new Set<string>();
+    let count = 0;
 
     const deregisterElementInternal = (elem: CRDTElement) => {
       const createdAt = elem.getCreatedAt().toIDString();
-      if (!seen.has(createdAt)) {
-        this.elementPairMapByCreatedAt.delete(createdAt);
-        this.removedElementSetByCreatedAt.delete(createdAt);
-        seen.add(elem.getCreatedAt().toIDString());
-      }
+      this.elementPairMapByCreatedAt.delete(createdAt);
+      this.removedElementSetByCreatedAt.delete(createdAt);
+      count++;
     };
 
     deregisterElementInternal(element);
@@ -188,7 +186,7 @@ export class CRDTRoot {
       });
     }
 
-    return seen.size;
+    return count;
   }
 
   /**

--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -15,6 +15,7 @@ import {
 } from '@yorkie-js-sdk/src/document/document';
 import { OperationInfo } from '@yorkie-js-sdk/src/document/operation/operation';
 import { YorkieError } from '@yorkie-js-sdk/src/util/error';
+import { MaxTimeTicket } from '@yorkie-js-sdk/src//document/time/ticket';
 
 describe('Document', function () {
   afterEach(() => {
@@ -930,5 +931,18 @@ describe('Document', function () {
       }
       assert.equal(doc.toSortedJSON(), '{"counter":100}');
     });
+  });
+
+  it.only('Deregister must not deregister same element twice in nested object', async function ({ task }) {
+    type TestDoc = { shape?: { point?: { x?: number; y?: number } } };
+    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
+    const doc = new yorkie.Document<TestDoc>(docKey);
+
+    doc.update((root) => {
+      root.shape = { point: { x: 0, y: 0 } };
+      delete root.shape;
+    });
+    assert.equal(doc.getGarbageLen(), 4); // shape, point, x, y
+    assert.equal(doc.garbageCollect(MaxTimeTicket), 4); // The number of GC nodes must also be 4. (It's 6 for now.)
   });
 });

--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -15,7 +15,6 @@ import {
 } from '@yorkie-js-sdk/src/document/document';
 import { OperationInfo } from '@yorkie-js-sdk/src/document/operation/operation';
 import { YorkieError } from '@yorkie-js-sdk/src/util/error';
-import { MaxTimeTicket } from '@yorkie-js-sdk/src//document/time/ticket';
 
 describe('Document', function () {
   afterEach(() => {

--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -933,7 +933,7 @@ describe('Document', function () {
     });
   });
 
-  it.only('Deregister must not deregister same element twice in nested object', async function ({ task }) {
+  it.only('deregisterElement must not deregister same element twice in nested object', async function ({ task }) {
     type TestDoc = { shape?: { point?: { x?: number; y?: number } } };
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc = new yorkie.Document<TestDoc>(docKey);
@@ -943,6 +943,6 @@ describe('Document', function () {
       delete root.shape;
     });
     assert.equal(doc.getGarbageLen(), 4); // shape, point, x, y
-    assert.equal(doc.garbageCollect(MaxTimeTicket), 4); // The number of GC nodes must also be 4. (It's 6 for now.)
+    assert.equal(doc.garbageCollect(MaxTimeTicket), 4); // The number of GC nodes must also be 4.
   });
 });

--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -932,17 +932,4 @@ describe('Document', function () {
       assert.equal(doc.toSortedJSON(), '{"counter":100}');
     });
   });
-
-  it('deregisterElement must not deregister same element twice in nested object', async function ({ task }) {
-    type TestDoc = { shape?: { point?: { x?: number; y?: number } } };
-    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
-    const doc = new yorkie.Document<TestDoc>(docKey);
-
-    doc.update((root) => {
-      root.shape = { point: { x: 0, y: 0 } };
-      delete root.shape;
-    });
-    assert.equal(doc.getGarbageLen(), 4); // shape, point, x, y
-    assert.equal(doc.garbageCollect(MaxTimeTicket), 4); // The number of GC nodes must also be 4.
-  });
 });

--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -933,7 +933,7 @@ describe('Document', function () {
     });
   });
 
-  it.only('deregisterElement must not deregister same element twice in nested object', async function ({ task }) {
+  it('deregisterElement must not deregister same element twice in nested object', async function ({ task }) {
     type TestDoc = { shape?: { point?: { x?: number; y?: number } } };
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc = new yorkie.Document<TestDoc>(docKey);

--- a/test/integration/gc_test.ts
+++ b/test/integration/gc_test.ts
@@ -682,6 +682,7 @@ describe('Garbage Collection', function () {
     await client1.deactivate();
     await client2.deactivate();
   });
+
   it('garbage collection test for nested object', async function ({ task }) {
     type TestDoc = { shape?: { point?: { x?: number; y?: number } } };
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);

--- a/test/integration/gc_test.ts
+++ b/test/integration/gc_test.ts
@@ -682,4 +682,16 @@ describe('Garbage Collection', function () {
     await client1.deactivate();
     await client2.deactivate();
   });
+  it('garbage collection test for nested object', async function ({ task }) {
+    type TestDoc = { shape?: { point?: { x?: number; y?: number } } };
+    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
+    const doc = new yorkie.Document<TestDoc>(docKey);
+
+    doc.update((root) => {
+      root.shape = { point: { x: 0, y: 0 } };
+      delete root.shape;
+    });
+    assert.equal(doc.getGarbageLen(), 4); // shape, point, x, y
+    assert.equal(doc.garbageCollect(MaxTimeTicket), 4); // The number of GC nodes must also be 4.
+  });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

* Prevent the `deregisterElement` function from deregistering twice in the nested object.
* Improve time complexity of `deregisterElement` function $O(2^n)$ to $O(n)$ when $n$ is number of elements to deregistered.

#### Any background context you want to provide?

Refer to issue #715 for details.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Addresses #715

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
