### PR TITLE
Prevent watch stream from reconnecting after intentional pause or detach

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -24,7 +24,12 @@ import {
   CompleteFn,
   NextFn,
 } from '@yorkie-js-sdk/src/util/observable';
-import { createPromiseClient, PromiseClient } from '@connectrpc/connect';
+import {
+  createPromiseClient,
+  PromiseClient,
+  ConnectError,
+  Code as ConnectErrorCode,
+} from '@connectrpc/connect';
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
 import { YorkieService } from '../api/yorkie/v1/yorkie_connect';
 import { WatchDocumentResponse } from '@yorkie-js-sdk/src/api/yorkie/v1/yorkie_pb';
@@ -792,7 +797,13 @@ export class Client implements Observable<ClientEvent> {
                 value: StreamConnectionStatus.Disconnected,
               });
               logger.debug(`[WD] c:"${this.getKey()}" unwatches`);
-              onDisconnect();
+
+              if (
+                err instanceof ConnectError &&
+                err.code != ConnectErrorCode.Canceled
+              ) {
+                await onDisconnect();
+              }
 
               reject(err);
             }

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -86,6 +86,30 @@ export class EventCollector<E = string> {
     });
   }
 
+  /**
+   * `waitAndVerifyEventNotOccurred` waits for a specified duration until an event does not occur.
+   */
+  public waitAndVerifyEventNotOccurred(timeout: number) {
+    const startTime = Date.now();
+    const eventCount = this.events.length;
+    return new Promise<void>((resolve, reject) => {
+      const doLoop = () => {
+        if (this.events.length > eventCount) {
+          reject(new Error('Event occurred'));
+          return;
+        }
+
+        if (Date.now() - startTime >= timeout) {
+          resolve();
+          return;
+        }
+        setTimeout(doLoop, 0);
+      };
+
+      doLoop();
+    });
+  }
+
   public reset() {
     this.events = [];
   }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

I've addressed the issue where the watch stream reconnects after intentional pausing or detaching.
(Ref: https://connectrpc.com/docs/web/cancellation-and-timeouts/)

https://github.com/yorkie-team/yorkie-js-sdk/assets/81357083/610ce5f8-570c-45e2-b336-df5b00a0d784

#### Any background context you want to provide?

Although this patch works in browser examples, it fails in test cases. 
I have a suspicion that the code(`if (reason instanceof Error)`) within connectrpc doesn't work correctly within the jsdom test environment. I need some help with this.

https://github.com/connectrpc/connect-es/blob/fd9a93127e1671cf614f14c7d410ec6b9b30b025/packages/connect/src/connect-error.ts#L115

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #771 

### Checklist
- [ ] Added relevant tests or not required
- [x] Didn't break anything
