### PR TITLE
Fix incorrect calculation in `indexTree.treePosToPath` operation

### DIFF
--- a/src/util/index_tree.ts
+++ b/src/util/index_tree.ts
@@ -252,10 +252,12 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
   }
 
   /**
-   * `hasTextChild` returns true if the node has an text child.
+   * `hasTextChild` returns true if the node's children consist of only text children.
    */
   hasTextChild(): boolean {
-    return this.children.some((child) => child.isText);
+    return (
+      this.children.length > 0 && this.children.every((child) => child.isText)
+    );
   }
 
   /**
@@ -804,8 +806,14 @@ export class IndexTree<T extends IndexTreeNode<T>> {
         node.parent! as T,
         offset,
       );
-      node = node.parent!;
       path.push(sizeOfLeftSiblings + treePos.offset);
+      node = node.parent!;
+    } else if (node.hasTextChild()) {
+      const sizeOfLeftSiblings = addSizeOfLeftSiblings(
+        node! as T,
+        treePos.offset,
+      );
+      path.push(sizeOfLeftSiblings);
     } else {
       path.push(treePos.offset);
     }

--- a/src/util/index_tree.ts
+++ b/src/util/index_tree.ts
@@ -809,6 +809,8 @@ export class IndexTree<T extends IndexTreeNode<T>> {
       path.push(sizeOfLeftSiblings + treePos.offset);
       node = node.parent!;
     } else if (node.hasTextChild()) {
+      // TODO(hackerwins): The function does not consider the situation 
+      // where Element and Text nodes are mixed in the Element's Children.
       const sizeOfLeftSiblings = addSizeOfLeftSiblings(
         node! as T,
         treePos.offset,

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -26,6 +26,7 @@ import {
   TreeStyleOpInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { Document, DocEventType } from '@yorkie-js-sdk/src/document/document';
+import { Indexable, OperationInfo } from 'yorkie-js-sdk';
 
 describe('Tree', () => {
   it('Can be created', function ({ task }) {
@@ -1453,11 +1454,14 @@ describe('Tree.style', function () {
 
       const eventCollector = new EventCollector<{ type: DocEventType }>();
       const unsub = d2.subscribe((event) => {
-        const { fromPath, toPath } = event.value.operations[0];
-        console.log(event.value.operations[0]);
-        assert.deepEqual(fromPath, [1, 0, 0, 7]); // fromPath should be [1,0,0,7] (same as in the remote change)
-        assert.deepEqual(toPath, [1, 0, 0, 8]);
-        eventCollector.add({ type: event.type });
+        if (event.type === 'local-change' || event.type === 'remote-change') {
+          const operation = event.value.operations[0] as TreeEditOpInfo;
+          const { fromPath, toPath } = operation;
+          console.log(event.value.operations[0]);
+          assert.deepEqual(fromPath, [1, 0, 0, 7]); // fromPath should be [1,0,0,7] (same as in the remote change)
+          assert.deepEqual(toPath, [1, 0, 0, 8]);
+          eventCollector.add({ type: event.type });
+        }
       });
 
       d2.update((r) => r.t.editByPath([1, 0, 0, 7], [1, 0, 0, 8]));

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -1456,8 +1456,7 @@ describe('Tree.style', function () {
         if (event.type === 'local-change' || event.type === 'remote-change') {
           const operation = event.value.operations[0] as TreeEditOpInfo;
           const { fromPath, toPath } = operation;
-          console.log(event.value.operations[0]);
-          assert.deepEqual(fromPath, [1, 0, 0, 7]); // fromPath should be [1,0,0,7] (same as in the remote change)
+          assert.deepEqual(fromPath, [1, 0, 0, 7]);
           assert.deepEqual(toPath, [1, 0, 0, 8]);
           eventCollector.add({ type: event.type });
         }

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -26,7 +26,6 @@ import {
   TreeStyleOpInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { Document, DocEventType } from '@yorkie-js-sdk/src/document/document';
-import { Indexable, OperationInfo } from 'yorkie-js-sdk';
 
 describe('Tree', () => {
   it('Can be created', function ({ task }) {


### PR DESCRIPTION
#### What this PR does / why we need it?

This patch addresses an issue arising from the `tree.edit` operation in response to problem with calculating the `fromPath` when multiple `treePos` represent a single index-based coordinate, leading to inaccuracies.

#### Any background context you want to provide?

In some cases, a single index-based coordinate can be represented by multiple `treePos`, causing complications in extracting the path. To resolve this, logic has been implemented in `treePosToPath` to handle cases where `children` consist only of **text type**.

<img width="704" alt="image" src="https://github.com/yorkie-team/yorkie-js-sdk/assets/31478163/d1d234d8-c9f4-44e5-a1e7-778283f3ad33">

Case description: In a situation where the children of `<node>` consist only of text type nodes, and the "e" text Node has already been removed, an additional operation is made to remove the text "f".
* AS-IS: When finding treePos, if leftNode was removed, {parentNode, offset from children} was searched.(return [0, 0, 0, 4] for above case)
* TO-BE: If the node's children consist of only text type nodes, the offset must be set based on text.(should be [0, 0, 0, 7]

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address #749

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything