### PR TITLE
Update exmples version to v0.4.20

### DIFF
--- a/examples/nextjs-scheduler/package.json
+++ b/examples/nextjs-scheduler/package.json
@@ -13,7 +13,7 @@
     "react": "18.2.0",
     "react-calendar": "^4.6.0",
     "react-dom": "18.2.0",
-    "yorkie-js-sdk": "^0.4.19"
+    "yorkie-js-sdk": "^0.4.20"
   },
   "devDependencies": {
     "@types/node": "20.4.2",

--- a/examples/profile-stack/package.json
+++ b/examples/profile-stack/package.json
@@ -12,6 +12,6 @@
     "vite": "^3.2.7"
   },
   "dependencies": {
-    "yorkie-js-sdk": "^0.4.19"
+    "yorkie-js-sdk": "^0.4.20"
   }
 }

--- a/examples/react-tldraw/package.json
+++ b/examples/react-tldraw/package.json
@@ -16,7 +16,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "unique-names-generator": "^4.7.1",
-    "yorkie-js-sdk": "^0.4.19"
+    "yorkie-js-sdk": "^0.4.20"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.198",

--- a/examples/react-todomvc/package.json
+++ b/examples/react-todomvc/package.json
@@ -13,7 +13,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "todomvc-app-css": "^2.4.2",
-    "yorkie-js-sdk": "^0.4.19"
+    "yorkie-js-sdk": "^0.4.20"
   },
   "devDependencies": {
     "@types/react": "^18.0.24",

--- a/examples/simultaneous-cursors/package.json
+++ b/examples/simultaneous-cursors/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "yorkie-js-sdk": "^0.4.19"
+    "yorkie-js-sdk": "^0.4.20"
   },
   "devDependencies": {
     "@types/react": "^18.0.37",

--- a/examples/vanilla-codemirror6/package.json
+++ b/examples/vanilla-codemirror6/package.json
@@ -20,6 +20,6 @@
     "@codemirror/state": "^6.1.2",
     "@codemirror/view": "^6.3.1",
     "codemirror": "^6.0.1",
-    "yorkie-js-sdk": "^0.4.19"
+    "yorkie-js-sdk": "^0.4.20"
   }
 }

--- a/examples/vanilla-codemirror6/src/main.ts
+++ b/examples/vanilla-codemirror6/src/main.ts
@@ -1,9 +1,6 @@
 /* eslint-disable jsdoc/require-jsdoc */
-import yorkie, {
-  DocEventType,
-  TextOperationInfo,
-  EditOpInfo,
-} from 'yorkie-js-sdk';
+import yorkie, { DocEventType } from 'yorkie-js-sdk';
+import type { TextOperationInfo, EditOpInfo } from 'yorkie-js-sdk';
 import { basicSetup, EditorView } from 'codemirror';
 import { keymap } from '@codemirror/view';
 import {
@@ -117,11 +114,11 @@ async function main() {
 
   // 03-3. define event handler that apply remote changes to local
   function handleOperations(operations: Array<TextOperationInfo>) {
-    operations.forEach((op) => {
+    for (const op of operations) {
       if (op.type === 'edit') {
         handleEditOp(op);
       }
-    });
+    }
   }
   function handleEditOp(op: EditOpInfo) {
     const changes = [

--- a/examples/vanilla-codemirror6/src/main.ts
+++ b/examples/vanilla-codemirror6/src/main.ts
@@ -1,5 +1,9 @@
 /* eslint-disable jsdoc/require-jsdoc */
-import yorkie, { DocEventType, OperationInfo } from 'yorkie-js-sdk';
+import yorkie, {
+  DocEventType,
+  TextOperationInfo,
+  EditOpInfo,
+} from 'yorkie-js-sdk';
 import { basicSetup, EditorView } from 'codemirror';
 import { keymap } from '@codemirror/view';
 import {
@@ -112,14 +116,14 @@ async function main() {
   });
 
   // 03-3. define event handler that apply remote changes to local
-  function handleOperations(operations: Array<OperationInfo>) {
+  function handleOperations(operations: Array<TextOperationInfo>) {
     operations.forEach((op) => {
       if (op.type === 'edit') {
         handleEditOp(op);
       }
     });
   }
-  function handleEditOp(op: any) {
+  function handleEditOp(op: EditOpInfo) {
     const changes = [
       {
         from: Math.max(0, op.from),

--- a/examples/vanilla-quill/package.json
+++ b/examples/vanilla-quill/package.json
@@ -19,6 +19,6 @@
     "quill": "^1.3.7",
     "quill-cursors": "^4.0.0",
     "quill-delta": "^5.0.0",
-    "yorkie-js-sdk": "^0.4.19"
+    "yorkie-js-sdk": "^0.4.20"
   }
 }

--- a/examples/vuejs-kanban/package.json
+++ b/examples/vuejs-kanban/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "vue": "^3.2.41",
-    "yorkie-js-sdk": "^0.4.19"
+    "yorkie-js-sdk": "^0.4.20"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yorkie-js-sdk",
-  "version": "0.4.19",
+  "version": "0.4.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yorkie-js-sdk",
-      "version": "0.4.19",
+      "version": "0.4.20",
       "license": "Apache-2.0",
       "workspaces": [
         "examples/*"
@@ -58,7 +58,7 @@
         "react": "18.2.0",
         "react-calendar": "^4.6.0",
         "react-dom": "18.2.0",
-        "yorkie-js-sdk": "^0.4.19"
+        "yorkie-js-sdk": "^0.4.20"
       },
       "devDependencies": {
         "@types/node": "20.4.2",
@@ -97,25 +97,10 @@
         "node": ">=4.2.0"
       }
     },
-    "examples/nextjs-scheduler/node_modules/yorkie-js-sdk": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.19.tgz",
-      "integrity": "sha512-jYyWTlnyiyacrlQHJ8BEx3IXb+T5V+3FrppfT/faSs9b2bHVP9wSvI9Pbt384T2YkflgYMpshdV88IESxxtmpg==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
-      }
-    },
     "examples/profile-stack": {
       "version": "0.0.0",
       "dependencies": {
-        "yorkie-js-sdk": "^0.4.19"
+        "yorkie-js-sdk": "^0.4.20"
       },
       "devDependencies": {
         "vite": "^3.2.7"
@@ -170,21 +155,6 @@
         }
       }
     },
-    "examples/profile-stack/node_modules/yorkie-js-sdk": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.19.tgz",
-      "integrity": "sha512-jYyWTlnyiyacrlQHJ8BEx3IXb+T5V+3FrppfT/faSs9b2bHVP9wSvI9Pbt384T2YkflgYMpshdV88IESxxtmpg==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
-      }
-    },
     "examples/react-tldraw": {
       "version": "0.1.0",
       "dependencies": {
@@ -195,7 +165,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "unique-names-generator": "^4.7.1",
-        "yorkie-js-sdk": "^0.4.19"
+        "yorkie-js-sdk": "^0.4.20"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.198",
@@ -256,21 +226,6 @@
         }
       }
     },
