### PR TITLE
Fix synchronization issue when editing multiple cursors simultaneously in CodeMirror6

### DIFF
--- a/examples/vanilla-codemirror6/src/main.ts
+++ b/examples/vanilla-codemirror6/src/main.ts
@@ -86,10 +86,13 @@ async function main() {
         if (tr.annotation(Transaction.remote)) {
           continue;
         }
+        let adj = 0;
         tr.changes.iterChanges((fromA, toA, _, __, inserted) => {
+          const insertText = inserted.toJSON().join('\n');
           doc.update((root) => {
-            root.content.edit(fromA, toA, inserted.toJSON().join('\n'));
+            root.content.edit(fromA + adj, toA + adj, insertText);
           }, `update content byA ${client.getID()}`);
+          adj += insertText.length - (toA - fromA);
         });
       }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR addresses the synchronization issue that occurs when editing multiple cursors simultaneously in CodeMirror6. 


https://github.com/yorkie-team/yorkie-js-sdk/assets/52884648/0a85bdf1-c87e-4c77-9245-17648dc5fff5



#### Any background context you want to provide?
The cause of this issue is that all updates within a single transaction have positions based on the previous Document. I have modified it to reflect the position of existing updates through the `adj` variable.

#### What are the relevant tickets?
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything