### PR TITLE
Reverse TreeChanges when Deletion Operations in Tree

### DIFF
--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -1445,7 +1445,7 @@ export class CRDTTree extends CRDTGCElement {
         }
       }
     }
-    return changes;
+    return changes.reverse();
   }
 
   /**

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -4400,14 +4400,14 @@ describe('TreeChange', () => {
           } as any,
           {
             type: 'tree-edit',
-            from: 1,
-            to: 2,
+            from: 3,
+            to: 4,
             value: undefined,
           } as any,
           {
             type: 'tree-edit',
-            from: 3,
-            to: 4,
+            from: 1,
+            to: 2,
             value: undefined,
           } as any,
         ],


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR addresses the issue where, in a tree data structure, when range deletion operations occur and are split into multiple events by [`makeDeletionChanges`](https://github.com/yorkie-team/yorkie-js-sdk/blob/dc9146fe04fce118616b0617494b645d3c0d8cb9/src/document/crdt/tree.ts#L1388), the order of events needs to be reversed. If you don't reverse the order, you may lead to situations where adjustments to the range are necessary for subscribers of the events.
More detailed information on this scenario can be found in issue #773.

#### Any background context you want to provide?
When range deletion operations result in multiple events due to the `makeDeletionChanges()` function, in order to prevent issues for subscribers handling these events, the order of events must be reversed. By reversing the order of events, there is no need to adjust the range of the next event by the previous event.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #773 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
