### PR TITLE
Improve `doc.subscribe()` to infer event types appropriately based on the topic

### DIFF
--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -87,16 +87,37 @@ export enum TreeChangeType {
 /**
  * `TreeChange` represents the change in the tree.
  */
-export interface TreeChange {
-  actor: ActorID;
-  type: TreeChangeType;
-  from: number;
-  to: number;
-  fromPath: Array<number>;
-  toPath: Array<number>;
-  value?: Array<TreeNode> | { [key: string]: any } | Array<string>;
-  splitLevel?: number;
-}
+export type TreeChange =
+  | {
+      actor: ActorID;
+      type: TreeChangeType.Content;
+      from: number;
+      to: number;
+      fromPath: Array<number>;
+      toPath: Array<number>;
+      value?: Array<TreeNode>;
+      splitLevel?: number;
+    }
+  | {
+      actor: ActorID;
+      type: TreeChangeType.Style;
+      from: number;
+      to: number;
+      fromPath: Array<number>;
+      toPath: Array<number>;
+      value: { [key: string]: string };
+      splitLevel?: number;
+    }
+  | {
+      actor: ActorID;
+      type: TreeChangeType.RemoveStyle;
+      from: number;
+      to: number;
+      fromPath: Array<number>;
+      toPath: Array<number>;
+      value?: Array<string>;
+      splitLevel?: number;
+    };
 
 /**
  * `CRDTTreePos` represent a position in the tree. It is used to identify a
@@ -876,7 +897,6 @@ export class CRDTTree extends CRDTGCElement {
     const [toParent, toLeft] = this.findNodesAndSplitText(range[1], editedAt);
 
     const changes: Array<TreeChange> = [];
-    const value = attributesToRemove ? attributesToRemove : undefined;
     this.traverseInPosRange(
       fromParent,
       fromLeft,
@@ -893,13 +913,13 @@ export class CRDTTree extends CRDTGCElement {
           }
 
           changes.push({
+            actor: editedAt.getActorID()!,
             type: TreeChangeType.RemoveStyle,
             from: this.toIndex(fromParent, fromLeft),
             to: this.toIndex(toParent, toLeft),
             fromPath: this.toPath(fromParent, fromLeft),
             toPath: this.toPath(toParent, toLeft),
-            actor: editedAt.getActorID()!,
-            value,
+            value: attributesToRemove,
           });
         }
       },

--- a/src/document/operation/operation.ts
+++ b/src/document/operation/operation.ts
@@ -149,7 +149,7 @@ export type TreeEditOpInfo = {
   path: string;
   from: number;
   to: number;
-  value: TreeNode;
+  value?: Array<TreeNode>;
   splitLevel: number;
   fromPath: Array<number>;
   toPath: Array<number>;

--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -140,7 +140,7 @@ describe.sequential('Client', function () {
 
     const unsub1 = {
       syncEvent: d1.subscribe('sync', (event) => {
-        eventCollectorSync1.add(event.value as DocumentSyncStatus);
+        eventCollectorSync1.add(event.value);
       }),
       doc: d1.subscribe((event) => {
         eventCollectorD1.add(event.type);
@@ -148,7 +148,7 @@ describe.sequential('Client', function () {
     };
     const unsub2 = {
       syncEvent: d2.subscribe('sync', (event) => {
-        eventCollectorSync2.add(event.value as DocumentSyncStatus);
+        eventCollectorSync2.add(event.value);
       }),
       doc: d2.subscribe((event) => {
         eventCollectorD2.add(event.type);
@@ -236,7 +236,7 @@ describe.sequential('Client', function () {
     // 02. c2 changes the sync mode to realtime sync mode.
     const eventCollector = new EventCollector();
     const unsub1 = d2.subscribe('sync', (event) => {
-      eventCollector.add(event.value as DocumentSyncStatus);
+      eventCollector.add(event.value);
     });
     await c2.changeSyncMode(d2, SyncMode.Realtime);
     await eventCollector.waitFor(DocumentSyncStatus.Synced); // sync occurs when resuming
@@ -414,7 +414,7 @@ describe.sequential('Client', function () {
 
     const eventCollector = new EventCollector();
     const unsub1 = d2.subscribe('sync', (event) => {
-      eventCollector.add(event.value as DocumentSyncStatus);
+      eventCollector.add(event.value);
     });
 
     // 01. c2 attach the doc with realtime sync mode at first.
@@ -491,7 +491,7 @@ describe.sequential('Client', function () {
     //     and sync with push-only mode: CP(2, 2) -> CP(3, 2)
     const eventCollector = new EventCollector();
     const unsub = d1.subscribe('sync', (event) => {
-      eventCollector.add(event.value as DocumentSyncStatus);
+      eventCollector.add(event.value);
     });
     d1.update((root) => {
       root.counter.increase(1);

--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -569,7 +569,7 @@ describe.sequential('Client', function () {
     assert.equal(d1.getRoot().tree.toXML(), '<doc><p>12</p><p>34</p></doc>');
     assert.equal(d2.getRoot().tree.toXML(), '<doc><p>12</p><p>34</p></doc>');
 
-    d1.update((root: any) => {
+    d1.update((root) => {
       root.tree.edit(2, 2, { type: 'text', value: 'a' });
     });
     await c1.sync();
@@ -595,7 +595,7 @@ describe.sequential('Client', function () {
 
     c2.changeSyncMode(d2, SyncMode.Realtime);
 
-    d2.update((root: any) => {
+    d2.update((root) => {
       root.tree.edit(2, 2, { type: 'text', value: 'b' });
     });
     await eventCollectorD1.waitAndVerifyNthEvent(3, DocEventType.RemoteChange);

--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -179,11 +179,16 @@ describe('Document', function () {
     let expectedEventValue: Array<OperationInfo>;
     const eventCollectorD1 = new EventCollector<EventForTest>();
     const eventCollectorD2 = new EventCollector<EventForTest>();
-    // TODO(chacha912): Remove any type after specifying the type of DocEvent
-    const unsub1 = d1.subscribe((event: any) => {
+    const unsub1 = d1.subscribe((event) => {
+      if (event.type === DocEventType.Snapshot) {
+        return;
+      }
       eventCollectorD1.add({ type: event.type, value: event.value.operations });
     });
-    const unsub2 = d2.subscribe((event: any) => {
+    const unsub2 = d2.subscribe((event) => {
+      if (event.type === DocEventType.Snapshot) {
+        return;
+      }
       eventCollectorD2.add({ type: event.type, value: event.value.operations });
     });
 
@@ -297,13 +302,16 @@ describe('Document', function () {
     const eventCollector = new EventCollector<EventForTest>();
     const eventCollectorForTodos = new EventCollector<EventForTest>();
     const eventCollectorForCounter = new EventCollector<EventForTest>();
-    const unsub = d1.subscribe((event: any) => {
+    const unsub = d1.subscribe((event) => {
+      if (event.type === DocEventType.Snapshot) {
+        return;
+      }
       eventCollector.add(event.value.operations);
     });
-    const unsubTodo = d1.subscribe('$.todos', (event: any) => {
+    const unsubTodo = d1.subscribe('$.todos', (event) => {
       eventCollectorForTodos.add(event.value.operations);
     });
-    const unsubCounter = d1.subscribe('$.counter', (event: any) => {
+    const unsubCounter = d1.subscribe('$.counter', (event) => {
       eventCollectorForCounter.add(event.value.operations);
     });
 
@@ -384,13 +392,16 @@ describe('Document', function () {
     const eventCollector = new EventCollector<EventForTest>();
     const eventCollectorForTodos0 = new EventCollector<EventForTest>();
     const eventCollectorForObjC1 = new EventCollector<EventForTest>();
-    const unsub = d1.subscribe((event: any) => {
+    const unsub = d1.subscribe((event) => {
+      if (event.type === DocEventType.Snapshot) {
+        return;
+      }
       eventCollector.add(event.value.operations);
     });
-    const unsubTodo = d1.subscribe('$.todos.0', (event: any) => {
+    const unsubTodo = d1.subscribe('$.todos.0', (event) => {
       eventCollectorForTodos0.add(event.value.operations);
     });
-    const unsubObj = d1.subscribe('$.obj.c1', (event: any) => {
+    const unsubObj = d1.subscribe('$.obj.c1', (event) => {
       eventCollectorForObjC1.add(event.value.operations);
     });
 

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -237,7 +237,7 @@ describe('Tree', () => {
           from: 1,
           to: 1,
           value: [{ type: 'text', value: 'X' }],
-        } as any,
+        },
       ],
     );
   });
@@ -309,7 +309,7 @@ describe('Tree', () => {
           fromPath: [0, 0, 0, 1],
           toPath: [0, 0, 0, 1],
           value: [{ type: 'text', value: 'X' }],
-        } as any,
+        },
       ],
     );
   });
@@ -4322,7 +4322,7 @@ describe('TreeChange', () => {
             from: 0,
             to: 4,
             value: undefined,
-          } as any,
+          },
         ],
       );
 
@@ -4341,13 +4341,13 @@ describe('TreeChange', () => {
             from: 1,
             to: 2,
             value: undefined,
-          } as any,
+          },
           {
             type: 'tree-edit',
             from: 0,
             to: 3,
             value: undefined,
-          } as any,
+          },
         ],
       );
     }, task.name);
@@ -4393,13 +4393,13 @@ describe('TreeChange', () => {
             from: 1,
             to: 3,
             value: undefined,
-          } as any,
+          },
           {
             type: 'tree-edit',
             from: 1,
             to: 1,
             value: [{ type: 'text', value: 'c' }],
-          } as any,
+          },
         ],
       );
 
@@ -4418,19 +4418,19 @@ describe('TreeChange', () => {
             from: 2,
             to: 2,
             value: [{ type: 'text', value: 'c' }],
-          } as any,
+          },
           {
             type: 'tree-edit',
             from: 3,
             to: 4,
             value: undefined,
-          } as any,
+          },
           {
             type: 'tree-edit',
             from: 1,
             to: 2,
             value: undefined,
-          } as any,
+          },
         ],
       );
     }, task.name);
@@ -4478,7 +4478,7 @@ describe('TreeChange', () => {
             from: 0,
             to: 4,
             value: undefined,
-          } as any,
+          },
         ],
       );
 
@@ -4497,13 +4497,13 @@ describe('TreeChange', () => {
             from: 2,
             to: 2,
             value: [{ type: 'text', value: 'c' }],
-          } as any,
+          },
           {
             type: 'tree-edit',
             from: 0,
             to: 5,
             value: undefined,
-          } as any,
+          },
         ],
       );
     }, task.name);
@@ -4549,13 +4549,13 @@ describe('TreeChange', () => {
             from: 1,
             to: 2,
             value: [{ type: 'text', value: 'b' }],
-          } as any,
+          },
           {
             type: 'tree-edit',
             from: 2,
             to: 2,
             value: [{ type: 'text', value: 'c' }],
-          } as any,
+          },
         ],
       );
 
@@ -4574,13 +4574,13 @@ describe('TreeChange', () => {
             from: 2,
             to: 2,
             value: [{ type: 'text', value: 'c' }],
-          } as any,
+          },
           {
             type: 'tree-edit',
             from: 1,
             to: 2,
             value: [{ type: 'text', value: 'b' }],
-          } as any,
+          },
         ],
       );
     }, task.name);
@@ -4628,13 +4628,13 @@ describe('TreeChange', () => {
             from: 0,
             to: 1,
             value: { value: 'changed' },
-          } as any,
+          },
           {
             type: 'tree-edit',
             from: 0,
             to: 2,
             value: undefined,
-          } as any,
+          },
         ],
       );
 
@@ -4648,7 +4648,7 @@ describe('TreeChange', () => {
             from: 0,
             to: 2,
             value: undefined,
-          } as any,
+          },
         ],
       );
     }, task.name);

--- a/test/unit/document/document_test.ts
+++ b/test/unit/document/document_test.ts
@@ -18,7 +18,7 @@ import { describe, it, assert, vi, afterEach } from 'vitest';
 import { EventCollector } from '@yorkie-js-sdk/test/helper/helper';
 
 import { MaxTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { Document } from '@yorkie-js-sdk/src/document/document';
+import { Document, DocEventType } from '@yorkie-js-sdk/src/document/document';
 import { OperationInfo } from '@yorkie-js-sdk/src/document/operation/operation';
 import { JSONArray, Text, Counter, Tree } from '@yorkie-js-sdk/src/yorkie';
 import { CounterType } from '@yorkie-js-sdk/src/document/crdt/counter';
@@ -967,8 +967,10 @@ describe.sequential('Document', function () {
 
     type EventForTest = Array<OperationInfo>;
     const eventCollector = new EventCollector<EventForTest>();
-    // TODO(chacha912): Remove any type after specifying the type of DocEvent
-    const unsub = doc.subscribe((event: any) => {
+    const unsub = doc.subscribe((event) => {
+      if (event.type === DocEventType.Snapshot) {
+        return;
+      }
       eventCollector.add(event.value.operations);
     });
 
@@ -1010,7 +1012,10 @@ describe.sequential('Document', function () {
     const doc = new Document<any>('test-doc');
     type EventForTest = Array<OperationInfo>;
     const eventCollector = new EventCollector<EventForTest>();
-    const unsub = doc.subscribe((event: any) => {
+    const unsub = doc.subscribe((event) => {
+      if (event.type === DocEventType.Snapshot) {
+        return;
+      }
       eventCollector.add(event.value.operations);
     });
 
@@ -1040,7 +1045,10 @@ describe.sequential('Document', function () {
     const doc = new Document<TestDoc>('test-doc');
     type EventForTest = Array<OperationInfo>;
     const eventCollector = new EventCollector<EventForTest>();
-    const unsub = doc.subscribe((event: any) => {
+    const unsub = doc.subscribe((event) => {
+      if (event.type === DocEventType.Snapshot) {
+        return;
+      }
       eventCollector.add(event.value.operations);
     });
 
@@ -1091,7 +1099,10 @@ describe.sequential('Document', function () {
     const doc = new Document<TestDoc>('test-doc');
     type EventForTest = Array<OperationInfo>;
     const eventCollector = new EventCollector<EventForTest>();
-    const unsub = doc.subscribe((event: any) => {
+    const unsub = doc.subscribe((event) => {
+      if (event.type === DocEventType.Snapshot) {
+        return;
+      }
       eventCollector.add(event.value.operations);
     });
 
@@ -1119,7 +1130,10 @@ describe.sequential('Document', function () {
     const doc = new Document<TestDoc>('test-doc');
     type EventForTest = Array<OperationInfo>;
     const eventCollector = new EventCollector<EventForTest>();
-    const unsub = doc.subscribe((event: any) => {
+    const unsub = doc.subscribe((event) => {
+      if (event.type === DocEventType.Snapshot) {
+        return;
+      }
       eventCollector.add(event.value.operations);
     });
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

- Improve `doc.subscribe()` to infer event types appropriately based on the topic
- Complete `TODO(chacha912): Remove any type after specifying the type of DocEvent`
>
- as-is: All events are inferred as the `DocEvent`.
  ![image](https://github.com/yorkie-team/yorkie-js-sdk/assets/81357083/93815023-9968-4bfd-917a-15103d8985a3)
- to-be: The event types are inferred appropriately based on the topic.
  ![image](https://github.com/yorkie-team/yorkie-js-sdk/assets/81357083/d5812cab-9581-4de3-ad74-d4c7d1ea71ee)

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