-    "examples/react-tldraw/node_modules/yorkie-js-sdk": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.19.tgz",
-      "integrity": "sha512-jYyWTlnyiyacrlQHJ8BEx3IXb+T5V+3FrppfT/faSs9b2bHVP9wSvI9Pbt384T2YkflgYMpshdV88IESxxtmpg==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
-      }
-    },
     "examples/react-todomvc": {
       "version": "0.0.0",
       "dependencies": {
@@ -278,7 +233,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "todomvc-app-css": "^2.4.2",
-        "yorkie-js-sdk": "^0.4.19"
+        "yorkie-js-sdk": "^0.4.20"
       },
       "devDependencies": {
         "@types/react": "^18.0.24",
@@ -337,21 +292,6 @@
         }
       }
     },
-    "examples/react-todomvc/node_modules/yorkie-js-sdk": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.19.tgz",
-      "integrity": "sha512-jYyWTlnyiyacrlQHJ8BEx3IXb+T5V+3FrppfT/faSs9b2bHVP9wSvI9Pbt384T2YkflgYMpshdV88IESxxtmpg==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
-      }
-    },
     "examples/simple-tldraw": {
       "extraneous": true,
       "dependencies": {
@@ -363,7 +303,7 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "yorkie-js-sdk": "^0.4.19"
+        "yorkie-js-sdk": "^0.4.20"
       },
       "devDependencies": {
         "@types/react": "^18.0.37",
@@ -389,21 +329,6 @@
         "vite": "^4.2.0"
       }
     },
-    "examples/simultaneous-cursors/node_modules/yorkie-js-sdk": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.19.tgz",
-      "integrity": "sha512-jYyWTlnyiyacrlQHJ8BEx3IXb+T5V+3FrppfT/faSs9b2bHVP9wSvI9Pbt384T2YkflgYMpshdV88IESxxtmpg==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
-      }
-    },
     "examples/vanilla-codemirror6": {
       "version": "0.0.0",
       "dependencies": {
@@ -414,7 +339,7 @@
         "@codemirror/state": "^6.1.2",
         "@codemirror/view": "^6.3.1",
         "codemirror": "^6.0.1",
-        "yorkie-js-sdk": "^0.4.19"
+        "yorkie-js-sdk": "^0.4.20"
       },
       "devDependencies": {
         "typescript": "^4.6.4",
@@ -470,21 +395,6 @@
         }
       }
     },
