### PR TITLE
Fix issue of incorrect display of remote selection in Quill example

### DIFF
--- a/examples/vanilla-quill/package.json
+++ b/examples/vanilla-quill/package.json
@@ -19,7 +19,6 @@
     "quill": "^1.3.7",
     "quill-cursors": "^4.0.0",
     "quill-delta": "^5.0.0",
-    "short-unique-id": "^4.4.4",
     "yorkie-js-sdk": "^0.4.13"
   }
 }

--- a/examples/vanilla-quill/src/main.ts
+++ b/examples/vanilla-quill/src/main.ts
@@ -86,6 +86,7 @@ async function main() {
     if (event.type === 'remote-change') {
       handleOperations(event.value.operations);
     }
+    updateAllCursors();
   });
   doc.subscribe('others', (event) => {
     if (event.type === DocEventType.Unwatched) {

--- a/examples/vanilla-quill/src/main.ts
+++ b/examples/vanilla-quill/src/main.ts
@@ -213,8 +213,25 @@ async function main() {
       }
     })
     .on('selection-change', (range, _, source) => {
-      if (source === 'api' || !range) {
+      if (!range) {
         return;
+      }
+
+      // NOTE(chacha912): If the selection in the Quill editor does not match the range computed by yorkie,
+      // additional updates are necessary. This condition addresses situations where Quill's selection behaves
+      // differently, such as when inserting text before a range selection made by another user, causing
+      // the second character onwards to be included in the selection.
+      if (source === 'api') {
+        const { selection } = doc.getMyPresence();
+        if (selection) {
+          const [from, to] = doc
+            .getRoot()
+            .content.posRangeToIndexRange(selection);
+          const { index, length } = range;
+          if (from === index && to === index + length) {
+            return;
+          }
+        }
       }
 
       doc.update((root, presence) => {

--- a/examples/vanilla-quill/src/type.ts
+++ b/examples/vanilla-quill/src/type.ts
@@ -6,5 +6,6 @@ export type YorkieDoc = {
 
 export type YorkiePresence = {
   username: string;
+  color: string;
   selection: TextPosStructRange | undefined;
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yorkie-js-sdk",
-  "version": "0.4.13",
+  "version": "0.4.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yorkie-js-sdk",
-      "version": "0.4.13",
+      "version": "0.4.16",
       "license": "Apache-2.0",
       "workspaces": [
         "examples/*",
@@ -72,7 +72,7 @@
         "react": "18.2.0",
         "react-calendar": "^4.6.0",
         "react-dom": "18.2.0",
-        "yorkie-js-sdk": "^0.4.12"
+        "yorkie-js-sdk": "^0.4.13"
       },
       "devDependencies": {
         "@types/node": "20.4.2",
@@ -114,7 +114,7 @@
     "examples/profile-stack": {
       "version": "0.0.0",
       "dependencies": {
-        "yorkie-js-sdk": "^0.4.12"
+        "yorkie-js-sdk": "^0.4.13"
       },
       "devDependencies": {
         "vite": "^3.2.7"
@@ -179,7 +179,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "unique-names-generator": "^4.7.1",
-        "yorkie-js-sdk": "^0.4.12"
+        "yorkie-js-sdk": "^0.4.13"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.198",
@@ -247,7 +247,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "todomvc-app-css": "^2.4.2",
-        "yorkie-js-sdk": "^0.4.12"
+        "yorkie-js-sdk": "^0.4.13"
       },
       "devDependencies": {
         "@types/react": "^18.0.24",
@@ -311,7 +311,7 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "yorkie-js-sdk": "^0.4.12"
+        "yorkie-js-sdk": "^0.4.13"
       },
       "devDependencies": {
         "@types/react": "^18.0.37",
@@ -347,7 +347,7 @@
         "@codemirror/state": "^6.1.2",
         "@codemirror/view": "^6.3.1",
         "codemirror": "^6.0.1",
-        "yorkie-js-sdk": "^0.4.12"
+        "yorkie-js-sdk": "^0.4.13"
       },
       "devDependencies": {
         "typescript": "^4.6.4",
@@ -410,8 +410,7 @@
         "quill": "^1.3.7",
         "quill-cursors": "^4.0.0",
         "quill-delta": "^5.0.0",
-        "short-unique-id": "^4.4.4",
-        "yorkie-js-sdk": "^0.4.12"
+        "yorkie-js-sdk": "^0.4.13"
       },
       "devDependencies": {
         "@types/color-hash": "^1.0.2",
@@ -485,7 +484,7 @@
       "version": "0.0.0",
       "dependencies": {
         "vue": "^3.2.41",
-        "yorkie-js-sdk": "^0.4.12"
+        "yorkie-js-sdk": "^0.4.13"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^3.1.2",
@@ -16969,14 +16968,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/short-unique-id": {
-      "version": "4.4.4",
-      "license": "Apache-2.0",
-      "bin": {
-        "short-unique-id": "bin/short-unique-id",
-        "suid": "bin/short-unique-id"
       }
     },
     "node_modules/side-channel": {

--- a/public/quill.html
+++ b/public/quill.html
@@ -103,6 +103,7 @@
               const { actor, message, operations } = event.value;
               handleOperations(operations, actor);
             }
+            updateAllCursors();
           });
 
           doc.subscribe('others', (event) => {
@@ -156,6 +157,12 @@
               index: range[0],
               length: range[1] - range[0],
             });
+          }
+
+          function updateAllCursors() {
+            for (const user of doc.getPresences()) {
+              updateCursor(user);
+            }
           }
 
           // 04. bind the document with the Quill.
@@ -323,10 +330,8 @@
           }
 
           syncText();
+          updateAllCursors();
           displayLog(documentElem, documentTextElem, doc);
-          for (const user of doc.getPresences()) {
-            updateCursor(user);
-          }
         } catch (e) {
           console.error(e);
         }

--- a/public/quill.html
+++ b/public/quill.html
@@ -244,8 +244,21 @@
               }
             })
             .on('selection-change', (range, _, source) => {
-              if (source === 'api' || !range) {
+              if (!range) {
                 return;
+              }
+              // NOTE(chacha912): If the selection in the Quill editor does not match the range computed by yorkie,
+              // additional updates are necessary. This condition addresses situations where Quill's selection behaves
+              // differently, such as when inserting text before a range selection made by another user, causing
+              // the second character onwards to be included in the selection.
+              if (source === 'api') {
+                const [from, to] = doc
+                  .getRoot()
+                  .content.posRangeToIndexRange(doc.getMyPresence().selection);
+                const { index, length } = range;
+                if (from === index && to === index + length) {
+                  return;
+                }
               }
 
               doc.update((root, presence) => {

--- a/public/quill.html
+++ b/public/quill.html
@@ -12,7 +12,6 @@
     <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/quill-cursors@3.1.0/dist/quill-cursors.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/color-hash@1.0.3/dist/color-hash.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/short-unique-id@4.4.4/dist/short-unique-id.min.js"></script>
   </head>
   <body>
     <div id="network-status"></div>
@@ -28,7 +27,6 @@
       const documentElem = document.getElementById('document');
       const documentTextElem = document.getElementById('document-text');
       const networkStatusElem = document.getElementById('network-status');
-      const shortUniqueID = new ShortUniqueId();
       const colorHash = new ColorHash();
       const documentKey = 'quill';
 
@@ -51,15 +49,16 @@
       }
 
       function displayOnlineClients(presences, myClientID) {
-        const usernames = [];
+        const clients = [];
         for (const { clientID, presence } of presences) {
-          usernames.push(
-            myClientID === clientID
-              ? `<b>${presence.username}</b>`
-              : presence.username,
-          );
+          const clientElem = `<span class="client" style='background: ${presence.color}; color: white; margin-right:2px; padding:2px;'>${presence.name}</span>`;
+          if (myClientID === clientID) {
+            clients.unshift(clientElem);
+            continue;
+          }
+          clients.push(clientElem);
         }
-        onlineClientsElem.innerHTML = JSON.stringify(usernames);
+        onlineClientsElem.innerHTML = clients.join('');
       }
 
       async function main() {
@@ -77,7 +76,10 @@
           });
 
           await client.attach(doc, {
-            initialPresence: { username: `username-${shortUniqueID()}` },
+            initialPresence: {
+              name: client.getID().slice(-2),
+              color: colorHash.hex(client.getID().slice(-2)),
+            },
           });
 
           doc.update((root) => {
@@ -102,11 +104,12 @@
               handleOperations(operations, actor);
             }
           });
+
           doc.subscribe('others', (event) => {
             if (event.type === 'unwatched') {
-              cursors.removeCursor(event.value.presence.username);
+              cursors.removeCursor(event.value.clientID);
             } else if (event.type === 'presence-changed') {
-              displayRemoteCursor(event.value);
+              updateCursor(event.value);
             }
           });
 
@@ -138,15 +141,18 @@
           });
           const cursors = quill.getModule('cursors');
 
-          function displayRemoteCursor(user) {
-            const {
-              clientID: id,
-              presence: { username, selection },
-            } = user;
-            if (!selection || id === client.getID()) return;
+          function updateCursor(user) {
+            const { clientID, presence } = user;
+            if (clientID === client.getID()) return;
+            // TODO(chacha912): After resolving the presence initialization issue(#608),
+            // remove the following check.
+            if (!presence) return;
+
+            const { name, color, selection } = presence;
+            if (!selection) return;
             const range = doc.getRoot().content.posRangeToIndexRange(selection);
-            cursors.createCursor(username, username, colorHash.hex(username));
-            cursors.moveCursor(username, {
+            cursors.createCursor(clientID, name, color);
+            cursors.moveCursor(clientID, {
               index: range[0],
               length: range[1] - range[0],
             });
@@ -250,7 +256,6 @@
             const deltaOperations = [];
             let prevTo = 0;
             for (const op of ops) {
-              const actorName = doc.getPresence(actor).username;
               const from = op.from;
               const to = op.to;
               const retainFrom = from - prevTo;
@@ -320,7 +325,7 @@
           syncText();
           displayLog(documentElem, documentTextElem, doc);
           for (const user of doc.getPresences()) {
-            displayRemoteCursor(user);
+            updateCursor(user);
           }
         } catch (e) {
           console.error(e);

--- a/public/style.css
+++ b/public/style.css
@@ -14,10 +14,6 @@ menu, nav, output, section, summary,
 time, mark, audio, video {
 	margin: 0;
 	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-  vertical-align: baseline;
   box-sizing: border-box;
 }
 ol,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR addresses the issue of the remote cursor not being accurately displayed when local edits are made in the Quill example. It ensures that the remote cursor is correctly rendered after each edit.(Ref: [y-quill](https://github.com/yjs/y-quill/commit/29d75f1a41395fc45bc3f282428daaedccc67e06))

- before
![quill-bug](https://github.com/yorkie-team/yorkie-js-sdk/assets/81357083/88c4a143-4c0a-4903-940e-01c57bab950c)
- after

https://github.com/yorkie-team/yorkie-js-sdk/assets/81357083/5aa20715-86d7-4f92-8045-8c9636503624

It also adds extra checks to update the selection when there are differences between the selection in Yorkie and Quill. For example, if you add text before another user's selected text, Quill might include the added text in the remote-selection. In such cases, it is necessary to update the Quill selection in Yorkie.

https://github.com/yorkie-team/yorkie-js-sdk/assets/81357083/dcdefd2a-7fa1-4ef6-bf1d-5f2c3e428d1e

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #553

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
