### PR TITLE
Avoid unnecessary syncs in push-only syncmode

### DIFF
--- a/src/client/attachment.ts
+++ b/src/client/attachment.ts
@@ -49,6 +49,10 @@ export class Attachment<T, P extends Indexable> {
       return false;
     }
 
+    if (this.syncMode === SyncMode.RealtimePushOnly) {
+      return this.doc.hasLocalChanges();
+    }
+
     return (
       this.syncMode !== SyncMode.Manual &&
       (this.doc.hasLocalChanges() || this.remoteChangeEventReceived)


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

When syncmode is set to pushonly and there are no local changes, sync requests should not be triggered by remote changes.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Addresses #816 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
