### PR TITLE
Fix errors when editing Tree due to missing insPrevID in CRDTTree

### DIFF
--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -416,11 +416,15 @@ export class CRDTTreeNode extends IndexTreeNode<CRDTTreeNode> {
     opts?: string | Array<CRDTTreeNode>,
     attributes?: RHT,
     removedAt?: TimeTicket,
+    insPrevID?: CRDTTreeNodeID,
+    insNextID?: CRDTTreeNodeID,
   ) {
     super(type);
     this.id = id;
     this.removedAt = removedAt;
     attributes && (this.attrs = attributes);
+    this.insPrevID = insPrevID;
+    this.insNextID = insNextID;
 
     if (typeof opts === 'string') {
       this.value = opts;
@@ -455,6 +459,8 @@ export class CRDTTreeNode extends IndexTreeNode<CRDTTreeNode> {
       childClone.parent = clone;
       return childClone;
     });
+    clone.insPrevID = this.insPrevID;
+    clone.insNextID = this.insNextID;
     return clone;
   }
 
@@ -517,6 +523,8 @@ export class CRDTTreeNode extends IndexTreeNode<CRDTTreeNode> {
       undefined,
       undefined,
       this.removedAt,
+      this.insPrevID,
+      this.insNextID,
     );
   }
 

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -416,15 +416,11 @@ export class CRDTTreeNode extends IndexTreeNode<CRDTTreeNode> {
     opts?: string | Array<CRDTTreeNode>,
     attributes?: RHT,
     removedAt?: TimeTicket,
-    insPrevID?: CRDTTreeNodeID,
-    insNextID?: CRDTTreeNodeID,
   ) {
     super(type);
     this.id = id;
     this.removedAt = removedAt;
     attributes && (this.attrs = attributes);
-    this.insPrevID = insPrevID;
-    this.insNextID = insNextID;
 
     if (typeof opts === 'string') {
       this.value = opts;

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -523,8 +523,6 @@ export class CRDTTreeNode extends IndexTreeNode<CRDTTreeNode> {
       undefined,
       undefined,
       this.removedAt,
-      this.insPrevID,
-      this.insNextID,
     );
   }
 

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -1483,7 +1483,7 @@ describe('Tree.style', function () {
     }, task.name);
   });
 
