### PR TITLE
Add window type condition for using devtools

### DIFF
--- a/src/devtools/index.ts
+++ b/src/devtools/index.ts
@@ -62,7 +62,11 @@ function sendToPanel(
 export function setupDevtools<T, P extends Indexable>(
   doc: Document<T, P>,
 ): void {
-  if (!doc.isEnableDevtools() || unsubsByDocKey.has(doc.getKey())) {
+  if (
+    !doc.isEnableDevtools() ||
+    typeof window === 'undefined' ||
+    unsubsByDocKey.has(doc.getKey())
+  ) {
     return;
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR resolves an issue encountered when using devtools in the `nextjs-scheduler` example. 

<img width="695" alt="image" src="https://github.com/yorkie-team/yorkie-js-sdk/assets/81357083/bdadd950-69a1-425b-b0e8-747f184841fa">

To resolve this, a condition based on the window type has been added to ensure that devtools only operates in a browser environment.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
