### PR TITLE
Fix issue of referencing process object on browser

### DIFF
--- a/src/devtools/index.ts
+++ b/src/devtools/index.ts
@@ -99,7 +99,10 @@ export function setupDevtools<T, P extends Indexable>(
   doc: Document<T, P>,
 ): void {
   // NOTE(hackerwins): For production builds, or when running in Node.js, do nothing.
-  if (process.env.NODE_ENV === 'production' || typeof window === 'undefined') {
+  if (
+    (typeof process !== 'undefined' && process.env.NODE_ENV === 'production') ||
+    typeof window === 'undefined'
+  ) {
     return;
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR do type-check first to avoid referencing the process object to prevents type issues when using the yorkie-js-sdk in a web browser via a CDN, etc.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #768 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
