### PR TITLE
Add RealtimeSyncOff and refactor interface of SyncMode

### DIFF
--- a/public/quill-two-clients.css
+++ b/public/quill-two-clients.css
@@ -1,0 +1,83 @@
+.client-container {
+  display: flex;
+}
+.client-id {
+  padding: 2px 4px;
+  margin: 0 4px;
+  border-radius: 10px;
+  background-color: #eee;
+}
+.client-container .ql-toolbar {
+  margin-top: 10px;
+}
+.client-container .ql-container {
+  height: 300px;
+}
+#client-a,
+#client-b {
+  width: 50%;
+  margin: 15px;
+}
+
+.online-clients {
+  margin: 1rem 0;
+  font-family: monospace;
+}
+.online-clients:before {
+  display: block;
+  margin-bottom: 4px;
+  content: 'online-clients: ';
+}
+
+/* sync mode option */
+.syncmode-option {
+  margin: 30px 0 10px;
+  display: flex;
+  align-items: center;
+}
+
+.realtime-sync {
+  display: flex;
+  flex-direction: row;
+  position: relative;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 4px;
+  gap: 4px;
+  margin: 0 4px;
+}
+
+.realtime-sync-title {
+  position: absolute;
+  top: -14px;
+  left: 0;
+  font-size: 12px;
+}
+
+.option input[type='radio'] {
+  display: none;
+}
+
+.option label {
+  display: block;
+  padding: 2px 6px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 12px;
+}
+
+.option label:hover {
+  background-color: #f0f0f0;
+}
+
+.option input[type='radio']:checked + label {
+  background-color: #007bff;
+  color: #fff;
+}
+
+.option input[type='radio']:checked + label.disabled {
+  background-color: #f0f0f0;
+  color: #999;
+  cursor: not-allowed;
+}

--- a/public/quill-two-clients.css
+++ b/public/quill-two-clients.css
@@ -81,3 +81,10 @@
   color: #999;
   cursor: not-allowed;
 }
+
+.ql-editor {
+  caret-color: transparent;
+}
+.ql-editor ::selection {
+  background: none;
+}

--- a/public/quill-two-clients.css
+++ b/public/quill-two-clients.css
@@ -58,8 +58,9 @@
   display: none;
 }
 
