### PR TITLE
Prevent remote-change events in RealtimeSyncOff mode

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -695,7 +695,8 @@ export class Client {
         // PushPull, ignore the response when the syncMode is PushOnly.
         if (
           respPack.hasChanges() &&
-          attachment.syncMode === SyncMode.RealtimePushOnly
+          (attachment.syncMode === SyncMode.RealtimePushOnly ||
+            attachment.syncMode === SyncMode.RealtimeSyncOff)
         ) {
           return doc;
         }

--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -610,6 +610,89 @@ describe.sequential('Client', function () {
     await c2.deactivate();
   });
 
+  it('Should prevent remote changes in sync-off mode', async function ({
+    task,
+  }) {
+    const c1 = new yorkie.Client(testRPCAddr);
+    const c2 = new yorkie.Client(testRPCAddr);
+    await c1.activate();
+    await c2.activate();
+
+    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
+    const d1 = new yorkie.Document<{ tree: Tree }>(docKey);
+    const d2 = new yorkie.Document<{ tree: Tree }>(docKey);
+    await c1.attach(d1);
+    await c2.attach(d2);
+
+    const eventCollectorD1 = new EventCollector();
+    const eventCollectorD2 = new EventCollector();
+    const unsub1 = d1.subscribe((event) => {
+      eventCollectorD1.add(event.type);
+    });
+    const unsub2 = d2.subscribe((event) => {
+      eventCollectorD2.add(event.type);
+    });
+
+    d1.update((root) => {
+      root.tree = new Tree({
+        type: 'doc',
+        children: [
+          {
+            type: 'p',
+            children: [{ type: 'text', value: '12' }],
+          },
+          {
+            type: 'p',
+            children: [{ type: 'text', value: '34' }],
+          },
+        ],
+      });
+    });
+    await eventCollectorD2.waitAndVerifyNthEvent(1, DocEventType.RemoteChange);
+
+    assert.equal(d1.getRoot().tree.toXML(), '<doc><p>12</p><p>34</p></doc>');
+    assert.equal(d2.getRoot().tree.toXML(), '<doc><p>12</p><p>34</p></doc>');
+
+    d1.update((root) => {
+      root.tree.edit(2, 2, { type: 'text', value: 'a' });
+    });
+    await c1.sync();
+
+    // Simulate the situation in the runSyncLoop where a pushpull request has been sent
+    // but a response has not yet been received.
+    c2.sync();
+
+    // In sync-off mode, remote-change events should not occur.
+    c2.changeSyncMode(d2, SyncMode.RealtimeSyncOff);
+    let remoteChangeOccured = false;
+    const unsub3 = d2.subscribe((event) => {
+      if (event.type === DocEventType.RemoteChange) {
+        remoteChangeOccured = true;
+      }
+    });
+    await new Promise((res) => {
+      // TODO(chacha912): We need to clean up this later because it is non-deterministic.
+      setTimeout(res, 0); // Keep the sync-off state.
+    });
+    unsub3();
+    assert.isFalse(remoteChangeOccured);
+
+    c2.changeSyncMode(d2, SyncMode.Realtime);
+
+    d2.update((root) => {
+      root.tree.edit(2, 2, { type: 'text', value: 'b' });
+    });
+    await eventCollectorD1.waitAndVerifyNthEvent(3, DocEventType.RemoteChange);
+
+    assert.equal(d1.getRoot().tree.toXML(), '<doc><p>1ba2</p><p>34</p></doc>');
+    assert.equal(d2.getRoot().tree.toXML(), '<doc><p>1ba2</p><p>34</p></doc>');
+
+    unsub1();
+    unsub2();
+    await c1.deactivate();
+    await c2.deactivate();
+  });
+
   it('Should avoid unnecessary syncs in push-only mode', async function ({
     task,
   }) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Prevent remote-change events from occurring in RealtimeSyncOff mode

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #823

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new synchronization mode called `RealtimeSyncOff` to provide more control over real-time sync settings.

- **Tests**
  - Added a test case to ensure remote changes are prevented when synchronization mode is set to `RealtimeSyncOff`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->