-  it('Should return correct range path with client reload case', async function ({ task }) {
+  it('Can handle client reload case', async function ({ task }) {
     type TestDoc = { t: Tree; num: number };
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
 

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -1719,7 +1719,6 @@ describe('Tree.style', function () {
       /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>1 카2 네이3</n></p></c></r>`,
     );
 
-    // debugger;
     d3.update((r) => {
       r.t.editByPath([1, 0, 0, 2], [1, 0, 0, 3]);
     });

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -17,6 +17,7 @@
 import { describe, it, assert } from 'vitest';
 import yorkie, { Tree } from '@yorkie-js-sdk/src/yorkie';
 import {
+  testRPCAddr,
   toDocKey,
   withTwoClientsAndDocuments,
 } from '@yorkie-js-sdk/test/integration/integration_helper';
@@ -1480,6 +1481,263 @@ describe('Tree.style', function () {
       });
       unsub();
     }, task.name);
+  });
+
+  it.only('tree delete test', async function ({ task }) {
+    type TestDoc = { t: Tree; num: number };
+    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
+
+    const d1 = new yorkie.Document<TestDoc>(docKey);
+    const d2 = new yorkie.Document<TestDoc>(docKey);
+
+    const c1 = new yorkie.Client(testRPCAddr);
+    const c2 = new yorkie.Client(testRPCAddr);
+
+    await c1.activate();
+    await c2.activate();
+
+    await c1.attach(d1, { isRealtimeSync: false });
+    await c2.attach(d2, { isRealtimeSync: false });
+
+    // Perform a dummy update to apply changes up to the snapshot threshold.
+    const snapshotThreshold = 500;
+    for (let idx = 0; idx < snapshotThreshold; idx++) {
+      d1.update((root) => {
+        root.num = 0;
+      });
+    }
+
+    // Start scenario.
+    d1.update((root) => {
+      root.t = new Tree({
+        type: 'r',
+        children: [
+          {
+            type: 'c',
+            children: [
+              {
+                type: 'u',
+                children: [
+                  {
+                    type: 'p',
+                    children: [
+                      {
+                        type: 'n',
+                        children: [],
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          {
+            type: 'c',
+            children: [
+              {
+                type: 'p',
+                children: [
+                  {
+                    type: 'n',
+                    children: [],
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      });
+    });
+    await c1.sync();
+    await c2.sync();
+    assert.equal(
+      d1.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n></n></p></c></r>`,
+    );
+    assert.equal(
+      d2.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n></n></p></c></r>`,
+    );
+
+    d1.update((r) => {
+      r.t.editByPath([1, 0, 0, 0], [1, 0, 0, 0], {
+        type: 'text',
+        value: '1',
+      });
+      r.t.editByPath([1, 0, 0, 1], [1, 0, 0, 1], {
+        type: 'text',
+        value: '2',
+      });
+      r.t.editByPath([1, 0, 0, 2], [1, 0, 0, 2], {
+        type: 'text',
+        value: '3',
+      });
+      r.t.editByPath([1, 0, 0, 2], [1, 0, 0, 2], {
+        type: 'text',
+        value: ' ',
+      });
+      r.t.editByPath([1, 0, 0, 3], [1, 0, 0, 3], {
+        type: 'text',
+        value: '네이버랑 ',
+      });
+    });
+    await c1.sync();
+    await c2.sync();
+    assert.equal(
+      d1.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>12 네이버랑 3</n></p></c></r>`,
+    );
+    assert.equal(
+      d2.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>12 네이버랑 3</n></p></c></r>`,
+    );
+
+    d2.update((r) => {
+      r.t.editByPath([1, 0, 0, 1], [1, 0, 0, 8], {
+        type: 'text',
+        value: ' 2 네이버랑 ',
+      });
+      r.t.editByPath([1, 0, 0, 2], [1, 0, 0, 2], {
+        type: 'text',
+        value: 'ㅋ',
+      });
+      r.t.editByPath([1, 0, 0, 2], [1, 0, 0, 3], {
+        type: 'text',
+        value: '카',
+      });
+      r.t.editByPath([1, 0, 0, 2], [1, 0, 0, 3], {
+        type: 'text',
+        value: '캌',
+      });
+      r.t.editByPath([1, 0, 0, 2], [1, 0, 0, 3], {
+        type: 'text',
+        value: '카카',
+      });
+      r.t.editByPath([1, 0, 0, 3], [1, 0, 0, 4], {
+        type: 'text',
+        value: '캉',
+      });
+      r.t.editByPath([1, 0, 0, 3], [1, 0, 0, 4], {
+        type: 'text',
+        value: '카오',
+      });
+      r.t.editByPath([1, 0, 0, 4], [1, 0, 0, 5], {
+        type: 'text',
+        value: '올',
+      });
+      r.t.editByPath([1, 0, 0, 4], [1, 0, 0, 5], {
+        type: 'text',
+        value: '오라',
+      });
+      r.t.editByPath([1, 0, 0, 5], [1, 0, 0, 6], {
+        type: 'text',
+        value: '랑',
+      });
+      r.t.editByPath([1, 0, 0, 6], [1, 0, 0, 6], {
+        type: 'text',
+        value: ' ',
+      });
+    });
+    await c2.sync();
+    await c1.sync();
+    assert.equal(
+      d1.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오랑 2 네이버랑 3</n></p></c></r>`,
+    );
+    assert.equal(
+      d2.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오랑 2 네이버랑 3</n></p></c></r>`,
+    );
+
+    d1.update((r) => {
+      r.t.editByPath([1, 0, 0, 13], [1, 0, 0, 14]);
+      r.t.editByPath([1, 0, 0, 12], [1, 0, 0, 13]);
+    });
+    await c1.sync();
+    await c2.sync();
+    assert.equal(
+      d1.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오랑 2 네이버3</n></p></c></r>`,
+    );
+    assert.equal(
+      d2.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오랑 2 네이버3</n></p></c></r>`,
+    );
+
+    d2.update((r) => {
+      r.t.editByPath([1, 0, 0, 6], [1, 0, 0, 7]);
+      r.t.editByPath([1, 0, 0, 5], [1, 0, 0, 6]);
+    });
+    await c2.sync();
+    await c1.sync();
+    assert.equal(
+      d1.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오2 네이버3</n></p></c></r>`,
+    );
+    assert.equal(
+      d2.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오2 네이버3</n></p></c></r>`,
+    );
+
+    d1.update((r) => {
+      r.t.editByPath([1, 0, 0, 9], [1, 0, 0, 10]);
+    });
+    await c1.sync();
+    await c2.sync();
+    assert.equal(
+      d1.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오2 네이3</n></p></c></r>`,
+    );
+    assert.equal(
+      d2.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오2 네이3</n></p></c></r>`,
+    );
+
+    // A new client has been added.
+    const d3 = new yorkie.Document<TestDoc>(docKey);
+    const c3 = new yorkie.Client(testRPCAddr);
+    await c3.activate();
+    await c3.attach(d3, { isRealtimeSync: false });
+    assert.equal(
+      d3.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오2 네이3</n></p></c></r>`,
+    );
+    await c2.sync();
+
+    d3.update((r) => {
+      r.t.editByPath([1, 0, 0, 4], [1, 0, 0, 5]);
+      r.t.editByPath([1, 0, 0, 3], [1, 0, 0, 4]);
+    });
+    await c3.sync();
+    await c2.sync();
+    assert.equal(
+      d3.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>1 카2 네이3</n></p></c></r>`,
+    );
+    assert.equal(
+      d2.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>1 카2 네이3</n></p></c></r>`,
+    );
+
+    // debugger;
+    d3.update((r) => {
+      r.t.editByPath([1, 0, 0, 2], [1, 0, 0, 3]);
+    });
+
+    await c3.sync();
+    await c2.sync();
+    assert.equal(
+      d3.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>1 2 네이3</n></p></c></r>`,
+    );
+    assert.equal(
+      d2.getRoot().t.toXML(),
+      /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>1 2 네이3</n></p></c></r>`,
+    );
+
+    await c1.deactivate();
+    await c2.deactivate();
+    await c3.deactivate();
   });
 });
 

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -1483,7 +1483,7 @@ describe('Tree.style', function () {
     }, task.name);
   });
 
-  it.only('tree delete test', async function ({ task }) {
+  it('Should return correct range path with client reload case', async function ({ task }) {
     type TestDoc = { t: Tree; num: number };
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR aims to resolve the issue of incorrect index calculation during tree edit when editing copy nodes, due to the missing `insPrevID` information in the `deepcopy()` process. By adding this information, the problem can be fixed.

#### Any background context you want to provide?
The process of creating a document from a snapshot works fine([link](https://github.com/yorkie-team/yorkie-js-sdk/blob/0bc7ce1bf18f7d99af52feaf960b753609fba38c/src/api/converter.ts#L1055-L1061)). However, the issue arises when editing copy nodes during the editing process, as the `insPrevID` information is not copied during the `deepcopy()` process. This omission leads to incorrect index calculation. To address this, relevant modifications have been implemented in the code.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address #754 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
