### PR TITLE
Remove Client.subscribe

### DIFF
--- a/public/counter.html
+++ b/public/counter.html
@@ -38,13 +38,13 @@
         try {
           // 01. create client with RPCAddr then activate it.
           const client = new yorkie.Client('http://localhost:8080');
-          client.subscribe(network.statusListener(statusHolder));
           await client.activate();
 
           // 02. create a document then attach it into the client.
           const doc = new yorkie.Document('counter', {
             enableDevtools: true,
           });
+          doc.subscribe('connection', new Network(statusHolder).statusListener);
           doc.subscribe('presence', (event) => {
             if (event.type === 'presence-changed') return;
             displayOnlineClients(doc.getPresences(), client.getID());

--- a/public/devtool/text.css
+++ b/public/devtool/text.css
@@ -94,7 +94,6 @@
 
 .user-info {
   --client-background-color: var(--client-color, #000);
-  --client-status-color: var(--network-status-color, --client-background-color);
   background-color: var(--client-background-color);
   position: relative;
   display: flex;
@@ -108,19 +107,6 @@
   text-transform: uppercase;
   color: white;
   cursor: pointer;
-}
-
-.user-info.me::before {
-  content: '';
-  position: absolute;
-  top: 50%;
-  left: 50%;
-  width: 100%;
-  height: 100%;
-  transform-origin: center center;
-  transform: translate(-50%, -50%) scale(1.2);
-  border: 2px solid var(--client-status-color);
-  border-radius: 50%;
 }
 
 /* toolbar > hide deleted node */

--- a/public/index.html
+++ b/public/index.html
@@ -227,11 +227,6 @@
           .join('');
 
         document.head.querySelector('#codemirror-custom-style').textContent = `
-          :root {
-            --network-status-color: ${
-              network.isOnline ? usersInfo[myClientID]?.color : '#ff0000'
-            };
-          }
           .CodeMirror-selected {
             background-color: ${usersInfo[myClientID]?.color} !important;
           }
@@ -325,16 +320,14 @@
 
           // 02-1. create client with RPCAddr.
           const client = new yorkie.Client('http://localhost:8080');
-          // 02-2. subscribe client event.
-          client.subscribe(network.statusListener(statusHolder));
-
-          // 02-3. activate client
+          // 02-2. activate client
           await client.activate();
 
           // 03-1. create a document then attach it into the client.
           const doc = new yorkie.Document('codemirror', {
             enableDevtools: true,
           });
+          doc.subscribe('connection', new Network(statusHolder).statusListener);
           doc.subscribe('presence', (event) => {
             if (event.type === 'presence-changed') return;
             displayUsers(doc.getPresences(), client.getID());

--- a/public/multi.html
+++ b/public/multi.html
@@ -80,15 +80,14 @@
         try {
           // 01-1. create client with RPCAddr.
           const client = new yorkie.Client('http://localhost:8080');
-          // 01-2. subscribe client event.
-          client.subscribe(network.statusListener(statusHolder));
-          // 01-3. activate client
+          // 01-2. activate client
           await client.activate();
 
           // 02. create a document then attach it into the client.
           const doc = new yorkie.Document('multi-example', {
             enableDevtools: true,
           });
+          doc.subscribe('connection', new Network(statusHolder).statusListener);
           doc.subscribe('presence', (event) => {
             if (event.type === 'presence-changed') return;
             displayOnlineClients(doc.getPresences(), client.getID());

--- a/public/quill-two-clients.html
+++ b/public/quill-two-clients.html
@@ -18,6 +18,7 @@
     <div class="client-container">
       <div id="client-a">
         Client A ( id:<span class="client-id"></span>)
+        <span class="network-status"></span>
         <div class="syncmode-option">
           <span>SyncMode: </span>
           <div class="realtime-sync">
@@ -67,6 +68,7 @@
       </div>
       <div id="client-b">
         Client B ( id:<span class="client-id"></span>)
+        <span class="network-status"></span>
         <div class="syncmode-option">
           <span>SyncMode: </span>
           <div class="realtime-sync">
@@ -149,7 +151,11 @@
             const doc = new yorkie.Document(documentKey, {
               enableDevtools: true,
             });
-
+            doc.subscribe(
+              'connection',
+              new Network(clientElem.querySelector('.network-status'))
+                .statusListener,
+            );
             const onlineClients = clientElem.querySelector('.online-clients');
             doc.subscribe('presence', (event) => {
               // Update online clients list

--- a/public/quill.html
+++ b/public/quill.html
@@ -66,12 +66,12 @@
           // 01. create client with RPCAddr then activate it.
           const client = new yorkie.Client('http://localhost:8080');
           await client.activate();
-          client.subscribe(network.statusListener(networkStatusElem));
 
           // 02. create a document then attach it into the client.
           const doc = new yorkie.Document(documentKey, {
             enableDevtools: true,
           });
+          doc.subscribe('connection', new Network(statusHolder).statusListener);
           doc.subscribe('presence', (event) => {
             if (event.type === 'presence-changed') return;
             displayOnlineClients(doc.getPresences(), client.getID());

--- a/public/style.css
+++ b/public/style.css
@@ -35,12 +35,14 @@ button {
 }
 
 #network-status,
+.network-status,
 #online-clients,
 #log-holder {
   margin: 1rem;
   font-family: monospace;
 }
-#network-status:before {
+#network-status:before,
+.network-status:before {
   content: 'network: ';
 }
 #online-clients:before {
@@ -49,16 +51,19 @@ button {
 #log-holder:before {
   content: 'root: ';
 }
-#network-status span {
+#network-status span,
+.network-status span {
   display: inline-block;
   height: 0.8rem;
   width: 0.8rem;
   border-radius: 0.4rem;
 }
-#network-status .green {
+#network-status .green,
+.network-status .green {
   background-color: green;
 }
-#network-status .red {
+#network-status .red,
+.network-status .red {
   background-color: red;
 }
 

--- a/public/util.js
+++ b/public/util.js
@@ -1,34 +1,36 @@
-const network = {
-  isOnline: false,
-  showOffline: (elem) => {
-    network.isOnline = false;
-    elem.innerHTML = '<span class="red"> </span>';
-  },
-  showOnline: (elem) => {
-    network.isOnline = true;
-    elem.innerHTML = '<span class="green"> </span>';
-  },
-  statusListener: (elem) => {
-    return (event) => {
-      if (
-        network.isOnline &&
-        ((event.type == 'status-changed' && event.value == 'deactivated') ||
-          (event.type == 'stream-connection-status-changed' &&
-            event.value == 'disconnected') ||
-          (event.type == 'document-sync-result' &&
-            event.value == 'sync-failed'))
-      ) {
-        network.showOffline(elem);
-      } else if (
-        !network.isOnline &&
-        ((event.type == 'status-changed' && event.value == 'activated') ||
-          (event.type == 'stream-connection-status-changed' &&
-            event.value == 'connected') ||
-          (event.type == 'document-sync-result' && event.value == 'synced') ||
-          event.type == 'document-changed')
-      ) {
-        network.showOnline(elem);
-      }
-    };
-  },
-};
+/**
+ * `Network` is a class that manages the network status.
+ */
+class Network {
+  constructor(elem) {
+    this.isOnline = false;
+    this.elem = elem;
+  }
+
+  /**
+   * Show offline status.
+   */
+  showOffline() {
+    this.isOnline = false;
+    this.elem.innerHTML = '<span class="red"> </span>';
+  }
+
+  /**
+   * Show online status.
+   */
+  showOnline() {
+    this.isOnline = true;
+    this.elem.innerHTML = '<span class="green"> </span>';
+  }
+
+  /**
+   * Listen to the network status changes.
+   */
+  statusListener = (event) => {
+    if (this.isOnline && event.value === 'disconnected') {
+      this.showOffline();
+    } else if (!this.isOnline && event.value === 'connected') {
+      this.showOnline();
+    }
+  };
+}

--- a/public/whiteboard.html
+++ b/public/whiteboard.html
@@ -255,7 +255,6 @@
         try {
           // 01. create client with RPCAddr then activate it.
           const client = new yorkie.Client('http://localhost:8080');
-          client.subscribe(network.statusListener(statusHolder));
           await client.activate();
           const myClientID = client.getID();
 
@@ -286,6 +285,7 @@
             redoStackCount.textContent = doc.getRedoStackForTest().length;
           };
 
+          doc.subscribe('connection', new Network(statusHolder).statusListener);
           doc.subscribe('presence', (event) => {
             if (event.type === 'presence-changed') {
               renderShapes(doc, myClientID);

--- a/src/devtools/index.ts
+++ b/src/devtools/index.ts
@@ -19,6 +19,7 @@ import {
   Indexable,
   TransactionEvent,
 } from '@yorkie-js-sdk/src/yorkie';
+import { DocEventType } from '@yorkie-js-sdk/src/document/document';
 import { logger } from '@yorkie-js-sdk/src/util/logger';
 import type * as DevTools from './protocol';
 import { EventSourceDevPanel, EventSourceSDK } from './protocol';
@@ -72,6 +73,22 @@ export function setupDevtools<T, P extends Indexable>(
 
   transactionEventsByDocKey.set(doc.getKey(), []);
   const unsub = doc.subscribe('all', (event) => {
+    if (
+      event.some(
+        (docEvent) =>
+          docEvent.type !== DocEventType.StatusChanged &&
+          docEvent.type !== DocEventType.Snapshot &&
+          docEvent.type !== DocEventType.LocalChange &&
+          docEvent.type !== DocEventType.RemoteChange &&
+          docEvent.type !== DocEventType.Initialized &&
+          docEvent.type !== DocEventType.Watched &&
+          docEvent.type !== DocEventType.Unwatched &&
+          docEvent.type !== DocEventType.PresenceChanged,
+      )
+    ) {
+      return;
+    }
+
     transactionEventsByDocKey.get(doc.getKey())!.push(event);
     if (devtoolsStatus === 'synced') {
       sendToPanel({

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -24,16 +24,8 @@ import * as Devtools from '@yorkie-js-sdk/src/devtools/types';
 
 export {
   Client,
-  ClientEvent,
   ClientStatus,
   SyncMode,
-  StreamConnectionStatus,
-  DocumentSyncResultType,
-  ClientEventType,
-  StatusChangedEvent,
-  DocumentChangedEvent,
-  StreamConnectionStatusChangedEvent,
-  DocumentSyncedEvent,
   ClientOptions,
 } from '@yorkie-js-sdk/src/client/client';
 export {
@@ -41,6 +33,15 @@ export {
   SnapshotEvent,
   LocalChangeEvent,
   RemoteChangeEvent,
+  ConnectionChangedEvent,
+  SyncStatusChangedEvent,
+  WatchedEvent,
+  UnwatchedEvent,
+  PresenceChangedEvent,
+  InitializedEvent,
+  StreamConnectionStatus,
+  DocumentSyncStatus,
+  DocumentStatus,
   Indexable,
   DocEvent,
   TransactionEvent,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

In this PR, `Client.subscribe()` was removed, and topics `connection` and `sync` were added to `document.subscribe()`.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #788

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
