### PR TITLE
Change actorID to be non-optional

### DIFF
--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -159,7 +159,7 @@ function toChangeID(changeID: ChangeID): PbChangeID {
   return new PbChangeID({
     clientSeq: changeID.getClientSeq(),
     lamport: changeID.getLamportAsString(),
-    actorId: toUint8Array(changeID.getActorID()!),
+    actorId: toUint8Array(changeID.getActorID()),
   });
 }
 
@@ -174,7 +174,7 @@ function toTimeTicket(ticket?: TimeTicket): PbTimeTicket | undefined {
   return new PbTimeTicket({
     lamport: ticket.getLamportAsString(),
     delimiter: ticket.getDelimiter(),
-    actorId: toUint8Array(ticket.getActorID()!),
+    actorId: toUint8Array(ticket.getActorID()),
   });
 }
 
@@ -478,7 +478,7 @@ function toOperations(operations: Array<Operation>): Array<PbOperation> {
  */
 function toChange(change: Change<Indexable>): PbChange {
   const pbChange = new PbChange({
-    id: toChangeID(change.getID()!),
+    id: toChangeID(change.getID()),
     message: change.getMessage(),
   });
   if (change.hasOperations()) {

--- a/src/document/change/change.ts
+++ b/src/document/change/change.ts
@@ -166,11 +166,11 @@ export class Change<P extends Indexable> {
     if (this.presenceChange) {
       if (this.presenceChange.type === PresenceChangeType.Put) {
         presences.set(
-          this.id.getActorID()!,
+          this.id.getActorID(),
           deepcopy(this.presenceChange.presence),
         );
       } else {
-        presences.delete(this.id.getActorID()!);
+        presences.delete(this.id.getActorID());
       }
     }
 

--- a/src/document/change/change_id.ts
+++ b/src/document/change/change_id.ts
@@ -31,9 +31,9 @@ export class ChangeID {
   private serverSeq?: Long;
 
   private lamport: Long;
-  private actor?: ActorID;
+  private actor: ActorID;
 
-  constructor(clientSeq: number, lamport: Long, actor?: ActorID) {
+  constructor(clientSeq: number, lamport: Long, actor: ActorID) {
     this.clientSeq = clientSeq;
     this.lamport = lamport;
     this.actor = actor;
@@ -42,11 +42,7 @@ export class ChangeID {
   /**
    * `of` creates a new instance of ChangeID.
    */
-  public static of(
-    clientSeq: number,
-    lamport: Long,
-    actor?: ActorID,
-  ): ChangeID {
+  public static of(clientSeq: number, lamport: Long, actor: ActorID): ChangeID {
     return new ChangeID(clientSeq, lamport, actor);
   }
 
@@ -108,7 +104,7 @@ export class ChangeID {
   /**
    * `getActorID` returns the actor of this ID.
    */
-  public getActorID(): string | undefined {
+  public getActorID(): string {
     return this.actor;
   }
 
@@ -116,10 +112,7 @@ export class ChangeID {
    * `toTestString` returns a string containing the meta data of this ID.
    */
   public toTestString(): string {
-    if (!this.actor) {
-      return `${this.lamport.toString()}:nil:${this.clientSeq}`;
-    }
-    return `${this.lamport.toString()}:${this.actor.substring(22, 24)}:${
+    return `${this.lamport.toString()}:${this.actor.slice(-2)}:${
       this.clientSeq
     }`;
   }

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -566,7 +566,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
         changes[changes.length - 1].value = value;
       } else {
         changes.push({
-          actor: editedAt.getActorID()!,
+          actor: editedAt.getActorID(),
           from: idx,
           to: idx,
           value,
@@ -902,8 +902,8 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
       const actorID = node.getCreatedAt().getActorID();
 
       const latestCreatedAt = isRemote
-        ? latestCreatedAtMapByActor!.has(actorID!)
-          ? latestCreatedAtMapByActor!.get(actorID!)
+        ? latestCreatedAtMapByActor!.has(actorID)
+          ? latestCreatedAtMapByActor!.get(actorID)
           : InitialTimeTicket
         : MaxTimeTicket;
 
@@ -960,7 +960,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> {
 
       if (fromIdx < toIdx) {
         changes.push({
-          actor: editedAt.getActorID()!,
+          actor: editedAt.getActorID(),
           from: fromIdx,
           to: toIdx,
         });

--- a/src/document/crdt/text.ts
+++ b/src/document/crdt/text.ts
@@ -255,11 +255,11 @@ export class CRDTText<A extends Indexable = Indexable> extends CRDTGCElement {
     const toBeStyleds: Array<RGATreeSplitNode<CRDTTextValue>> = [];
 
     for (const node of nodes) {
-      const actorID = node.getCreatedAt().getActorID()!;
+      const actorID = node.getCreatedAt().getActorID();
 
       const latestCreatedAt = latestCreatedAtMapByActor?.size
-        ? latestCreatedAtMapByActor!.has(actorID!)
-          ? latestCreatedAtMapByActor!.get(actorID!)!
+        ? latestCreatedAtMapByActor!.has(actorID)
+          ? latestCreatedAtMapByActor!.get(actorID)!
           : InitialTimeTicket
         : MaxTimeTicket;
 
@@ -283,7 +283,7 @@ export class CRDTText<A extends Indexable = Indexable> extends CRDTGCElement {
       );
       changes.push({
         type: TextChangeType.Style,
-        actor: editedAt.getActorID()!,
+        actor: editedAt.getActorID(),
         from: fromIdx,
         to: toIdx,
         value: {

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -774,7 +774,7 @@ export class CRDTTree extends CRDTGCElement {
             to: this.toIndex(toParent, toLeft),
             fromPath: this.toPath(fromParent, fromLeft),
             toPath: this.toPath(toParent, toLeft),
-            actor: editedAt.getActorID()!,
+            actor: editedAt.getActorID(),
             value,
           });
         }
@@ -832,10 +832,10 @@ export class CRDTTree extends CRDTGCElement {
           }
         }
 
-        const actorID = node.getCreatedAt().getActorID()!;
+        const actorID = node.getCreatedAt().getActorID();
         const latestCreatedAt = latestCreatedAtMapByActor
-          ? latestCreatedAtMapByActor!.has(actorID!)
-            ? latestCreatedAtMapByActor!.get(actorID!)!
+          ? latestCreatedAtMapByActor!.has(actorID)
+            ? latestCreatedAtMapByActor!.get(actorID)!
             : InitialTimeTicket
           : MaxTimeTicket;
 
@@ -901,7 +901,7 @@ export class CRDTTree extends CRDTGCElement {
         to: fromIdx,
         fromPath,
         toPath: fromPath,
-        actor: editedAt.getActorID()!,
+        actor: editedAt.getActorID(),
       });
     }
 
@@ -946,7 +946,7 @@ export class CRDTTree extends CRDTGCElement {
             to: fromIdx,
             fromPath,
             toPath: fromPath,
-            actor: editedAt.getActorID()!,
+            actor: editedAt.getActorID(),
             value,
           });
         }
@@ -1390,7 +1390,7 @@ export class CRDTTree extends CRDTGCElement {
             to: toIdx,
             fromPath: this.toPath(fromParent, fromLeft),
             toPath: this.toPath(toParent, toLeft),
-            actor: editedAt.getActorID()!,
+            actor: editedAt.getActorID(),
           });
         }
       }

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -193,7 +193,7 @@ export interface SnapshotEvent extends BaseDocEvent {
 export interface ChangeInfo<T = OperationInfo> {
   message: string;
   operations: Array<T>;
-  actor: ActorID | undefined;
+  actor: ActorID;
 }
 
 /**
@@ -489,7 +489,7 @@ export class Document<T, P extends Indexable = Indexable> {
 
     // 01. Update the clone object and create a change.
     this.ensureClone();
-    const actorID = this.changeID.getActorID()!;
+    const actorID = this.changeID.getActorID();
     const context = ChangeContext.create<P>(
       this.changeID.next(),
       this.clone!.root,
@@ -955,7 +955,7 @@ export class Document<T, P extends Indexable = Indexable> {
     const context = ChangeContext.create(
       this.changeID.next(),
       this.clone!.root,
-      this.clone!.presences.get(this.changeID.getActorID()!) || ({} as P),
+      this.clone!.presences.get(this.changeID.getActorID()) || ({} as P),
     );
     return createJSON<T>(context, this.clone!.root.getObject());
   }
@@ -1081,7 +1081,7 @@ export class Document<T, P extends Indexable = Indexable> {
         | UnwatchedEvent<P>
         | PresenceChangedEvent<P>
         | undefined;
-      const actorID = change.getID().getActorID()!;
+      const actorID = change.getID().getActorID();
       if (change.hasPresenceChange() && this.onlineClients.has(actorID)) {
         const presenceChange = change.getPresenceChange()!;
         switch (presenceChange.type) {
@@ -1216,7 +1216,7 @@ export class Document<T, P extends Indexable = Indexable> {
       return {} as P;
     }
 
-    const p = this.presences.get(this.changeID.getActorID()!)!;
+    const p = this.presences.get(this.changeID.getActorID())!;
     return deepcopy(p);
   }
 
@@ -1263,7 +1263,7 @@ export class Document<T, P extends Indexable = Indexable> {
    */
   public getSelfForTest() {
     return {
-      clientID: this.getChangeID().getActorID()!,
+      clientID: this.getChangeID().getActorID(),
       presence: this.getMyPresence(),
     };
   }
@@ -1274,7 +1274,7 @@ export class Document<T, P extends Indexable = Indexable> {
    * @internal
    */
   public getOthersForTest() {
-    const myClientID = this.getChangeID().getActorID()!;
+    const myClientID = this.getChangeID().getActorID();
 
     return this.getPresences()
       .filter((a) => a.clientID !== myClientID)
@@ -1314,7 +1314,7 @@ export class Document<T, P extends Indexable = Indexable> {
     const context = ChangeContext.create<P>(
       this.changeID.next(),
       this.clone!.root,
-      this.clone!.presences.get(this.changeID.getActorID()!) || ({} as P),
+      this.clone!.presences.get(this.changeID.getActorID()) || ({} as P),
     );
 
     // apply undo operation in the context to generate a change
@@ -1323,7 +1323,7 @@ export class Document<T, P extends Indexable = Indexable> {
         // apply presence change to the context
         const presence = new Presence<P>(
           context,
-          deepcopy(this.clone!.presences.get(this.changeID.getActorID()!)!),
+          deepcopy(this.clone!.presences.get(this.changeID.getActorID())!),
         );
         presence.set(undoOp.value, { addToHistory: true });
         continue;
@@ -1360,7 +1360,7 @@ export class Document<T, P extends Indexable = Indexable> {
 
     this.localChanges.push(change);
     this.changeID = change.getID();
-    const actorID = this.changeID.getActorID()!;
+    const actorID = this.changeID.getActorID();
     if (opInfos.length > 0) {
       this.publish({
         type: DocEventType.LocalChange,
@@ -1400,7 +1400,7 @@ export class Document<T, P extends Indexable = Indexable> {
     const context = ChangeContext.create<P>(
       this.changeID.next(),
       this.clone!.root,
-      this.clone!.presences.get(this.changeID.getActorID()!) || ({} as P),
+      this.clone!.presences.get(this.changeID.getActorID()) || ({} as P),
     );
 
     // apply redo operation in the context to generate a change
@@ -1409,7 +1409,7 @@ export class Document<T, P extends Indexable = Indexable> {
         // apply presence change to the context
         const presence = new Presence<P>(
           context,
-          deepcopy(this.clone!.presences.get(this.changeID.getActorID()!)!),
+          deepcopy(this.clone!.presences.get(this.changeID.getActorID())!),
         );
         presence.set(redoOp.value, { addToHistory: true });
         continue;
@@ -1446,7 +1446,7 @@ export class Document<T, P extends Indexable = Indexable> {
 
     this.localChanges.push(change);
     this.changeID = change.getID();
-    const actorID = this.changeID.getActorID()!;
+    const actorID = this.changeID.getActorID();
     if (opInfos.length > 0) {
       this.publish({
         type: DocEventType.LocalChange,

--- a/src/document/time/ticket.ts
+++ b/src/document/time/ticket.ts
@@ -36,7 +36,7 @@ export const TicketComparator: Comparator<TimeTicket> = (
 export type TimeTicketStruct = {
   lamport: string;
   delimiter: number;
-  actorID: ActorID | undefined;
+  actorID: ActorID;
 };
 
 /**
@@ -48,10 +48,10 @@ export type TimeTicketStruct = {
 export class TimeTicket {
   private lamport: Long;
   private delimiter: number;
-  private actorID?: ActorID;
+  private actorID: ActorID;
 
   /** @hideconstructor */
-  constructor(lamport: Long, delimiter: number, actorID?: string) {
+  constructor(lamport: Long, delimiter: number, actorID: string) {
     this.lamport = lamport;
     this.delimiter = delimiter;
     this.actorID = actorID;
@@ -63,7 +63,7 @@ export class TimeTicket {
   public static of(
     lamport: Long,
     delimiter: number,
-    actorID?: string,
+    actorID: string,
   ): TimeTicket {
     return new TimeTicket(lamport, delimiter, actorID);
   }
@@ -83,9 +83,6 @@ export class TimeTicket {
    * `toIDString` returns the lamport string for this Ticket.
    */
   public toIDString(): string {
-    if (!this.actorID) {
-      return `${this.lamport.toString()}:nil:${this.delimiter}`;
-    }
     return `${this.lamport.toString()}:${this.actorID}:${this.delimiter}`;
   }
 
@@ -105,9 +102,6 @@ export class TimeTicket {
    * for debugging purpose.
    */
   public toTestString(): string {
-    if (!this.actorID) {
-      return `${this.lamport.toString()}:nil:${this.delimiter}`;
-    }
     return `${this.lamport.toString()}:${this.actorID.slice(-2)}:${
       this.delimiter
     }`;
@@ -144,7 +138,7 @@ export class TimeTicket {
   /**
    * `getActorID` returns actorID.
    */
-  public getActorID(): string | undefined {
+  public getActorID(): string {
     return this.actorID;
   }
 
@@ -174,7 +168,7 @@ export class TimeTicket {
       return -1;
     }
 
-    const compare = this.actorID!.localeCompare(other.actorID!);
+    const compare = this.actorID.localeCompare(other.actorID);
     if (compare !== 0) {
       return compare;
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

When creating a document, the InitialChangeID is used as the ChangeID, ensuring that there are no cases where actorID is undefined.
Therefore, the actorID of ChangeID and TimeTicket always exists, making it non-optional.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #552 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
