### PR TITLE
Fix incorrect index returned when using posRangeToIndexRange

### DIFF
--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -691,6 +691,9 @@ export class CRDTTree extends CRDTGCElement {
    * The ids of the given `pos` are the ids of the node in the CRDT perspective.
    * This is different from `TreePos` which is a position of the tree in the
    * physical perspective.
+   *
+   * If `editedAt` is given, then it is used to find the appropriate left node
+   * for concurrent insertion.
    */
   public findNodesAndSplitText(
     pos: CRDTTreePos,

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -694,7 +694,7 @@ export class CRDTTree extends CRDTGCElement {
    */
   public findNodesAndSplitText(
     pos: CRDTTreePos,
-    editedAt: TimeTicket,
+    editedAt?: TimeTicket,
   ): [CRDTTreeNode, CRDTTreeNode] {
     // 01. Find the parent and left sibling node of the given position.
     const [parent, leftSibling] = pos.toTreeNodes(this);
@@ -717,16 +717,18 @@ export class CRDTTree extends CRDTGCElement {
     // 04. Find the appropriate left node. If some nodes are inserted at the
     // same position concurrently, then we need to find the appropriate left
     // node. This is similar to RGA.
-    const allChildren = realParent.allChildren;
-    const index = isLeftMost ? 0 : allChildren.indexOf(leftNode) + 1;
+    if (editedAt) {
+      const allChildren = realParent.allChildren;
+      const index = isLeftMost ? 0 : allChildren.indexOf(leftNode) + 1;
 
-    for (let i = index; i < allChildren.length; i++) {
-      const next = allChildren[i];
-      if (!next.id.getCreatedAt().after(editedAt)) {
-        break;
+      for (let i = index; i < allChildren.length; i++) {
+        const next = allChildren[i];
+        if (!next.id.getCreatedAt().after(editedAt)) {
+          break;
+        }
+
+        leftNode = next;
       }
-
-      leftNode = next;
     }
 
     return [realParent, leftNode];
@@ -1247,28 +1249,18 @@ export class CRDTTree extends CRDTGCElement {
    */
   public posRangeToPathRange(
     range: TreePosRange,
-    timeTicket: TimeTicket,
   ): [Array<number>, Array<number>] {
-    const [fromParent, fromLeft] = this.findNodesAndSplitText(
-      range[0],
-      timeTicket,
-    );
-    const [toParent, toLeft] = this.findNodesAndSplitText(range[1], timeTicket);
+    const [fromParent, fromLeft] = this.findNodesAndSplitText(range[0]);
+    const [toParent, toLeft] = this.findNodesAndSplitText(range[1]);
     return [this.toPath(fromParent, fromLeft), this.toPath(toParent, toLeft)];
   }
 
   /**
    * `posRangeToIndexRange` converts the given position range to the path range.
    */
-  public posRangeToIndexRange(
-    range: TreePosRange,
-    timeTicket: TimeTicket,
-  ): [number, number] {
-    const [fromParent, fromLeft] = this.findNodesAndSplitText(
-      range[0],
-      timeTicket,
-    );
-    const [toParent, toLeft] = this.findNodesAndSplitText(range[1], timeTicket);
+  public posRangeToIndexRange(range: TreePosRange): [number, number] {
+    const [fromParent, fromLeft] = this.findNodesAndSplitText(range[0]);
+    const [toParent, toLeft] = this.findNodesAndSplitText(range[1]);
     return [this.toIndex(fromParent, fromLeft), this.toIndex(toParent, toLeft)];
   }
 

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -1124,7 +1124,6 @@ export class Document<T, P extends Indexable = Indexable> {
         this.presences,
         OpSource.Remote,
       );
-      this.changeID = this.changeID.syncLamport(change.getID().getLamport());
 
       // DocEvent should be emitted synchronously with applying changes.
       // This is because 3rd party model should be synced with the Document
@@ -1143,6 +1142,8 @@ export class Document<T, P extends Indexable = Indexable> {
       if (presenceEvent) {
         this.publish(presenceEvent);
       }
+
+      this.changeID = this.changeID.syncLamport(change.getID().getLamport());
     }
 
     if (logger.isEnabled(LogLevel.Debug)) {

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -1124,6 +1124,7 @@ export class Document<T, P extends Indexable = Indexable> {
         this.presences,
         OpSource.Remote,
       );
+      this.changeID = this.changeID.syncLamport(change.getID().getLamport());
 
       // DocEvent should be emitted synchronously with applying changes.
       // This is because 3rd party model should be synced with the Document
@@ -1142,8 +1143,6 @@ export class Document<T, P extends Indexable = Indexable> {
       if (presenceEvent) {
         this.publish(presenceEvent);
       }
-
-      this.changeID = this.changeID.syncLamport(change.getID().getLamport());
     }
 
     if (logger.isEnabled(LogLevel.Debug)) {

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -613,10 +613,7 @@ export class Tree {
       CRDTTreePos.fromStruct(range[1]),
     ];
 
-    return this.tree.posRangeToIndexRange(
-      posRange,
-      this.context.getLastTimeTicket(),
-    );
+    return this.tree.posRangeToIndexRange(posRange);
   }
 
   /**
@@ -636,9 +633,6 @@ export class Tree {
       CRDTTreePos.fromStruct(range[1]),
     ];
 
-    return this.tree.posRangeToPathRange(
-      posRange,
-      this.context.getLastTimeTicket(),
-    );
+    return this.tree.posRangeToPathRange(posRange);
   }
 }

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { describe, it, assert, vi } from 'vitest';
+import { describe, it, assert } from 'vitest';
 import yorkie, { Tree } from '@yorkie-js-sdk/src/yorkie';
 import {
   toDocKey,
@@ -644,14 +644,13 @@ describe('Tree', () => {
       assert.deepEqual(d1.getRoot().t.posRangeToIndexRange(selection), [2, 2]);
 
       const eventCollector = new EventCollector<{ type: DocEventType }>();
-      const stub = vi.fn().mockImplementation((event) => {
+      const unsub = d1.subscribe((event) => {
         assert.deepEqual(
           d1.getRoot().t.posRangeToIndexRange(selection),
           [2, 2],
         );
         eventCollector.add({ type: event.type });
       });
-      d1.subscribe(stub);
       d2.update((root) => {
         root.t.edit(2, 2, { type: 'text', value: 'b' });
       });
@@ -670,6 +669,7 @@ describe('Tree', () => {
       await eventCollector.waitAndVerifyNthEvent(1, {
         type: DocEventType.RemoteChange,
       });
+      unsub();
     }, task.name);
   });
 });

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
-import { describe, it, assert } from 'vitest';
+import { describe, it, assert, vi } from 'vitest';
 import yorkie, { Tree } from '@yorkie-js-sdk/src/yorkie';
 import {
   toDocKey,
   withTwoClientsAndDocuments,
 } from '@yorkie-js-sdk/test/integration/integration_helper';
+import { EventCollector } from '@yorkie-js-sdk/test/helper/helper';
 import {
   TreeEditOpInfo,
   TreeStyleOpInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
-import { Document } from '@yorkie-js-sdk/src/document/document';
+import { Document, DocEventType } from '@yorkie-js-sdk/src/document/document';
 
 describe('Tree', () => {
   it('Can be created', function ({ task }) {
@@ -611,6 +612,65 @@ describe('Tree', () => {
 
     range = tree.pathRangeToPosRange([[0], [1]]);
     assert.deepEqual(tree.posRangeToPathRange(range), [[0], [1]]);
+  });
+
+  it('Should return correct range from index within doc.subscribe', async function ({
+    task,
+  }) {
+    await withTwoClientsAndDocuments<{ t: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.t = new Tree({
+          type: 'doc',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'hello' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+      assert.equal(d1.getRoot().t.toXML(), /*html*/ `<doc><p>hello</p></doc>`);
+      assert.equal(d2.getRoot().t.toXML(), /*html*/ `<doc><p>hello</p></doc>`);
+
+      d1.update((root, presence) => {
+        root.t.edit(1, 1, { type: 'text', value: 'a' });
+        const posSelection = root.t.indexRangeToPosRange([2, 2]);
+        presence.set({ selection: posSelection });
+      });
+      await c1.sync();
+      await c2.sync();
+      assert.equal(d1.getRoot().t.toXML(), /*html*/ `<doc><p>ahello</p></doc>`);
+      assert.equal(d2.getRoot().t.toXML(), /*html*/ `<doc><p>ahello</p></doc>`);
+      const { selection } = d1.getMyPresence();
+      assert.deepEqual(d1.getRoot().t.posRangeToIndexRange(selection), [2, 2]);
+
+      const eventCollector = new EventCollector<{ type: DocEventType }>();
+      const stub = vi.fn().mockImplementation((event) => {
+        assert.deepEqual(
+          d1.getRoot().t.posRangeToIndexRange(selection),
+          [2, 2],
+        );
+        eventCollector.add({ type: event.type });
+      });
+      d1.subscribe(stub);
+      d2.update((root) => {
+        root.t.edit(2, 2, { type: 'text', value: 'b' });
+      });
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(
+        d1.getRoot().t.toXML(),
+        /*html*/ `<doc><p>abhello</p></doc>`,
+      );
+      assert.equal(
+        d2.getRoot().t.toXML(),
+        /*html*/ `<doc><p>abhello</p></doc>`,
+      );
+
+      await eventCollector.waitAndVerifyNthEvent(1, {
+        type: DocEventType.RemoteChange,
+      });
+    }, task.name);
   });
 });
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

> ~~There was an issue with incorrect index values being returned when using `posRangeToIndexRange` within `doc.subscribe`. This problem occurred because the `subscribe` callback function was executed before the `changeID` was updated, potentially causing different index calculations.
To address this issue, the event is now published after all relevant operations are completed, ensuring the correct index values are returned when using `posRangeToIndexRange` within `doc.subscribe`.~~
>
> I have reverted the previously changes as there is no dependency between the event and changeID.

The root cause of the issue was related to the use of `getLastTimeTicket` within `PosRangeToIndexRange`.(Ref: #611 ) To find nodes, the function `findNodesAndSplitText` was used, which includes a process to determine the position when inserting nodes, requiring a timeticket as a reference. However, for the purpose of `PosRangeToIndexRange`, which involves simple retrieval without node insertion, this logic was unnecessary. Consequently, I have made modifications to exclude this specific logic.


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