-    "examples/vanilla-codemirror6/node_modules/yorkie-js-sdk": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.19.tgz",
-      "integrity": "sha512-jYyWTlnyiyacrlQHJ8BEx3IXb+T5V+3FrppfT/faSs9b2bHVP9wSvI9Pbt384T2YkflgYMpshdV88IESxxtmpg==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
-      }
-    },
     "examples/vanilla-quill": {
       "version": "0.0.0",
       "dependencies": {
@@ -492,7 +402,7 @@
         "quill": "^1.3.7",
         "quill-cursors": "^4.0.0",
         "quill-delta": "^5.0.0",
-        "yorkie-js-sdk": "^0.4.19"
+        "yorkie-js-sdk": "^0.4.20"
       },
       "devDependencies": {
         "@types/color-hash": "^1.0.2",
@@ -562,26 +472,11 @@
         }
       }
     },
-    "examples/vanilla-quill/node_modules/yorkie-js-sdk": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.19.tgz",
-      "integrity": "sha512-jYyWTlnyiyacrlQHJ8BEx3IXb+T5V+3FrppfT/faSs9b2bHVP9wSvI9Pbt384T2YkflgYMpshdV88IESxxtmpg==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
-      }
-    },
     "examples/vuejs-kanban": {
       "version": "0.0.0",
       "dependencies": {
         "vue": "^3.2.41",
-        "yorkie-js-sdk": "^0.4.19"
+        "yorkie-js-sdk": "^0.4.20"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^3.1.2",
@@ -635,21 +530,6 @@
         "terser": {
           "optional": true
         }
-      }
-    },
-    "examples/vuejs-kanban/node_modules/yorkie-js-sdk": {
-      "version": "0.4.19",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.19.tgz",
-      "integrity": "sha512-jYyWTlnyiyacrlQHJ8BEx3IXb+T5V+3FrppfT/faSs9b2bHVP9wSvI9Pbt384T2YkflgYMpshdV88IESxxtmpg==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1063,10 +943,6 @@
       "engines": {
         "node": ">=6.9.0"
       }
-    },
-    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
-      "version": "0.13.11",
-      "license": "MIT"
     },
     "node_modules/@babel/template": {
       "version": "7.22.15",
@@ -2058,22 +1934,6 @@
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/argparse": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
-    },
-    "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/@floating-ui/core": {
@@ -6060,11 +5920,6 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
-    "node_modules/eslint/node_modules/argparse": {
-      "version": "2.0.1",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/eslint/node_modules/eslint-scope": {
       "version": "7.1.1",
       "dev": true,
@@ -6094,17 +5949,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/eslint/node_modules/js-yaml": {
-      "version": "4.1.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/espree": {
@@ -6923,6 +6767,24 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "license": "MIT"
+    },
+    "node_modules/js-yaml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
+      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "dev": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/js-yaml/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true
     },
     "node_modules/jsdoc-type-pratt-parser": {
       "version": "3.1.0",
@@ -8231,6 +8093,11 @@
       "engines": {
         "node": ">=8.10.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.13.11",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.11.tgz",
+      "integrity": "sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.3.1",
@@ -9750,6 +9617,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yorkie-js-sdk": {
+      "version": "0.4.20",
+      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.20.tgz",
+      "integrity": "sha512-e9uXXYfm7vVL/kGJ5tyyL8Erod9P1Ggiq5p6wP8FRh2G4BrJk9kAzHXUjvWqhw5XywiQsVXvWtIX1rlD6WsYqg==",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.6.0",
+        "@connectrpc/connect": "^1.2.0",
+        "@connectrpc/connect-web": "^1.2.0",
+        "long": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=7.1.0"
       }
     },
     "node_modules/z-schema": {

--- a/public/quill.html
+++ b/public/quill.html
@@ -71,7 +71,10 @@
           const doc = new yorkie.Document(documentKey, {
             enableDevtools: true,
           });
-          doc.subscribe('connection', new Network(statusHolder).statusListener);
+          doc.subscribe(
+            'connection',
+            new Network(networkStatusElem).statusListener,
+          );
           doc.subscribe('presence', (event) => {
             if (event.type === 'presence-changed') return;
             displayOnlineClients(doc.getPresences(), client.getID());


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Update exmples version to v0.4.20

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependencies**
  - Updated `yorkie-js-sdk` dependency version from `^0.4.19` to `^0.4.20` across various examples (nextjs-scheduler, profile-stack, react-tldraw, react-todomvc, simultaneous-cursors, vanilla-codemirror6, vuejs-kanban).

- **Enhancements**
  - Improved type safety and clarity in `vanilla-codemirror6` by updating imports and function parameters to use specific types from `yorkie-js-sdk`.

- **Bug Fixes**
  - Adjusted event subscription in `public/quill.html` to use a new parameter for `Network` instance creation, ensuring proper event handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->