### PR TITLE
Fix inconsistent garbage collection for multiple nodes in text and tree type

### DIFF
--- a/src/document/crdt/root.ts
+++ b/src/document/crdt/root.ts
@@ -278,7 +278,7 @@ export class CRDTRoot {
       const elem = pair.element as CRDTGCElement;
 
       const removedNodeCnt = elem.purgeRemovedNodesBefore(ticket);
-      if (removedNodeCnt > 0) {
+      if (elem.getRemovedNodesLen() === 0) {
         this.elementHasRemovedNodesSetByCreatedAt.delete(
           elem.getCreatedAt().toIDString(),
         );


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

There was an issue in the garbage collection process when dealing with multiple nodes in text(tree) types. When some nodes in text were collected, the corresponding text was removed from `elementHasRemovedNodesSetByCreatedAt` in the root, preventing the GC from correctly processing the remaining nodes.

This PR addresses the inconsistency in the GC process by modifying the condition under which text is removed from `elementHasRemovedNodesSetByCreatedAt`. Instead of removing text when _**some**_ nodes are garbage collected, text will now only be removed when _**all**_ nodes have been garbage collected. This change ensures that GC behaves consistently even when multiple nodes are involved.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