-.option label {
-  display: block;
+.option label,
+.option .manual-sync {
+  display: inline-block;
   padding: 2px 6px;
   border: 1px solid #ccc;
   border-radius: 4px;
@@ -76,10 +77,16 @@
   color: #fff;
 }
 
-.option input[type='radio']:checked + label.disabled {
-  background-color: #f0f0f0;
-  color: #999;
-  cursor: not-allowed;
+.option .manual-sync {
+  display: none;
+}
+
+.option .manual-sync:hover {
+  background-color: #ddd;
+}
+
+.option input[type='radio']:checked + label + .manual-sync {
+  display: inline-block;
 }
 
 .ql-editor {

--- a/public/quill-two-clients.html
+++ b/public/quill-two-clients.html
@@ -121,7 +121,7 @@
       const colorHash = new ColorHash();
       const clientAElem = document.getElementById('client-a');
       const clientBElem = document.getElementById('client-b');
-      const documentKey = 'quill-two-clients-nice11124346333';
+      const documentKey = 'quill-two-clients';
 
       function toDeltaOperation(textValue) {
         const { embed, ...restAttributes } = textValue.attributes ?? {};
@@ -344,8 +344,23 @@
                 }
               })
               .on('selection-change', (range, _, source) => {
-                if (source === 'api' || !range) {
+                if (!range) {
                   return;
+                }
+                // NOTE(chacha912): If the selection in the Quill editor does not match the range computed by yorkie,
+                // additional updates are necessary. This condition addresses situations where Quill's selection behaves
+                // differently, such as when inserting text before a range selection made by another user, causing
+                // the second character onwards to be included in the selection.
+                if (source === 'api') {
+                  const [from, to] = doc
+                    .getRoot()
+                    .content.posRangeToIndexRange(
+                      doc.getMyPresence().selection,
+                    );
+                  const { index, length } = range;
+                  if (from === index && to === index + length) {
+                    return;
+                  }
                 }
 
                 doc.update((root, presence) => {

--- a/public/quill-two-clients.html
+++ b/public/quill-two-clients.html
@@ -439,12 +439,15 @@
               switch (syncMode) {
                 case 'pushpull':
                   await client.resume(doc);
-                  await client.resumeRemoteChanges(doc);
+                  client.changeRealtimeSyncMode(doc, 'pushpull');
                   break;
                 case 'pushonly':
-                  await client.pauseRemoteChanges(doc);
+                  await client.resume(doc);
+                  client.changeRealtimeSyncMode(doc, 'pushonly');
                   break;
                 case 'syncoff':
+                  await client.resume(doc);
+                  client.changeRealtimeSyncMode(doc, 'syncoff');
                   break;
                 case 'manual':
                   await client.pause(doc);

--- a/public/quill-two-clients.html
+++ b/public/quill-two-clients.html
@@ -156,6 +156,13 @@
                   .join(', ');
                 onlineClients.textContent = clientIDs;
               }
+
+              console.warn(
+                `%c${clientID}`,
+                `color:white; padding: 2px 4px; border-radius: 3px;
+                 background: ${colorHash.hex(clientID)}; `,
+                event.type,
+              );
             });
 
             await client.attach(doc, {
@@ -175,6 +182,13 @@
                 // The text is replaced to snapshot and must be re-synced.
                 syncText(doc, quill);
               }
+
+              console.warn(
+                `%c${clientID}`,
+                `color:white; padding: 2px 4px; border-radius: 3px;
+                 background: ${colorHash.hex(clientID)}; `,
+                event.type,
+              );
             });
 
             doc.subscribe('$.content', (event) => {

--- a/public/quill-two-clients.html
+++ b/public/quill-two-clients.html
@@ -12,6 +12,7 @@
     <link rel="stylesheet" href="quill-two-clients.css" />
     <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/quill-cursors@3.1.0/dist/quill-cursors.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/color-hash@1.0.3/dist/color-hash.js"></script>
   </head>
   <body>
     <div class="client-container">
@@ -115,6 +116,7 @@
     <script src="./yorkie.js"></script>
     <script src="./util.js"></script>
     <script>
+      const colorHash = new ColorHash();
       const clientAElem = document.getElementById('client-a');
       const clientBElem = document.getElementById('client-b');
       const documentKey = 'quill-two-clients-nice11124346333';
@@ -138,23 +140,27 @@
             // 01. create client with RPCAddr(envoy) then activate it.
             const client = new yorkie.Client('http://localhost:8080');
             await client.activate();
-            clientElem.querySelector('.client-id').textContent = client
-              .getID()
-              .slice(-2);
+            const clientID = client.getID().slice(-2);
+            clientElem.querySelector('.client-id').textContent = clientID;
 
             // 02. create a document then attach it into the client.
             const doc = new yorkie.Document(documentKey);
 
             const onlineClients = clientElem.querySelector('.online-clients');
-            doc.subscribe('presence', (p) => {
-              const clientIDs = doc
-                .getPresences()
-                .map(({ clientID }) => clientID)
-                .join(', ');
-              onlineClients.textContent = clientIDs;
+            doc.subscribe('presence', (event) => {
+              // Update online clients list
+              if (event.type !== 'presence-changed') {
+                const clientIDs = doc
+                  .getPresences()
+                  .map(({ clientID }) => clientID)
+                  .join(', ');
+                onlineClients.textContent = clientIDs;
+              }
             });
 
-            await client.attach(doc);
+            await client.attach(doc, {
+              initialPresence: { name: clientID },
+            });
 
             doc.update((root) => {
               if (!root.content) {
@@ -176,10 +182,23 @@
                 const { message, operations } = event.value;
                 handleOperations(quill, operations);
               }
+              updateAllCursors();
+            });
+
+            doc.subscribe('presence', (event) => {
+              // Update cursors
+              if (event.type === 'initialized') {
+                updateAllCursors();
+              } else if (event.type === 'unwatched') {
+                cursors.removeCursor(event.value.clientID);
+              } else {
+                updateCursor(event.value);
+              }
             });
 
             // 03. create an instance of Quill
             const editorElem = clientElem?.getElementsByClassName('editor')[0];
+            Quill.register('modules/cursors', QuillCursors);
             const quill = new Quill(editorElem, {
               modules: {
                 toolbar: [
@@ -198,70 +217,130 @@
                   ['image', 'video'],
                   ['clean'],
                 ],
+                cursors: {
+                  hideDelayMs: Number.MAX_VALUE,
+                },
               },
               theme: 'snow',
             });
+            const cursors = quill.getModule('cursors');
+
+            function updateCursor(user) {
+              const { clientID, presence } = user;
+              // TODO(chacha912): After resolving the presence initialization issue(#608),
+              // remove the following check.
+              if (!presence) return;
+
+              const { name, selection } = presence;
+              if (!selection) return;
+              const range = doc
+                .getRoot()
+                .content.posRangeToIndexRange(selection);
+              cursors.createCursor(clientID, name, colorHash.hex(name));
+              cursors.moveCursor(clientID, {
+                index: range[0],
+                length: range[1] - range[0],
+              });
+            }
+
+            function updateAllCursors() {
+              for (const user of doc.getPresences()) {
+                updateCursor(user);
+              }
+            }
 
             // 04. bind the document with the Quill.
             // 04-1. Quill to Document.
-            quill.on('text-change', (delta, _, source) => {
-              if (source === 'api' || !delta.ops) {
-                return;
-              }
-
-              let from = 0,
-                to = 0;
-              console.log(
-                `%c quill: ${JSON.stringify(delta.ops)}`,
-                'color: green',
-              );
-              for (const op of delta.ops) {
-                if (op.attributes !== undefined || op.insert !== undefined) {
-                  if (op.retain !== undefined) {
-                    to = from + op.retain;
-                  }
-                  console.log(
-                    `%c local: ${from}-${to}: ${op.insert} ${
-                      op.attributes ? JSON.stringify(op.attributes) : '{}'
-                    }`,
-                    'color: green',
-                  );
-
-                  doc.update((root, presence) => {
-                    if (
-                      op.attributes !== undefined &&
-                      op.insert === undefined
-                    ) {
-                      root.content.setStyle(from, to, op.attributes);
-                    } else if (op.insert !== undefined) {
-                      if (to < from) {
-                        to = from;
-                      }
-
-                      if (typeof op.insert === 'object') {
-                        root.content.edit(from, to, ' ', {
-                          embed: op.insert,
-                          ...op.attributes,
-                        });
-                      } else {
-                        root.content.edit(from, to, op.insert, op.attributes);
-                      }
-                      from = to + op.insert.length;
-                    }
-                  }, `update style by ${client.getID()}`);
-                } else if (op.delete !== undefined) {
-                  to = from + op.delete;
-                  console.log(`%c local: ${from}-${to}: ''`, 'color: green');
-
-                  doc.update((root, presence) => {
-                    root.content.edit(from, to, '');
-                  }, `update content by ${client.getID()}`);
-                } else if (op.retain !== undefined) {
-                  from = to + op.retain;
-                  to = from;
+            quill
+              .on('text-change', (delta, _, source) => {
+                if (source === 'api' || !delta.ops) {
+                  return;
                 }
-              }
-            });
+
+                let from = 0,
+                  to = 0;
+                console.log(
+                  `%c quill: ${JSON.stringify(delta.ops)}`,
+                  'color: green',
+                );
+                for (const op of delta.ops) {
+                  if (op.attributes !== undefined || op.insert !== undefined) {
+                    if (op.retain !== undefined) {
+                      to = from + op.retain;
+                    }
+                    console.log(
+                      `%c local: ${from}-${to}: ${op.insert} ${
+                        op.attributes ? JSON.stringify(op.attributes) : '{}'
+                      }`,
+                      'color: green',
+                    );
+
+                    doc.update((root, presence) => {
+                      let range;
+                      if (
+                        op.attributes !== undefined &&
+                        op.insert === undefined
+                      ) {
+                        root.content.setStyle(from, to, op.attributes);
+                      } else if (op.insert !== undefined) {
+                        if (to < from) {
+                          to = from;
+                        }
+
+                        if (typeof op.insert === 'object') {
+                          range = root.content.edit(from, to, ' ', {
+                            embed: op.insert,
+                            ...op.attributes,
+                          });
+                        } else {
+                          range = root.content.edit(
+                            from,
+                            to,
+                            op.insert,
+                            op.attributes,
+                          );
+                        }
+                        from = to + op.insert.length;
+                      }
+
+                      if (range) {
+                        presence.set({
+                          selection: root.content.indexRangeToPosRange(range),
+                        });
+                      }
+                    }, `update style by ${client.getID()}`);
+                  } else if (op.delete !== undefined) {
+                    to = from + op.delete;
+                    console.log(`%c local: ${from}-${to}: ''`, 'color: green');
+
+                    doc.update((root, presence) => {
+                      const range = root.content.edit(from, to, '');
+                      if (range) {
+                        presence.set({
+                          selection: root.content.indexRangeToPosRange(range),
+                        });
+                      }
+                    }, `update content by ${client.getID()}`);
+                  } else if (op.retain !== undefined) {
+                    from = to + op.retain;
+                    to = from;
+                  }
+                }
+              })
+              .on('selection-change', (range, _, source) => {
+                if (source === 'api' || !range) {
+                  return;
+                }
+
+                doc.update((root, presence) => {
+                  presence.set({
+                    selection: root.content.indexRangeToPosRange([
+                      range.index,
+                      range.index + range.length,
+                    ]),
+                  });
+                }, `update selection by ${client.getID()}`);
+              });
 
             // 04-2. document to Quill(remote).
             function handleOperations(quill, ops) {
@@ -360,6 +439,7 @@
             });
 
             syncText(doc, quill);
+            updateAllCursors();
             window.addEventListener('beforeunload', async () => {
               await client.deactivate();
             });

--- a/public/quill-two-clients.html
+++ b/public/quill-two-clients.html
@@ -59,6 +59,7 @@
               value="manual"
             />
             <label for="manual-a">Manual Sync</label>
+            <button class="manual-sync">sync</button>
           </div>
         </div>
         <div class="editor"></div>
@@ -107,6 +108,7 @@
               value="manual"
             />
             <label for="manual-b">Manual Sync</label>
+            <button class="manual-sync">sync</button>
           </div>
         </div>
         <div class="editor"></div>
@@ -450,6 +452,10 @@
                 default:
                   break;
               }
+            });
+            const syncButton = clientElem.querySelector('.manual-sync');
+            syncButton.addEventListener('click', async () => {
+              await client.sync(doc);
             });
 
             syncText(doc, quill);

--- a/public/quill-two-clients.html
+++ b/public/quill-two-clients.html
@@ -453,19 +453,16 @@
               const syncMode = event.target.value;
               switch (syncMode) {
                 case 'pushpull':
-                  await client.resume(doc);
-                  client.changeRealtimeSyncMode(doc, 'pushpull');
+                  await client.changeSyncMode(doc, 'realtime');
                   break;
                 case 'pushonly':
-                  await client.resume(doc);
-                  client.changeRealtimeSyncMode(doc, 'pushonly');
+                  await client.changeSyncMode(doc, 'realtime-pushonly');
                   break;
                 case 'syncoff':
-                  await client.resume(doc);
-                  client.changeRealtimeSyncMode(doc, 'syncoff');
+                  await client.changeSyncMode(doc, 'realtime-syncoff');
                   break;
                 case 'manual':
-                  await client.pause(doc);
+                  await client.changeSyncMode(doc, 'manual');
                   break;
                 default:
                   break;

--- a/public/quill-two-clients.html
+++ b/public/quill-two-clients.html
@@ -1,0 +1,380 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Yorkie + Quill Two Clients Example</title>
+    <link
+      href="https://cdn.quilljs.com/1.3.6/quill.snow.css"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="quill-two-clients.css" />
+    <script src="https://cdn.quilljs.com/1.3.6/quill.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/quill-cursors@3.1.0/dist/quill-cursors.min.js"></script>
+  </head>
+  <body>
+    <div class="client-container">
+      <div id="client-a">
+        Client A ( id:<span class="client-id"></span>)
+        <div class="syncmode-option">
+          <span>SyncMode: </span>
+          <div class="realtime-sync">
+            <span class="realtime-sync-title">Realtime Sync</span>
+            <div class="option">
+              <input
+                type="radio"
+                id="realtime-pushpull-a"
+                name="syncMode-a"
+                value="pushpull"
+                checked
+              />
+              <label for="realtime-pushpull-a">PushPull</label>
+            </div>
+            <div class="option">
+              <input
+                type="radio"
+                id="realtime-pushonly-a"
+                name="syncMode-a"
+                value="pushonly"
+              />
+              <label for="realtime-pushonly-a">PushOnly</label>
+            </div>
+            <div class="option">
+              <input
+                type="radio"
+                id="realtime-syncoff-a"
+                name="syncMode-a"
+                value="syncoff"
+              />
+              <label for="realtime-syncoff-a">SyncOff</label>
+            </div>
+          </div>
+          <div class="option">
+            <input
+              type="radio"
+              id="manual-a"
+              name="syncMode-a"
+              value="manual"
+            />
+            <label for="manual-a">Manual Sync</label>
+          </div>
+        </div>
+        <div class="editor"></div>
+        <div class="online-clients"></div>
+      </div>
+      <div id="client-b">
+        Client B ( id:<span class="client-id"></span>)
+        <div class="syncmode-option">
+          <span>SyncMode: </span>
+          <div class="realtime-sync">
+            <span class="realtime-sync-title">Realtime Sync</span>
+            <div class="option">
+              <input
+                type="radio"
+                id="realtime-pushpull-b"
+                name="syncMode-b"
+                value="pushpull"
+                checked
+              />
+              <label for="realtime-pushpull-b">PushPull</label>
+            </div>
+            <div class="option">
+              <input
+                type="radio"
+                id="realtime-pushonly-b"
+                name="syncMode-b"
+                value="pushonly"
+              />
+              <label for="realtime-pushonly-b">PushOnly</label>
+            </div>
+            <div class="option">
+              <input
+                type="radio"
+                id="realtime-syncoff-b"
+                name="syncMode-b"
+                value="syncoff"
+              />
+              <label for="realtime-syncoff-b">SyncOff</label>
+            </div>
+          </div>
+          <div class="option">
+            <input
+              type="radio"
+              id="manual-b"
+              name="syncMode-b"
+              value="manual"
+            />
+            <label for="manual-b">Manual Sync</label>
+          </div>
+        </div>
+        <div class="editor"></div>
+        <div class="online-clients"></div>
+      </div>
+    </div>
+    <script src="./yorkie.js"></script>
+    <script src="./util.js"></script>
+    <script>
+      const clientAElem = document.getElementById('client-a');
+      const clientBElem = document.getElementById('client-b');
+      const documentKey = 'quill-two-clients-nice11124346333';
+
+      function toDeltaOperation(textValue) {
+        const { embed, ...restAttributes } = textValue.attributes ?? {};
+
+        if (embed) {
+          return { insert: embed, attributes: restAttributes };
+        }
+
+        return {
+          insert: textValue.content || '',
+          attributes: textValue.attributes,
+        };
+      }
+
+      async function main() {
+        try {
+          async function initializeRealtimeEditor(clientElem) {
+            // 01. create client with RPCAddr(envoy) then activate it.
+            const client = new yorkie.Client('http://localhost:8080');
+            await client.activate();
+            clientElem.querySelector('.client-id').textContent = client
+              .getID()
+              .slice(-2);
+
+            // 02. create a document then attach it into the client.
+            const doc = new yorkie.Document(documentKey);
+
+            const onlineClients = clientElem.querySelector('.online-clients');
+            doc.subscribe('presence', (p) => {
+              const clientIDs = doc
+                .getPresences()
+                .map(({ clientID }) => clientID)
+                .join(', ');
+              onlineClients.textContent = clientIDs;
+            });
+
+            await client.attach(doc);
+
+            doc.update((root) => {
+              if (!root.content) {
+                root.content = new yorkie.Text();
+                root.content.edit(0, 0, '\n');
+              }
+            }, 'create content if not exists');
+
+            // 02-2. subscribe document event.
+            doc.subscribe((event) => {
+              if (event.type === 'snapshot') {
+                // The text is replaced to snapshot and must be re-synced.
+                syncText(doc, quill);
+              }
+            });
+
+            doc.subscribe('$.content', (event) => {
+              if (event.type === 'remote-change') {
+                const { message, operations } = event.value;
+                handleOperations(quill, operations);
+              }
+            });
+
+            // 03. create an instance of Quill
+            const editorElem = clientElem?.getElementsByClassName('editor')[0];
+            const quill = new Quill(editorElem, {
+              modules: {
+                toolbar: [
+                  ['bold', 'italic', 'underline', 'strike', 'link'],
+                  ['blockquote', 'code-block'],
+                  [{ header: 1 }, { header: 2 }],
+                  [{ list: 'ordered' }, { list: 'bullet' }],
+                  [{ script: 'sub' }, { script: 'super' }],
+                  [{ indent: '-1' }, { indent: '+1' }],
+                  [{ direction: 'rtl' }],
+                  [{ size: ['small', false, 'large', 'huge'] }],
+                  [{ header: [1, 2, 3, 4, 5, 6, false] }],
+                  [{ color: [] }, { background: [] }],
+                  [{ font: [] }],
+                  [{ align: [] }],
+                  ['image', 'video'],
+                  ['clean'],
+                ],
+              },
+              theme: 'snow',
+            });
+
+            // 04. bind the document with the Quill.
+            // 04-1. Quill to Document.
+            quill.on('text-change', (delta, _, source) => {
+              if (source === 'api' || !delta.ops) {
+                return;
+              }
+
+              let from = 0,
+                to = 0;
+              console.log(
+                `%c quill: ${JSON.stringify(delta.ops)}`,
+                'color: green',
+              );
+              for (const op of delta.ops) {
+                if (op.attributes !== undefined || op.insert !== undefined) {
+                  if (op.retain !== undefined) {
+                    to = from + op.retain;
+                  }
+                  console.log(
+                    `%c local: ${from}-${to}: ${op.insert} ${
+                      op.attributes ? JSON.stringify(op.attributes) : '{}'
+                    }`,
+                    'color: green',
+                  );
+
+                  doc.update((root, presence) => {
+                    if (
+                      op.attributes !== undefined &&
+                      op.insert === undefined
+                    ) {
+                      root.content.setStyle(from, to, op.attributes);
+                    } else if (op.insert !== undefined) {
+                      if (to < from) {
+                        to = from;
+                      }
+
+                      if (typeof op.insert === 'object') {
+                        root.content.edit(from, to, ' ', {
+                          embed: op.insert,
+                          ...op.attributes,
+                        });
+                      } else {
+                        root.content.edit(from, to, op.insert, op.attributes);
+                      }
+                      from = to + op.insert.length;
+                    }
+                  }, `update style by ${client.getID()}`);
+                } else if (op.delete !== undefined) {
+                  to = from + op.delete;
+                  console.log(`%c local: ${from}-${to}: ''`, 'color: green');
+
+                  doc.update((root, presence) => {
+                    root.content.edit(from, to, '');
+                  }, `update content by ${client.getID()}`);
+                } else if (op.retain !== undefined) {
+                  from = to + op.retain;
+                  to = from;
+                }
+              }
+            });
+
+            // 04-2. document to Quill(remote).
+            function handleOperations(quill, ops) {
+              const deltaOperations = [];
+              let prevTo = 0;
+              for (const op of ops) {
+                const from = op.from;
+                const to = op.to;
+                const retainFrom = from - prevTo;
+                const retainTo = to - from;
+
+                if (op.type === 'edit') {
+                  const { insert, attributes } = toDeltaOperation(op.value);
+                  console.log(
+                    `%c remote: ${from}-${to}: ${insert}`,
+                    'color: skyblue',
+                  );
+
+                  if (retainFrom) {
+                    deltaOperations.push({ retain: retainFrom });
+                  }
+                  if (retainTo) {
+                    deltaOperations.push({ delete: retainTo });
+                  }
+                  if (insert) {
+                    const deltaOp = { insert };
+                    if (attributes) {
+                      deltaOp.attributes = attributes;
+                    }
+                    deltaOperations.push(deltaOp);
+                  }
+                } else if (op.type === 'style') {
+                  const { attributes } = toDeltaOperation(op.value);
+                  console.log(
+                    `%c remote: ${from}-${to}: ${JSON.stringify(attributes)}`,
+                    'color: skyblue',
+                  );
+
+                  if (retainFrom) {
+                    deltaOperations.push({ retain: retainFrom });
+                  }
+                  if (attributes) {
+                    const deltaOp = { attributes };
+                    if (retainTo) {
+                      deltaOp.retain = retainTo;
+                    }
+
+                    deltaOperations.push(deltaOp);
+                  }
+                }
+
+                prevTo = to;
+              }
+
+              if (deltaOperations.length) {
+                console.log(
+                  `%c to quill: ${JSON.stringify(deltaOperations)}`,
+                  'color: green',
+                );
+                quill.updateContents({ ops: deltaOperations }, 'api');
+              }
+            }
+
+            // 05. synchronize text of document and Quill.
+            function syncText(doc, quill) {
+              const text = doc.getRoot().content;
+              const delta = {
+                ops: text.values().map((val) => toDeltaOperation(val)),
+              };
+              quill.setContents(delta, 'api');
+            }
+
+            // 06. sync option
+            const option = clientElem.querySelector('.syncmode-option');
+            option.addEventListener('change', async (e) => {
+              if (!event.target.matches('input[type="radio"]')) {
+                return;
+              }
+              const syncMode = event.target.value;
+              switch (syncMode) {
+                case 'pushpull':
+                  await client.resume(doc);
+                  await client.resumeRemoteChanges(doc);
+                  break;
+                case 'pushonly':
+                  await client.pauseRemoteChanges(doc);
+                  break;
+                case 'syncoff':
+                  break;
+                case 'manual':
+                  await client.pause(doc);
+                  break;
+                default:
+                  break;
+              }
+            });
+
+            syncText(doc, quill);
+            window.addEventListener('beforeunload', async () => {
+              await client.deactivate();
+            });
+
+            return { client, doc, quill };
+          }
+
+          await initializeRealtimeEditor(clientAElem);
+          await initializeRealtimeEditor(clientBElem);
+        } catch (e) {
+          console.error(e);
+        }
+      }
+
+      main();
+    </script>
+  </body>
+</html>

--- a/public/style.css
+++ b/public/style.css
@@ -14,10 +14,6 @@ menu, nav, output, section, summary,
 time, mark, audio, video {
 	margin: 0;
 	padding: 0;
-	border: 0;
-	font-size: 100%;
-	font: inherit;
-  vertical-align: baseline;
   box-sizing: border-box;
 }
 ol,

--- a/public/whiteboard.html
+++ b/public/whiteboard.html
@@ -364,10 +364,10 @@
           const syncButton = document.querySelector('.sync-button');
           syncButton.addEventListener('click', async () => {
             if (isRealtime) {
-              await client.pause(doc);
+              await client.changeSyncMode(doc, 'manual');
               syncButton.textContent = 'Connect';
             } else {
-              await client.resume(doc);
+              await client.changeSyncMode(doc, 'realtime');
               syncButton.textContent = 'Disconnect';
             }
             isRealtime = !isRealtime;

--- a/src/client/attachment.ts
+++ b/src/client/attachment.ts
@@ -14,7 +14,6 @@ export class Attachment<T, P extends Indexable> {
   private reconnectStreamDelay: number;
   doc: Document<T, P>;
   docID: string;
-  isRealtimeSync: boolean;
   syncMode: SyncMode;
   remoteChangeEventReceived: boolean;
 
@@ -26,13 +25,12 @@ export class Attachment<T, P extends Indexable> {
     reconnectStreamDelay: number,
     doc: Document<T, P>,
     docID: string,
-    isRealtimeSync: boolean,
+    syncMode: SyncMode,
   ) {
     this.reconnectStreamDelay = reconnectStreamDelay;
     this.doc = doc;
     this.docID = docID;
-    this.isRealtimeSync = isRealtimeSync;
-    this.syncMode = isRealtimeSync ? SyncMode.Realtime : SyncMode.Manual;
+    this.syncMode = syncMode;
     this.remoteChangeEventReceived = false;
   }
 
@@ -41,7 +39,6 @@ export class Attachment<T, P extends Indexable> {
    */
   public changeSyncMode(syncMode: SyncMode) {
     this.syncMode = syncMode;
-    this.isRealtimeSync = syncMode !== SyncMode.Manual;
   }
 
   /**
@@ -53,7 +50,7 @@ export class Attachment<T, P extends Indexable> {
     }
 
     return (
-      this.isRealtimeSync &&
+      this.syncMode !== SyncMode.Manual &&
       (this.doc.hasLocalChanges() || this.remoteChangeEventReceived)
     );
   }

--- a/src/client/attachment.ts
+++ b/src/client/attachment.ts
@@ -58,6 +58,14 @@ export class Attachment<T, P extends Indexable> {
    * `changeSyncMode` changes the sync mode of the document.
    */
   public changeSyncMode(syncMode: SyncMode) {
+    // NOTE(chacha912): In pushonly/syncoff mode, the client does not receive change events
+    // from the server. Therefore, we need to set `remoteChangeEventReceived` to true
+    // to sync the local and remote changes. This has limitations in that unnecessary
+    // syncs occur if the client and server do not have any changes.
+    if (syncMode === SyncMode.PushPull && syncMode !== this.syncMode) {
+      this.remoteChangeEventReceived = true;
+    }
+
     this.syncMode = syncMode;
   }
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -425,7 +425,7 @@ export class Client implements Observable<ClientEvent> {
     doc: Document<T, P>,
     options: {
       initialPresence?: P;
-      isRealtimeSync?: boolean;
+      syncMode?: SyncMode;
     } = {},
   ): Promise<Document<T, P>> {
     if (!this.isActive()) {
@@ -440,7 +440,7 @@ export class Client implements Observable<ClientEvent> {
     doc.setActor(this.id!);
     doc.update((_, p) => p.set(options.initialPresence || {}));
 
-    const isRealtimeSync = options.isRealtimeSync ?? true;
+    const syncMode = options.syncMode ?? SyncMode.Realtime;
 
     return this.rpcClient
       .attachDocument(
@@ -466,11 +466,11 @@ export class Client implements Observable<ClientEvent> {
             this.reconnectStreamDelay,
             doc,
             res.documentId,
-            isRealtimeSync,
+            syncMode,
           ),
         );
 
-        if (isRealtimeSync) {
+        if (syncMode !== SyncMode.Manual) {
           await this.runWatchLoop(doc.getKey());
         }
 

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -593,7 +593,6 @@ export class Client implements Observable<ClientEvent> {
    */
   public sync<T, P extends Indexable>(
     doc?: Document<T, P>,
-    syncMode = SyncMode.Realtime,
   ): Promise<Array<Document<T, P>>> {
     if (!this.isActive()) {
       throw new YorkieError(Code.ClientNotActive, `${this.key} is not active`);
@@ -608,7 +607,7 @@ export class Client implements Observable<ClientEvent> {
           `${doc.getKey()} is not attached`,
         );
       }
-      promises.push(this.syncInternal(attachment, syncMode));
+      promises.push(this.syncInternal(attachment, SyncMode.Realtime));
     } else {
       this.attachmentMap.forEach((attachment) => {
         promises.push(this.syncInternal(attachment, attachment.syncMode));

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -587,45 +587,6 @@ export class Client implements Observable<ClientEvent> {
   }
 
   /**
-   * `pauseRemoteChanges` pauses the synchronization of remote changes,
-   * allowing only local changes to be applied.
-   */
-  public pauseRemoteChanges<T, P extends Indexable>(doc: Document<T, P>) {
-    if (!this.isActive()) {
-      throw new YorkieError(Code.ClientNotActive, `${this.key} is not active`);
-    }
-    const attachment = this.attachmentMap.get(doc.getKey());
-    if (!attachment) {
-      throw new YorkieError(
-        Code.DocumentNotAttached,
-        `${doc.getKey()} is not attached`,
-      );
-    }
-
-    attachment.changeSyncMode(SyncMode.PushOnly);
-  }
-
-  /**
-   * `resumeRemoteChanges` resumes the synchronization of remote changes,
-   * allowing both local and remote changes to be applied.
-   */
-  public resumeRemoteChanges<T, P extends Indexable>(doc: Document<T, P>) {
-    if (!this.isActive()) {
-      throw new YorkieError(Code.ClientNotActive, `${this.key} is not active`);
-    }
-    const attachment = this.attachmentMap.get(doc.getKey());
-    if (!attachment) {
-      throw new YorkieError(
-        Code.DocumentNotAttached,
-        `${doc.getKey()} is not attached`,
-      );
-    }
-
-    attachment.changeSyncMode(SyncMode.PushPull);
-    attachment.remoteChangeEventReceived = true;
-  }
-
-  /**
    * `changeRealtimeSync` changes the synchronization mode of the given document.
    */
   private async changeRealtimeSync<T, P extends Indexable>(

--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -612,7 +612,7 @@ describe.sequential('Client', function () {
     c2.sync();
 
     // In push-only mode, remote-change events should not occur.
-    c2.pauseRemoteChanges(d2);
+    c2.changeRealtimeSyncMode(d2, SyncMode.PushOnly);
     let remoteChangeOccured = false;
     const unsub3 = d2.subscribe((event) => {
       if (event.type === DocEventType.RemoteChange) {
@@ -626,7 +626,7 @@ describe.sequential('Client', function () {
     unsub3();
     assert.isFalse(remoteChangeOccured);
 
-    c2.resumeRemoteChanges(d2);
+    c2.changeRealtimeSyncMode(d2, SyncMode.PushPull);
 
     d2.update((root: any) => {
       root.tree.edit(2, 2, { type: 'text', value: 'b' });

--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -232,8 +232,8 @@ describe.sequential('Client', function () {
 
     // 01. c1 and c2 attach the doc with manual sync mode.
     //     c1 updates the doc, but c2 does't get until call sync manually.
-    await c1.attach(d1, { isRealtimeSync: false });
-    await c2.attach(d2, { isRealtimeSync: false });
+    await c1.attach(d1, { syncMode: SyncMode.Manual });
+    await c2.attach(d2, { syncMode: SyncMode.Manual });
     d1.update((root) => {
       root.version = 'v1';
     });
@@ -433,7 +433,7 @@ describe.sequential('Client', function () {
     const unsub1 = c2.subscribe(stub);
 
     // 01. c2 attach the doc with realtime sync mode at first.
-    await c1.attach(d1, { isRealtimeSync: false });
+    await c1.attach(d1, { syncMode: SyncMode.Manual });
     await c2.attach(d2);
     d1.update((root) => {
       root.version = 'v1';
@@ -485,7 +485,7 @@ describe.sequential('Client', function () {
     // 01. cli attach to the document having counter.
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const d1 = new yorkie.Document<{ counter: Counter }>(docKey);
-    await c1.attach(d1, { isRealtimeSync: false });
+    await c1.attach(d1, { syncMode: SyncMode.Manual });
 
     // 02. cli update the document with creating a counter
     //     and sync with push-pull mode: CP(1, 1) -> CP(2, 2)

--- a/test/integration/counter_test.ts
+++ b/test/integration/counter_test.ts
@@ -7,7 +7,7 @@ import {
   toDocKey,
   testRPCAddr,
 } from '@yorkie-js-sdk/test/integration/integration_helper';
-import yorkie, { Counter } from '@yorkie-js-sdk/src/yorkie';
+import yorkie, { Counter, SyncMode } from '@yorkie-js-sdk/src/yorkie';
 import { CounterType } from '@yorkie-js-sdk/src/document/crdt/counter';
 import Long from 'long';
 
@@ -232,14 +232,14 @@ describe('Counter', function () {
     await client1.activate();
     await client2.activate();
 
-    await client1.attach(doc1, { isRealtimeSync: false });
+    await client1.attach(doc1, { syncMode: SyncMode.Manual });
     doc1.update((root) => {
       root.counter = new Counter(yorkie.IntType, 100);
     }, 'init counter');
     await client1.sync();
     assert.equal(doc1.toSortedJSON(), '{"counter":100}');
 
-    await client2.attach(doc2, { isRealtimeSync: false });
+    await client2.attach(doc2, { syncMode: SyncMode.Manual });
     assert.equal(doc2.toSortedJSON(), '{"counter":100}');
 
     // client1 increases 1 and client2 increases 2

--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -1,5 +1,10 @@
 import { describe, it, assert, vi, afterEach } from 'vitest';
-import yorkie, { Counter, Text, JSONArray } from '@yorkie-js-sdk/src/yorkie';
+import yorkie, {
+  Counter,
+  Text,
+  JSONArray,
+  SyncMode,
+} from '@yorkie-js-sdk/src/yorkie';
 import {
   testRPCAddr,
   toDocKey,
@@ -32,7 +37,7 @@ describe('Document', function () {
     await client1.activate();
     await client2.activate();
 
-    await client1.attach(doc1, { isRealtimeSync: false });
+    await client1.attach(doc1, { syncMode: SyncMode.Manual });
     doc1.update((root) => {
       root['k1'] = { 'k1-1': 'v1' };
       root['k2'] = ['1', '2'];
@@ -40,14 +45,14 @@ describe('Document', function () {
     await client1.sync();
     assert.equal('{"k1":{"k1-1":"v1"},"k2":["1","2"]}', doc1.toSortedJSON());
 
-    await client2.attach(doc2, { isRealtimeSync: false });
+    await client2.attach(doc2, { syncMode: SyncMode.Manual });
     assert.equal('{"k1":{"k1-1":"v1"},"k2":["1","2"]}', doc2.toSortedJSON());
 
     await client1.detach(doc1);
     await client2.detach(doc2);
 
-    await client1.attach(doc1, { isRealtimeSync: false });
-    await client2.attach(doc2, { isRealtimeSync: false });
+    await client1.attach(doc1, { syncMode: SyncMode.Manual });
+    await client2.attach(doc2, { syncMode: SyncMode.Manual });
 
     await client1.detach(doc1);
     await client2.detach(doc2);
@@ -465,8 +470,8 @@ describe('Document', function () {
     await c1.activate();
     await c2.activate();
 
-    await c1.attach(d1, { isRealtimeSync: false });
-    await c2.attach(d2, { isRealtimeSync: false });
+    await c1.attach(d1, { syncMode: SyncMode.Manual });
+    await c2.attach(d2, { syncMode: SyncMode.Manual });
 
     d1.update((root) => {
       root['k1'] = [1, 2];
@@ -590,13 +595,13 @@ describe('Document', function () {
     d1.update((root) => {
       root['k1'] = [1, 2];
     }, 'set array');
-    await c1.attach(d1, { isRealtimeSync: false });
+    await c1.attach(d1, { syncMode: SyncMode.Manual });
     assert.equal(d1.toSortedJSON(), '{"k1":[1,2]}');
 
     const c2 = new yorkie.Client(testRPCAddr);
     await c2.activate();
     const d2 = new yorkie.Document<TestDoc>(docKey);
-    await c2.attach(d2, { isRealtimeSync: false });
+    await c2.attach(d2, { syncMode: SyncMode.Manual });
     assert.equal(d2.toSortedJSON(), '{"k1":[1,2]}');
 
     // 02. c1 updates d1 and removes it.
@@ -629,13 +634,13 @@ describe('Document', function () {
     d1.update((root) => {
       root['k1'] = [1, 2];
     }, 'set array');
-    await c1.attach(d1, { isRealtimeSync: false });
+    await c1.attach(d1, { syncMode: SyncMode.Manual });
     assert.equal(d1.toSortedJSON(), '{"k1":[1,2]}');
 
     const c2 = new yorkie.Client(testRPCAddr);
     await c2.activate();
     const d2 = new yorkie.Document<TestDoc>(docKey);
-    await c2.attach(d2, { isRealtimeSync: false });
+    await c2.attach(d2, { syncMode: SyncMode.Manual });
     assert.equal(d2.toSortedJSON(), '{"k1":[1,2]}');
 
     // 02. c1 removes d1 and c2 detaches d2.
@@ -663,13 +668,13 @@ describe('Document', function () {
     d1.update((root) => {
       root['k1'] = [1, 2];
     }, 'set array');
-    await c1.attach(d1, { isRealtimeSync: false });
+    await c1.attach(d1, { syncMode: SyncMode.Manual });
     assert.equal(d1.toSortedJSON(), '{"k1":[1,2]}');
 
     const c2 = new yorkie.Client(testRPCAddr);
     await c2.activate();
     const d2 = new yorkie.Document<TestDoc>(docKey);
-    await c2.attach(d2, { isRealtimeSync: false });
+    await c2.attach(d2, { syncMode: SyncMode.Manual });
     assert.equal(d2.toSortedJSON(), '{"k1":[1,2]}');
 
     // 02. c1 removes d1 and c2 removes d2.

--- a/test/integration/gc_test.ts
+++ b/test/integration/gc_test.ts
@@ -1,7 +1,7 @@
 import { describe, it, assert } from 'vitest';
 import { MaxTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';
-import yorkie, { Text, Tree } from '@yorkie-js-sdk/src/yorkie';
+import yorkie, { Text, Tree, SyncMode } from '@yorkie-js-sdk/src/yorkie';
 import {
   testRPCAddr,
   toDocKey,
@@ -129,10 +129,10 @@ describe('Garbage Collection', function () {
     await client2.activate();
 
     // 1. initial state
-    await client1.attach(doc1, { isRealtimeSync: false });
+    await client1.attach(doc1, { syncMode: SyncMode.Manual });
     doc1.update((root) => (root.point = { x: 0, y: 0 }));
     await client1.sync();
-    await client2.attach(doc2, { isRealtimeSync: false });
+    await client2.attach(doc2, { syncMode: SyncMode.Manual });
 
     // 2. client1 updates doc
     doc1.update((root) => {
@@ -349,8 +349,8 @@ describe('Garbage Collection', function () {
     await client1.activate();
     await client2.activate();
 
-    await client1.attach(doc1, { isRealtimeSync: false });
-    await client2.attach(doc2, { isRealtimeSync: false });
+    await client1.attach(doc1, { syncMode: SyncMode.Manual });
+    await client2.attach(doc2, { syncMode: SyncMode.Manual });
 
     doc1.update((root) => {
       root.t = new Tree({
@@ -434,8 +434,8 @@ describe('Garbage Collection', function () {
     await client1.activate();
     await client2.activate();
 
-    await client1.attach(doc1, { isRealtimeSync: false });
-    await client2.attach(doc2, { isRealtimeSync: false });
+    await client1.attach(doc1, { syncMode: SyncMode.Manual });
+    await client2.attach(doc2, { syncMode: SyncMode.Manual });
 
     doc1.update((root) => {
       root['1'] = 1;
@@ -502,8 +502,8 @@ describe('Garbage Collection', function () {
     await client1.activate();
     await client2.activate();
 
-    await client1.attach(doc1, { isRealtimeSync: false });
-    await client2.attach(doc2, { isRealtimeSync: false });
+    await client1.attach(doc1, { syncMode: SyncMode.Manual });
+    await client2.attach(doc2, { syncMode: SyncMode.Manual });
 
     doc1.update((root) => {
       root.text = new Text();
@@ -581,8 +581,8 @@ describe('Garbage Collection', function () {
     await client1.activate();
     await client2.activate();
 
-    await client1.attach(doc1, { isRealtimeSync: false });
-    await client2.attach(doc2, { isRealtimeSync: false });
+    await client1.attach(doc1, { syncMode: SyncMode.Manual });
+    await client2.attach(doc2, { syncMode: SyncMode.Manual });
 
     doc1.update((root) => {
       root['1'] = 1;
@@ -643,7 +643,7 @@ describe('Garbage Collection', function () {
     const cli = new yorkie.Client(testRPCAddr);
     await cli.activate();
 
-    await cli.attach(doc, { isRealtimeSync: false });
+    await cli.attach(doc, { syncMode: SyncMode.Manual });
     doc.update((root) => {
       root.point = { x: 0, y: 0 };
     });
@@ -666,7 +666,7 @@ describe('Garbage Collection', function () {
     const cli = new yorkie.Client(testRPCAddr);
     await cli.activate();
 
-    await cli.attach(doc, { isRealtimeSync: false });
+    await cli.attach(doc, { syncMode: SyncMode.Manual });
     doc.update((root) => {
       root.list = [0, 1, 2];
       root.list.push([3, 4, 5]);
@@ -699,13 +699,13 @@ describe('Garbage Collection', function () {
     await client1.activate();
     await client2.activate();
 
-    await client1.attach(doc1, { isRealtimeSync: false });
+    await client1.attach(doc1, { syncMode: SyncMode.Manual });
     doc1.update((root) => (root.point = { x: 0, y: 0 }));
     doc1.update((root) => (root.point.x = 1));
     assert.equal(doc1.getGarbageLen(), 1);
     await client1.sync();
 
-    await client2.attach(doc2, { isRealtimeSync: false });
+    await client2.attach(doc2, { syncMode: SyncMode.Manual });
     assert.equal(doc2.getGarbageLen(), 1);
     doc2.update((root) => (root.point.x = 2));
     assert.equal(doc2.getGarbageLen(), 2);

--- a/test/integration/integration_helper.ts
+++ b/test/integration/integration_helper.ts
@@ -1,5 +1,5 @@
 import { assert } from 'vitest';
-import yorkie from '@yorkie-js-sdk/src/yorkie';
+import yorkie, { SyncMode } from '@yorkie-js-sdk/src/yorkie';
 import { Client } from '@yorkie-js-sdk/src/client/client';
 import { Document } from '@yorkie-js-sdk/src/document/document';
 import { Indexable } from '@yorkie-js-sdk/test/helper/helper';
@@ -31,8 +31,8 @@ export async function withTwoClientsAndDocuments<T>(
   const doc1 = new yorkie.Document<T>(docKey);
   const doc2 = new yorkie.Document<T>(docKey);
 
-  await client1.attach(doc1, { isRealtimeSync: false });
-  await client2.attach(doc2, { isRealtimeSync: false });
+  await client1.attach(doc1, { syncMode: SyncMode.Manual });
+  await client2.attach(doc2, { syncMode: SyncMode.Manual });
 
   await callback(client1, doc1, client2, doc2);
 

--- a/test/integration/object_test.ts
+++ b/test/integration/object_test.ts
@@ -1,5 +1,5 @@
 import { describe, it, assert } from 'vitest';
-import { JSONObject, Client } from '@yorkie-js-sdk/src/yorkie';
+import { JSONObject, Client, SyncMode } from '@yorkie-js-sdk/src/yorkie';
 import { Document } from '@yorkie-js-sdk/src/document/document';
 import {
   withTwoClientsAndDocuments,
@@ -382,14 +382,14 @@ describe('Object', function () {
       await client1.activate();
       await client2.activate();
 
-      await client1.attach(doc1, { isRealtimeSync: false });
+      await client1.attach(doc1, { syncMode: SyncMode.Manual });
       doc1.update((root) => {
         root.shape = { point: { x: 0, y: 0 } };
       });
       await client1.sync();
       assert.equal(doc1.toSortedJSON(), '{"shape":{"point":{"x":0,"y":0}}}');
 
-      await client2.attach(doc2, { isRealtimeSync: false });
+      await client2.attach(doc2, { syncMode: SyncMode.Manual });
       assert.equal(doc2.toSortedJSON(), '{"shape":{"point":{"x":0,"y":0}}}');
 
       doc1.update((root) => {
@@ -426,14 +426,14 @@ describe('Object', function () {
       await client1.activate();
       await client2.activate();
 
-      await client1.attach(doc1, { isRealtimeSync: false });
+      await client1.attach(doc1, { syncMode: SyncMode.Manual });
       doc1.update((root) => {
         root.shape = { color: 'black' };
       }, 'init doc');
       await client1.sync();
       assert.equal(doc1.toSortedJSON(), '{"shape":{"color":"black"}}');
 
-      await client2.attach(doc2, { isRealtimeSync: false });
+      await client2.attach(doc2, { syncMode: SyncMode.Manual });
       assert.equal(doc2.toSortedJSON(), '{"shape":{"color":"black"}}');
 
       doc1.update((root) => {
@@ -476,7 +476,7 @@ describe('Object', function () {
       await client1.activate();
       await client2.activate();
 
-      await client1.attach(doc1, { isRealtimeSync: false });
+      await client1.attach(doc1, { syncMode: SyncMode.Manual });
       doc1.update((root) => {
         root.shape = { circle: { point: { x: 0, y: 0 } } };
       });
@@ -486,7 +486,7 @@ describe('Object', function () {
         '{"shape":{"circle":{"point":{"x":0,"y":0}}}}',
       );
 
-      await client2.attach(doc2, { isRealtimeSync: false });
+      await client2.attach(doc2, { syncMode: SyncMode.Manual });
       assert.equal(
         doc2.toSortedJSON(),
         '{"shape":{"circle":{"point":{"x":0,"y":0}}}}',
@@ -546,14 +546,14 @@ describe('Object', function () {
       await client1.activate();
       await client2.activate();
 
-      await client1.attach(doc1, { isRealtimeSync: false });
+      await client1.attach(doc1, { syncMode: SyncMode.Manual });
       doc1.update((root) => {
         root.shape = { color: 'black' };
       }, 'init doc');
       await client1.sync();
       assert.equal(doc1.toSortedJSON(), '{"shape":{"color":"black"}}');
 
-      await client2.attach(doc2, { isRealtimeSync: false });
+      await client2.attach(doc2, { syncMode: SyncMode.Manual });
       assert.equal(doc2.toSortedJSON(), '{"shape":{"color":"black"}}');
 
       doc2.update((root) => {
@@ -592,14 +592,14 @@ describe('Object', function () {
       await client1.activate();
       await client2.activate();
 
-      await client1.attach(doc1, { isRealtimeSync: false });
+      await client1.attach(doc1, { syncMode: SyncMode.Manual });
       doc1.update((root) => {
         root.shape = { circle: { color: 'red' } };
       });
       await client1.sync();
       assert.equal(doc1.toSortedJSON(), '{"shape":{"circle":{"color":"red"}}}');
 
-      await client2.attach(doc2, { isRealtimeSync: false });
+      await client2.attach(doc2, { syncMode: SyncMode.Manual });
       assert.equal(doc2.toSortedJSON(), '{"shape":{"circle":{"color":"red"}}}');
 
       doc1.update((root) => {
@@ -651,7 +651,7 @@ describe('Object', function () {
       await client1.activate();
       await client2.activate();
 
-      await client1.attach(doc1, { isRealtimeSync: false });
+      await client1.attach(doc1, { syncMode: SyncMode.Manual });
       let doc1ChangeID = doc1.getChangeID();
       let doc1Checkpoint = doc1.getCheckpoint();
       assert.equal(doc1ChangeID.getClientSeq(), 1);
@@ -669,7 +669,7 @@ describe('Object', function () {
       assert.equal(doc1Checkpoint.getClientSeq(), 2);
       assert.equal(doc1Checkpoint.getServerSeq().toInt(), 2);
 
-      await client2.attach(doc2, { isRealtimeSync: false });
+      await client2.attach(doc2, { syncMode: SyncMode.Manual });
       assert.equal(doc2.toSortedJSON(), '{"shape":{"color":"black"}}');
 
       doc2.update((root) => {
@@ -727,7 +727,7 @@ describe('Object', function () {
       await client1.activate();
       await client2.activate();
 
-      await client1.attach(doc1, { isRealtimeSync: false });
+      await client1.attach(doc1, { syncMode: SyncMode.Manual });
       let doc1ChangeID = doc1.getChangeID();
       let doc1Checkpoint = doc1.getCheckpoint();
       assert.equal(doc1ChangeID.getClientSeq(), 1);
@@ -745,7 +745,7 @@ describe('Object', function () {
       assert.equal(doc1Checkpoint.getClientSeq(), 2);
       assert.equal(doc1Checkpoint.getServerSeq().toInt(), 2);
 
-      await client2.attach(doc2, { isRealtimeSync: false });
+      await client2.attach(doc2, { syncMode: SyncMode.Manual });
       assert.equal(doc2.toSortedJSON(), '{"shape":{"color":"black"}}');
 
       doc2.update((root) => {
@@ -803,8 +803,8 @@ describe('Object', function () {
       await client1.activate();
       await client2.activate();
 
-      await client1.attach(doc1, { isRealtimeSync: false });
-      await client2.attach(doc2, { isRealtimeSync: false });
+      await client1.attach(doc1, { syncMode: SyncMode.Manual });
+      await client2.attach(doc2, { syncMode: SyncMode.Manual });
       doc1.update((root) => {
         root.color = 'black';
       }, 'init doc');
@@ -859,8 +859,8 @@ describe('Object', function () {
       await client1.activate();
       await client2.activate();
 
-      await client1.attach(doc1, { isRealtimeSync: false });
-      await client2.attach(doc2, { isRealtimeSync: false });
+      await client1.attach(doc1, { syncMode: SyncMode.Manual });
+      await client2.attach(doc2, { syncMode: SyncMode.Manual });
       doc1.update((root) => {
         root.color = 'black';
       }, 'init doc');
@@ -912,8 +912,8 @@ describe('Object', function () {
       await client1.activate();
       await client2.activate();
 
-      await client1.attach(doc1, { isRealtimeSync: false });
-      await client2.attach(doc2, { isRealtimeSync: false });
+      await client1.attach(doc1, { syncMode: SyncMode.Manual });
+      await client2.attach(doc2, { syncMode: SyncMode.Manual });
 
       doc1.update((root) => {
         root.shape = { color: 'black' };
@@ -960,8 +960,8 @@ describe('Object', function () {
       await client1.activate();
       await client2.activate();
 
-      await client1.attach(doc1, { isRealtimeSync: false });
-      await client2.attach(doc2, { isRealtimeSync: false });
+      await client1.attach(doc1, { syncMode: SyncMode.Manual });
+      await client2.attach(doc2, { syncMode: SyncMode.Manual });
 
       doc1.update((root) => {
         root.shape = { color: 'black' };

--- a/test/integration/presence_test.ts
+++ b/test/integration/presence_test.ts
@@ -25,10 +25,10 @@ describe('Presence', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     type PresenceType = { key: string };
     const doc1 = new yorkie.Document<{}, PresenceType>(docKey);
-    await c1.attach(doc1, { isRealtimeSync: false });
+    await c1.attach(doc1, { syncMode: SyncMode.Manual });
 
     const doc2 = new yorkie.Document<{}, PresenceType>(docKey);
-    await c2.attach(doc2, { isRealtimeSync: false });
+    await c2.attach(doc2, { syncMode: SyncMode.Manual });
 
     const snapshotThreshold = 500;
     for (let i = 0; i < snapshotThreshold; i++) {
@@ -58,13 +58,13 @@ describe('Presence', function () {
     const doc1 = new yorkie.Document<{}, PresenceType>(docKey);
     await c1.attach(doc1, {
       initialPresence: { key: 'key1' },
-      isRealtimeSync: false,
+      syncMode: SyncMode.Manual,
     });
 
     const doc2 = new yorkie.Document<{}, PresenceType>(docKey);
     await c2.attach(doc2, {
       initialPresence: { key: 'key2' },
-      isRealtimeSync: false,
+      syncMode: SyncMode.Manual,
     });
 
     assert.deepEqual(doc1.getPresenceForTest(c1.getID()!), { key: 'key1' });
@@ -91,10 +91,10 @@ describe('Presence', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     type PresenceType = { key: string };
     const doc1 = new yorkie.Document<{}, PresenceType>(docKey);
-    await c1.attach(doc1, { isRealtimeSync: false });
+    await c1.attach(doc1, { syncMode: SyncMode.Manual });
 
     const doc2 = new yorkie.Document<{}, PresenceType>(docKey);
-    await c2.attach(doc2, { isRealtimeSync: false });
+    await c2.attach(doc2, { syncMode: SyncMode.Manual });
 
     const emptyObject = {} as PresenceType;
     assert.deepEqual(doc1.getPresenceForTest(c1.getID()!), emptyObject);
@@ -185,13 +185,13 @@ describe('Presence', function () {
     const doc1 = new yorkie.Document<{}, PresenceType>(docKey);
     await c1.attach(doc1, {
       initialPresence: { key: 'key1', cursor: { x: 0, y: 0 } },
-      isRealtimeSync: false,
+      syncMode: SyncMode.Manual,
     });
 
     const doc2 = new yorkie.Document<{}, PresenceType>(docKey);
     await c2.attach(doc2, {
       initialPresence: { key: 'key2', cursor: { x: 0, y: 0 } },
-      isRealtimeSync: false,
+      syncMode: SyncMode.Manual,
     });
 
     doc1.update((root, p) => p.set({ cursor: { x: 1, y: 1 } }));
@@ -240,7 +240,7 @@ describe('Presence', function () {
     const doc3 = new yorkie.Document<{}, PresenceType>(docKey);
     await c3.attach(doc3, {
       initialPresence: { name: 'c1', cursor: { x: 0, y: 0 } },
-      isRealtimeSync: false,
+      syncMode: SyncMode.Manual,
     });
     await eventCollector.waitAndVerifyNthEvent(1, {
       type: DocEventType.Watched,
@@ -288,13 +288,13 @@ describe('Presence', function () {
     const doc1 = new yorkie.Document<{}, PresenceType>(docKey);
     await c1.attach(doc1, {
       initialPresence: { counter: 0 },
-      isRealtimeSync: false,
+      syncMode: SyncMode.Manual,
     });
 
     const doc2 = new yorkie.Document<{}, PresenceType>(docKey);
     await c2.attach(doc2, {
       initialPresence: { counter: 0 },
-      isRealtimeSync: false,
+      syncMode: SyncMode.Manual,
     });
 
     doc1.update((root, p) => {
@@ -447,7 +447,7 @@ describe(`Document.Subscribe('presence')`, function () {
     const doc3 = new yorkie.Document<{}, PresenceType>(docKey);
     await c3.attach(doc3, {
       initialPresence: { name: 'c1', cursor: { x: 0, y: 0 } },
-      isRealtimeSync: false,
+      syncMode: SyncMode.Manual,
     });
     await events.waitAndVerifyNthEvent(1, {
       type: DocEventType.Watched,

--- a/test/integration/presence_test.ts
+++ b/test/integration/presence_test.ts
@@ -3,6 +3,7 @@ import yorkie, {
   DocEvent,
   DocEventType,
   Counter,
+  SyncMode,
 } from '@yorkie-js-sdk/src/yorkie';
 import {
   testRPCAddr,
@@ -251,13 +252,13 @@ describe('Presence', function () {
     ]);
     assert.deepEqual(doc1.getPresence(c3ID), undefined);
 
-    // 02. c2 pauses the document (in manual sync), c3 resumes the document (in realtime sync).
-    await c2.pause(doc2);
+    // 02. c2 is changed to manual sync, while c3 is changed to realtime sync.
+    await c2.changeSyncMode(doc2, SyncMode.Manual);
     await eventCollector.waitAndVerifyNthEvent(2, {
       type: DocEventType.Unwatched,
       value: { clientID: c2ID, presence: doc2.getMyPresence() },
     });
-    await c3.resume(doc3);
+    await c3.changeSyncMode(doc3, SyncMode.Realtime);
     await eventCollector.waitAndVerifyNthEvent(3, {
       type: DocEventType.Watched,
       value: { clientID: c3ID, presence: doc3.getMyPresence() },
@@ -468,8 +469,8 @@ describe(`Document.Subscribe('presence')`, function () {
       },
     });
 
-    // 03-1. c2 pauses the document, c1 receives an unwatched event from c2.
-    await c2.pause(doc2);
+    // 03-1. c2 is changed to manual sync, c1 receives an unwatched event from c2.
+    await c2.changeSyncMode(doc2, SyncMode.Manual);
     await events.waitAndVerifyNthEvent(3, {
       type: DocEventType.Unwatched,
       value: {
@@ -477,14 +478,14 @@ describe(`Document.Subscribe('presence')`, function () {
         presence: { cursor: { x: 0, y: 0 }, name: 'b2' },
       },
     });
-    // 03-2. c3 resumes the document, c1 receives a watched event from c3.
+    // 03-2. c3 is changed to realtime sync, c1 receives a watched event from c3.
     // NOTE(chacha912): The events are influenced by the timing of realtime sync
-    // and watch stream resolution. For deterministic testing, the resume is performed
+    // and watch stream resolution. For deterministic testing, changeSyncMode is performed
     // after the sync. Since the sync updates c1 with all previous presence changes
     // from c3, only the watched event is triggered.
     await c3.sync();
     await c1.sync();
-    await c3.resume(doc3);
+    await c3.changeSyncMode(doc3, SyncMode.Realtime);
     await events.waitAndVerifyNthEvent(4, {
       type: DocEventType.Watched,
       value: {
@@ -505,8 +506,8 @@ describe(`Document.Subscribe('presence')`, function () {
       },
     });
 
-    // 05-1. c3 pauses the document, c1 receives an unwatched event from c3.
-    await c3.pause(doc3);
+    // 05-1. c3 is changed to manual sync, c1 receives an unwatched event from c3.
+    await c3.changeSyncMode(doc3, SyncMode.Manual);
     await events.waitAndVerifyNthEvent(6, {
       type: DocEventType.Unwatched,
       value: {
@@ -515,10 +516,10 @@ describe(`Document.Subscribe('presence')`, function () {
       },
     });
 
-    // 05-2. c2 resumes the document, c1 receives a watched event from c2.
+    // 05-2. c2 is changed to realtime sync, c1 receives a watched event from c2.
     await c2.sync();
     await c1.sync();
-    await c2.resume(doc2);
+    await c2.changeSyncMode(doc2, SyncMode.Realtime);
     await events.waitAndVerifyNthEvent(7, {
       type: DocEventType.Watched,
       value: {

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, assert } from 'vitest';
-import yorkie, { Tree } from '@yorkie-js-sdk/src/yorkie';
+import yorkie, { Tree, SyncMode } from '@yorkie-js-sdk/src/yorkie';
 import {
   testRPCAddr,
   toDocKey,
@@ -1532,8 +1532,8 @@ describe('Tree.style', function () {
     await c1.activate();
     await c2.activate();
 
-    await c1.attach(d1, { isRealtimeSync: false });
-    await c2.attach(d2, { isRealtimeSync: false });
+    await c1.attach(d1, { syncMode: SyncMode.Manual });
+    await c2.attach(d2, { syncMode: SyncMode.Manual });
 
     // Perform a dummy update to apply changes up to the snapshot threshold.
     const snapshotThreshold = 500;
@@ -1733,7 +1733,7 @@ describe('Tree.style', function () {
     const d3 = new yorkie.Document<TestDoc>(docKey);
     const c3 = new yorkie.Client(testRPCAddr);
     await c3.activate();
-    await c3.attach(d3, { isRealtimeSync: false });
+    await c3.attach(d3, { syncMode: SyncMode.Manual });
     assert.equal(
       d3.getRoot().t.toXML(),
       /*html*/ `<r><c><u><p><n></n></p></u></c><c><p><n>1 카카오2 네이3</n></p></c></r>`,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

The `SyncOff` mode will allow users to maintain the watch stream functionality while disabling synchronization. 

**Does this PR introduce a user-facing change?**:
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".
-->

```release-note
- 1️⃣ With the addition of the `RealtimeSyncOff` mode, the `SyncMode` has been simplified into four options. Usage is as follows:

// as-is
await client.pause(doc); // manual sync
await client.resume(doc); // realtime sync(pushpull)
client.pauseRemoteChanges(doc); // pushonly 
client.resumeRemoteChanges(doc); // pushpull 

// to-be
await client.changeSyncMode(doc, SyncMode.Manual);
await client.changeSyncMode(doc, SyncMode.Realtime); // Same as PushPull mode
await client.changeSyncMode(doc, SyncMode.RealtimePushOnly); 
await client.changeSyncMode(doc, SyncMode.RealtimeSyncOff); // Added RealtimeSyncOff mode 

- 2️⃣ In manual sync mode, the `sync()` function can now only be executed in pushpull mode.

await client.sync(doc, SyncMode.PushOnly) // Deprecated: Only pushpull synchronization is supported now.

- 3️⃣ The option to specify manual sync during attachment has been updated.

// as-is 
await client.attach(doc, { isRealtimeSync: false });

// to-be
await client.attach(doc, { syncMode: SyncMode.Manual });
```

#### Any background context you want to provide?

- I'd like to discuss the user interface

1. With the addition of `SyncOff` mode, the existing functions (`pauseRemoteChanges`, `resumeRemoteChanges`) have been unified under `changeRealtimeSyncMode`.

```js
// as-is
client.pauseRemoteChanges(doc); // pushonly 
client.resumeRemoteChanges(doc); // pushpull 

// to-be
client.changeRealtimeSyncMode(doc, SyncMode.PushPull); // pushpull
client.changeRealtimeSyncMode(doc, SyncMode.PushOnly); // pushonly
client.changeRealtimeSyncMode(doc, SyncMode.SyncOff); // syncoff
```

2. The `changeRealtimeSyncMode` is currently designated for use only in realtime sync. Therefore, if you want to resume from manual mode to `pushonly` mode, you need to call `resume()` and then change the sync mode. By default, `resume()` operates in push-pull mode, but would it be necessary to provide an option to set the sync mode during the resume process?

```js
// manual -> realtime(pushonly)
// as-is
await client.pause(doc); // manual sync
await client.resume(doc); // realtime sync
client.changeRealtimeSyncMode(doc, SyncMode.PushOnly);

// provide option
await client.pause(doc); // manual sync
await client.resume(doc, {mode: SyncMode.PushOnly}); // realtime sync
```

- The quill-two-clients example is based on the code from #647.
 
![image](https://github.com/yorkie-team/yorkie-js-sdk/assets/81357083/f6b57d23-d989-4517-8d9c-e803f33581ea)

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #770

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
