### PR TITLE
Reset online clients when stream is disconnected

### DIFF
--- a/public/quill-two-clients.html
+++ b/public/quill-two-clients.html
@@ -268,6 +268,7 @@
             }
 
             function updateAllCursors() {
+              cursors.clearCursors();
               for (const user of doc.getPresences()) {
                 updateCursor(user);
               }

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -39,6 +39,7 @@ import {
   StreamConnectionStatus,
   DocumentSyncStatus,
 } from '@yorkie-js-sdk/src/document/document';
+import { OpSource } from '@yorkie-js-sdk/src/document/operation/operation';
 import { createAuthInterceptor } from '@yorkie-js-sdk/src/client/auth_interceptor';
 import { createMetricInterceptor } from '@yorkie-js-sdk/src/client/metric_interceptor';
 
@@ -604,6 +605,14 @@ export class Client {
                 }
               }
             } catch (err) {
+              attachment.doc.resetOnlineClients();
+              attachment.doc.publish([
+                {
+                  type: DocEventType.Initialized,
+                  source: OpSource.Local,
+                  value: attachment.doc.getPresences(),
+                },
+              ]);
               attachment.doc.publish([
                 {
                   type: DocEventType.ConnectionChanged,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

When the stream is disconnected, online-clients' information should be cleared and no longer accessible.

https://github.com/yorkie-team/yorkie-js-sdk/assets/81357083/c44b31b3-148a-4c5a-b953-cd32b5ce051b


#### Any background context you want to provide?

> Before, the `initialized` event only occurred when first attaching to the document, indicating who was using it. Now, it also occurs if the watch stream is disconnected and clients have reset.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address #791 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
