### PR TITLE
Restore interface changes due to server DB sharding

### DIFF
--- a/src/api/yorkie/v1/yorkie.proto
+++ b/src/api/yorkie/v1/yorkie.proto
@@ -48,7 +48,6 @@ message ActivateClientResponse {
 }
 
 message DeactivateClientRequest {
-  string client_key = 2;
   string client_id = 1;
 }
 
@@ -56,7 +55,6 @@ message DeactivateClientResponse {
 }
 
 message AttachDocumentRequest {
-  string client_key = 3;
   string client_id = 1;
   ChangePack change_pack = 2;
 }
@@ -67,7 +65,6 @@ message AttachDocumentResponse {
 }
 
 message DetachDocumentRequest {
-  string client_key = 5;
   string client_id = 1;
   string document_id = 2;
   ChangePack change_pack = 3;
@@ -79,9 +76,7 @@ message DetachDocumentResponse {
 }
 
 message WatchDocumentRequest {
-  string client_key = 4;
   string client_id = 1;
-  string document_key = 3;
   string document_id = 2;
 }
 
@@ -97,7 +92,6 @@ message WatchDocumentResponse {
 }
 
 message RemoveDocumentRequest {
-  string client_key = 4;
   string client_id = 1;
   string document_id = 2;
   ChangePack change_pack = 3;
@@ -108,7 +102,6 @@ message RemoveDocumentResponse {
 }
 
 message PushPullChangesRequest {
-  string client_key = 5;
   string client_id = 1;
   string document_id = 2;
   ChangePack change_pack = 3;
@@ -120,9 +113,7 @@ message PushPullChangesResponse {
 }
 
 message BroadcastRequest {
-  string client_key = 6;
   string client_id = 1;
-  string document_key = 5;
   string document_id = 2;
   string topic = 3;
   bytes payload = 4;

--- a/src/api/yorkie/v1/yorkie_pb.d.ts
+++ b/src/api/yorkie/v1/yorkie_pb.d.ts
@@ -75,11 +75,6 @@ export declare class ActivateClientResponse extends Message<ActivateClientRespon
  */
 export declare class DeactivateClientRequest extends Message<DeactivateClientRequest> {
   /**
-   * @generated from field: string client_key = 2;
-   */
-  clientKey: string;
-
-  /**
    * @generated from field: string client_id = 1;
    */
   clientId: string;
@@ -122,11 +117,6 @@ export declare class DeactivateClientResponse extends Message<DeactivateClientRe
  * @generated from message yorkie.v1.AttachDocumentRequest
  */
 export declare class AttachDocumentRequest extends Message<AttachDocumentRequest> {
-  /**
-   * @generated from field: string client_key = 3;
-   */
-  clientKey: string;
-
   /**
    * @generated from field: string client_id = 1;
    */
@@ -185,11 +175,6 @@ export declare class AttachDocumentResponse extends Message<AttachDocumentRespon
  * @generated from message yorkie.v1.DetachDocumentRequest
  */
 export declare class DetachDocumentRequest extends Message<DetachDocumentRequest> {
-  /**
-   * @generated from field: string client_key = 5;
-   */
-  clientKey: string;
-
   /**
    * @generated from field: string client_id = 1;
    */
@@ -254,19 +239,9 @@ export declare class DetachDocumentResponse extends Message<DetachDocumentRespon
  */
 export declare class WatchDocumentRequest extends Message<WatchDocumentRequest> {
   /**
-   * @generated from field: string client_key = 4;
-   */
-  clientKey: string;
-
-  /**
    * @generated from field: string client_id = 1;
    */
   clientId: string;
-
-  /**
-   * @generated from field: string document_key = 3;
-   */
-  documentKey: string;
 
   /**
    * @generated from field: string document_id = 2;
@@ -353,11 +328,6 @@ export declare class WatchDocumentResponse_Initialization extends Message<WatchD
  */
 export declare class RemoveDocumentRequest extends Message<RemoveDocumentRequest> {
   /**
-   * @generated from field: string client_key = 4;
-   */
-  clientKey: string;
-
-  /**
    * @generated from field: string client_id = 1;
    */
   clientId: string;
@@ -415,11 +385,6 @@ export declare class RemoveDocumentResponse extends Message<RemoveDocumentRespon
  * @generated from message yorkie.v1.PushPullChangesRequest
  */
 export declare class PushPullChangesRequest extends Message<PushPullChangesRequest> {
-  /**
-   * @generated from field: string client_key = 5;
-   */
-  clientKey: string;
-
   /**
    * @generated from field: string client_id = 1;
    */
@@ -484,19 +449,9 @@ export declare class PushPullChangesResponse extends Message<PushPullChangesResp
  */
 export declare class BroadcastRequest extends Message<BroadcastRequest> {
   /**
-   * @generated from field: string client_key = 6;
-   */
-  clientKey: string;
-
-  /**
    * @generated from field: string client_id = 1;
    */
   clientId: string;
-
-  /**
-   * @generated from field: string document_key = 5;
-   */
-  documentKey: string;
 
   /**
    * @generated from field: string document_id = 2;

--- a/src/api/yorkie/v1/yorkie_pb.js
+++ b/src/api/yorkie/v1/yorkie_pb.js
@@ -50,7 +50,6 @@ const ActivateClientResponse = proto3.makeMessageType(
 const DeactivateClientRequest = proto3.makeMessageType(
   "yorkie.v1.DeactivateClientRequest",
   () => [
-    { no: 2, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ],
 );
@@ -69,7 +68,6 @@ const DeactivateClientResponse = proto3.makeMessageType(
 const AttachDocumentRequest = proto3.makeMessageType(
   "yorkie.v1.AttachDocumentRequest",
   () => [
-    { no: 3, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "change_pack", kind: "message", T: ChangePack },
   ],
@@ -92,7 +90,6 @@ const AttachDocumentResponse = proto3.makeMessageType(
 const DetachDocumentRequest = proto3.makeMessageType(
   "yorkie.v1.DetachDocumentRequest",
   () => [
-    { no: 5, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "change_pack", kind: "message", T: ChangePack },
@@ -116,9 +113,7 @@ const DetachDocumentResponse = proto3.makeMessageType(
 const WatchDocumentRequest = proto3.makeMessageType(
   "yorkie.v1.WatchDocumentRequest",
   () => [
-    { no: 4, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "document_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ],
 );
@@ -151,7 +146,6 @@ const WatchDocumentResponse_Initialization = proto3.makeMessageType(
 const RemoveDocumentRequest = proto3.makeMessageType(
   "yorkie.v1.RemoveDocumentRequest",
   () => [
-    { no: 4, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "change_pack", kind: "message", T: ChangePack },
@@ -174,7 +168,6 @@ const RemoveDocumentResponse = proto3.makeMessageType(
 const PushPullChangesRequest = proto3.makeMessageType(
   "yorkie.v1.PushPullChangesRequest",
   () => [
-    { no: 5, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "change_pack", kind: "message", T: ChangePack },
@@ -198,9 +191,7 @@ const PushPullChangesResponse = proto3.makeMessageType(
 const BroadcastRequest = proto3.makeMessageType(
   "yorkie.v1.BroadcastRequest",
   () => [
-    { no: 6, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 5, name: "document_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "topic", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 4, name: "payload", kind: "scalar", T: 12 /* ScalarType.BYTES */ },

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -388,7 +388,6 @@ export class Client implements Observable<ClientEvent> {
     return this.rpcClient
       .deactivateClient(
         {
-          clientKey: this.key!,
           clientId: this.id!,
         },
         { headers: { 'x-shard-key': this.apiKey } },
@@ -436,7 +435,6 @@ export class Client implements Observable<ClientEvent> {
     return this.rpcClient
       .attachDocument(
         {
-          clientKey: this.key!,
           clientId: this.id!,
           changePack: converter.toChangePack(doc.createChangePack()),
         },
@@ -504,7 +502,6 @@ export class Client implements Observable<ClientEvent> {
     return this.rpcClient
       .detachDocument(
         {
-          clientKey: this.key!,
           clientId: this.id!,
           documentId: attachment.docID,
           changePack: converter.toChangePack(doc.createChangePack()),
@@ -694,7 +691,6 @@ export class Client implements Observable<ClientEvent> {
     return this.rpcClient
       .removeDocument(
         {
-          clientKey: this.key!,
           clientId: this.id!,
           documentId: attachment.docID,
           changePack: pbChangePack,
@@ -810,9 +806,7 @@ export class Client implements Observable<ClientEvent> {
         const ac = new AbortController();
         const stream = this.rpcClient.watchDocument(
           {
-            clientKey: this.key!,
             clientId: this.id!,
-            documentKey: docKey,
             documentId: attachment.docID,
           },
           {
@@ -948,7 +942,6 @@ export class Client implements Observable<ClientEvent> {
     return this.rpcClient
       .pushPullChanges(
         {
-          clientKey: this.key!,
           clientId: this.id!,
           documentId: docID,
           changePack: converter.toChangePack(reqPack),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This commit restores passing sharding keys to the SDK in accordance with https://github.com/yorkie-team/yorkie/pull/776.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
