### PR TITLE
Handle concurrent editing and styling in Tree

### DIFF
--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -444,6 +444,10 @@ function toOperation(operation: Operation): PbOperation {
     );
     pbTreeStyleOperation.from = toTreePos(treeStyleOperation.getFromPos());
     pbTreeStyleOperation.to = toTreePos(treeStyleOperation.getToPos());
+    const pbCreatedAtMapByActor = pbTreeStyleOperation.createdAtMapByActor;
+    for (const [key, value] of treeStyleOperation.getMaxCreatedAtMapByActor()) {
+      pbCreatedAtMapByActor[key] = toTimeTicket(value)!;
+    }
 
     const attributesToRemove = treeStyleOperation.getAttributesToRemove();
     if (attributesToRemove.length > 0) {
@@ -1177,6 +1181,12 @@ function fromOperation(pbOperation: PbOperation): Operation | undefined {
     const pbTreeStyleOperation = pbOperation.body.value;
     const attributes = new Map();
     const attributesToRemove = pbTreeStyleOperation.attributesToRemove;
+    const createdAtMapByActor = new Map();
+    Object.entries(pbTreeStyleOperation!.createdAtMapByActor).forEach(
+      ([key, value]) => {
+        createdAtMapByActor.set(key, fromTimeTicket(value));
+      },
+    );
 
     if (attributesToRemove.length > 0) {
       return TreeStyleOperation.createTreeRemoveStyleOperation(
@@ -1196,6 +1206,7 @@ function fromOperation(pbOperation: PbOperation): Operation | undefined {
         fromTimeTicket(pbTreeStyleOperation!.parentCreatedAt)!,
         fromTreePos(pbTreeStyleOperation!.from!),
         fromTreePos(pbTreeStyleOperation!.to!),
+        createdAtMapByActor,
         attributes,
         fromTimeTicket(pbTreeStyleOperation!.executedAt)!,
       );

--- a/src/api/yorkie/v1/resources.proto
+++ b/src/api/yorkie/v1/resources.proto
@@ -134,6 +134,7 @@ message Operation {
     map<string, string> attributes = 4;
     TimeTicket executed_at = 5;
     repeated string attributes_to_remove = 6;
+    map<string, TimeTicket> created_at_map_by_actor = 7;
   }
 
   oneof body {

--- a/src/api/yorkie/v1/resources_pb.d.ts
+++ b/src/api/yorkie/v1/resources_pb.d.ts
@@ -788,6 +788,11 @@ export declare class Operation_TreeStyle extends Message<Operation_TreeStyle> {
    */
   attributesToRemove: string[];
 
+  /**
+   * @generated from field: map<string, yorkie.v1.TimeTicket> created_at_map_by_actor = 7;
+   */
+  createdAtMapByActor: { [key: string]: TimeTicket };
+
   constructor(data?: PartialMessage<Operation_TreeStyle>);
 
   static readonly runtime: typeof proto3;

--- a/src/api/yorkie/v1/resources_pb.js
+++ b/src/api/yorkie/v1/resources_pb.js
@@ -286,6 +286,7 @@ const Operation_TreeStyle = proto3.makeMessageType(
     { no: 4, name: "attributes", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "scalar", T: 9 /* ScalarType.STRING */} },
     { no: 5, name: "executed_at", kind: "message", T: TimeTicket },
     { no: 6, name: "attributes_to_remove", kind: "scalar", T: 9 /* ScalarType.STRING */, repeated: true },
+    { no: 7, name: "created_at_map_by_actor", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: TimeTicket} },
   ],
   {localName: "Operation_TreeStyle"},
 );

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -279,13 +279,19 @@ export class Tree {
     const ticket = this.context.issueTimeTicket();
     const attrs = attributes ? stringifyObjectValues(attributes) : undefined;
 
-    this.tree!.style([fromPos, toPos], attrs, ticket);
+    const [maxCreationMapByActor, change] = this.tree!.style(
+      [fromPos, toPos],
+      attrs,
+      ticket,
+      undefined,
+    );
 
     this.context.push(
       TreeStyleOperation.create(
         this.tree.getCreatedAt(),
         fromPos,
         toPos,
+        maxCreationMapByActor,
         attrs ? new Map(Object.entries(attrs)) : new Map(),
         ticket,
       ),
@@ -313,13 +319,19 @@ export class Tree {
     const ticket = this.context.issueTimeTicket();
     const attrs = attributes ? stringifyObjectValues(attributes) : undefined;
 
-    this.tree!.style([fromPos, toPos], attrs, ticket);
+    const [maxCreationMapByActor, change] = this.tree!.style(
+      [fromPos, toPos],
+      attrs,
+      ticket,
+      undefined,
+    );
 
     this.context.push(
       TreeStyleOperation.create(
         this.tree.getCreatedAt(),
         fromPos,
         toPos,
+        maxCreationMapByActor,
         attrs ? new Map(Object.entries(attrs)) : new Map(),
         ticket,
       ),

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -279,7 +279,7 @@ export class Tree {
     const ticket = this.context.issueTimeTicket();
     const attrs = attributes ? stringifyObjectValues(attributes) : undefined;
 
-    const [maxCreationMapByActor, change] = this.tree!.style(
+    const [maxCreationMapByActor] = this.tree!.style(
       [fromPos, toPos],
       attrs,
       ticket,
@@ -319,7 +319,7 @@ export class Tree {
     const ticket = this.context.issueTimeTicket();
     const attrs = attributes ? stringifyObjectValues(attributes) : undefined;
 
-    const [maxCreationMapByActor, change] = this.tree!.style(
+    const [maxCreationMapByActor] = this.tree!.style(
       [fromPos, toPos],
       attrs,
       ticket,

--- a/src/document/operation/tree_style_operation.ts
+++ b/src/document/operation/tree_style_operation.ts
@@ -116,7 +116,7 @@ export class TreeStyleOperation extends Operation {
       const attributes: { [key: string]: any } = {};
       [...this.attributes].forEach(([key, value]) => (attributes[key] = value));
 
-      const [maxCreatedAtMapByActor, change] = tree.style(
+      const [, change] = tree.style(
         [this.fromPos, this.toPos],
         attributes,
         this.getExecutedAt(),

--- a/src/document/operation/tree_style_operation.ts
+++ b/src/document/operation/tree_style_operation.ts
@@ -35,6 +35,7 @@ import {
 export class TreeStyleOperation extends Operation {
   private fromPos: CRDTTreePos;
   private toPos: CRDTTreePos;
+  private maxCreatedAtMapByActor: Map<string, TimeTicket>;
   private attributes: Map<string, string>;
   private attributesToRemove: Array<string>;
 
@@ -42,6 +43,7 @@ export class TreeStyleOperation extends Operation {
     parentCreatedAt: TimeTicket,
     fromPos: CRDTTreePos,
     toPos: CRDTTreePos,
+    maxCreatedAtMapByActor: Map<string, TimeTicket>,
     attributes: Map<string, string>,
     attributesToRemove: Array<string>,
     executedAt: TimeTicket,
@@ -49,6 +51,7 @@ export class TreeStyleOperation extends Operation {
     super(parentCreatedAt, executedAt);
     this.fromPos = fromPos;
     this.toPos = toPos;
+    this.maxCreatedAtMapByActor = maxCreatedAtMapByActor;
     this.attributes = attributes;
     this.attributesToRemove = attributesToRemove;
   }
@@ -60,6 +63,7 @@ export class TreeStyleOperation extends Operation {
     parentCreatedAt: TimeTicket,
     fromPos: CRDTTreePos,
     toPos: CRDTTreePos,
+    maxCreatedAtMapByActor: Map<string, TimeTicket>,
     attributes: Map<string, string>,
     executedAt: TimeTicket,
   ): TreeStyleOperation {
@@ -67,6 +71,7 @@ export class TreeStyleOperation extends Operation {
       parentCreatedAt,
       fromPos,
       toPos,
+      maxCreatedAtMapByActor,
       attributes,
       new Array<string>(),
       executedAt,
@@ -87,6 +92,7 @@ export class TreeStyleOperation extends Operation {
       parentCreatedAt,
       fromPos,
       toPos,
+      new Map(),
       new Map(),
       attributesToRemove,
       executedAt,
@@ -110,11 +116,13 @@ export class TreeStyleOperation extends Operation {
       const attributes: { [key: string]: any } = {};
       [...this.attributes].forEach(([key, value]) => (attributes[key] = value));
 
-      changes = tree.style(
+      const [maxCreatedAtMapByActor, change] = tree.style(
         [this.fromPos, this.toPos],
         attributes,
         this.getExecutedAt(),
+        this.maxCreatedAtMapByActor,
       );
+      changes = change;
     } else {
       const attributesToRemove = this.attributesToRemove;
 
@@ -193,5 +201,13 @@ export class TreeStyleOperation extends Operation {
    */
   public getAttributesToRemove(): Array<string> {
     return this.attributesToRemove;
+  }
+
+  /**
+   * `getMaxCreatedAtMapByActor` returns the map that stores the latest creation time
+   * by actor for the nodes included in the styling range.
+   */
+  public getMaxCreatedAtMapByActor(): Map<string, TimeTicket> {
+    return this.maxCreatedAtMapByActor;
   }
 }

--- a/test/integration/tree_concurrency_test.ts
+++ b/test/integration/tree_concurrency_test.ts
@@ -579,7 +579,7 @@ describe('Tree.concurrency', () => {
     );
   });
 
-  describe.skip('concurrently-edit-style-test', async () => {
+  describe('concurrently-edit-style-test', async () => {
     const initialTree = new Tree({
       type: 'r',
       children: [


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Handle concurrent editing and styling in Tree

We will use maxCreatedAtMapByActor until the introduction of
VersionVector. https://github.com/yorkie-team/yorkie/pull/800

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related https://github.com/yorkie-team/yorkie/pull/854

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
