### PR TITLE
Show removed node in devtools

### DIFF
--- a/tools/devtools/package-lock.json
+++ b/tools/devtools/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yorkie-devtools",
-  "version": "0.4.13",
+  "version": "0.4.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yorkie-devtools",
-      "version": "0.4.13",
+      "version": "0.4.20",
       "dependencies": {
         "@microlink/react-json-view": "^1.23.0",
         "classnames": "^2.3.2",
@@ -18,7 +18,7 @@
         "react-dom": "18.2.0",
         "react-resizable-layout": "^0.7.2",
         "use-resize-observer": "^9.1.0",
-        "yorkie-js-sdk": "^0.4.18-rc"
+        "yorkie-js-sdk": "^0.4.21-rc3"
       },
       "devDependencies": {
         "@types/chrome": "0.0.251",
@@ -392,6 +392,28 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bufbuild/protobuf": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-1.9.0.tgz",
+      "integrity": "sha512-W7gp8Q/v1NlCZLsv8pQ3Y0uCu/SHgXOVFK+eUluUKWXmsb6VHkpNx0apdOWWcDbB9sJoKeP8uPrjmehJz6xETQ=="
+    },
+    "node_modules/@connectrpc/connect": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect/-/connect-1.4.0.tgz",
+      "integrity": "sha512-vZeOkKaAjyV4+RH3+rJZIfDFJAfr+7fyYr6sLDKbYX3uuTVszhFe9/YKf5DNqrDb5cKdKVlYkGn6DTDqMitAnA==",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2"
+      }
+    },
+    "node_modules/@connectrpc/connect-web": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@connectrpc/connect-web/-/connect-web-1.4.0.tgz",
+      "integrity": "sha512-13aO4psFbbm7rdOFGV0De2Za64DY/acMspgloDlcOKzLPPs0yZkhp1OOzAQeiAIr7BM/VOHIA3p8mF0inxCYTA==",
+      "peerDependencies": {
+        "@bufbuild/protobuf": "^1.4.2",
+        "@connectrpc/connect": "1.4.0"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -4682,11 +4704,6 @@
       "integrity": "sha512-xFU8ZXTw4gd358lb2jw25nxY9QAgqn2+bKKjKOYfNCzN4DKCFetK7sPtrlpg66Ywe3vWY9FNxprZawAh9wfJ3g==",
       "dev": true
     },
-    "node_modules/@types/google-protobuf": {
-      "version": "3.15.12",
-      "resolved": "https://registry.npmjs.org/@types/google-protobuf/-/google-protobuf-3.15.12.tgz",
-      "integrity": "sha512-40um9QqwHjRS92qnOaDpL7RmDK15NuZYo9HihiJRbYkMQZlWnuH8AdvbMy8/o6lgLmKbDUKa+OALCltHdbOTpQ=="
-    },
     "node_modules/@types/har-format": {
       "version": "1.2.15",
       "resolved": "https://registry.npmjs.org/@types/har-format/-/har-format-1.2.15.tgz",
@@ -4702,11 +4719,6 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
-    },
-    "node_modules/@types/long": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/@types/long/-/long-4.0.2.tgz",
-      "integrity": "sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA=="
     },
     "node_modules/@types/node": {
       "version": "20.9.0",
@@ -6376,11 +6388,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/google-protobuf": {
-      "version": "3.21.2",
-      "resolved": "https://registry.npmjs.org/google-protobuf/-/google-protobuf-3.21.2.tgz",
-      "integrity": "sha512-3MSOYFO5U9mPGikIYCzK0SaThypfGgS6bHqrUGXG3DPHCrb+txNqeEcns1W0lkGfk0rCyNXm7xB9rMxnCiZOoA=="
-    },
     "node_modules/gopd": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
@@ -6436,11 +6443,6 @@
       "dependencies": {
         "graphql": "^15.0.0"
       }
-    },
-    "node_modules/grpc-web": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/grpc-web/-/grpc-web-1.5.0.tgz",
-      "integrity": "sha512-y1tS3BBIoiVSzKTDF3Hm7E8hV2n7YY7pO0Uo7depfWJqKzWE+SKr0jvHNIJsJJYILQlpYShpi/DRJJMbosgDMQ=="
     },
     "node_modules/has-flag": {
       "version": "3.0.0",
@@ -9677,15 +9679,18 @@
       }
     },
     "node_modules/yorkie-js-sdk": {
-      "version": "0.4.18-rc",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.18-rc.tgz",
-      "integrity": "sha512-IxwBaxdCgYD+GUMb/csWzO2rEDbelTUgwKbxd82OngIGBOEvYaLqtwcokwiShSwheOz9KhsIdwlRDUglodpiJg==",
+      "version": "0.4.21-rc3",
+      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.21-rc3.tgz",
+      "integrity": "sha512-pWTJKncLDAGWh5D1LM8owWe0t8htFyptYBRvd8HYA0xDOZhFFZ9x8eDQWOWdbxEox7SVpVQN/nkqm7E3hyivOQ==",
       "dependencies": {
-        "@types/google-protobuf": "^3.15.5",
-        "@types/long": "^4.0.1",
-        "google-protobuf": "^3.19.4",
-        "grpc-web": "^1.3.1",
+        "@bufbuild/protobuf": "^1.6.0",
+        "@connectrpc/connect": "^1.2.0",
+        "@connectrpc/connect-web": "^1.2.0",
         "long": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=7.1.0"
       }
     }
   }

--- a/tools/devtools/package.json
+++ b/tools/devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yorkie-devtools",
   "displayName": "Yorkie Devtools",
-  "version": "0.4.18",
+  "version": "0.4.20",
   "description": "A browser extension that helps you debug Yorkie.",
   "homepage": "https://yorkie.dev/",
   "scripts": {
@@ -20,7 +20,7 @@
     "react-dom": "18.2.0",
     "react-resizable-layout": "^0.7.2",
     "use-resize-observer": "^9.1.0",
-    "yorkie-js-sdk": "^0.4.18-rc"
+    "yorkie-js-sdk": "^0.4.21-rc3"
   },
   "devDependencies": {
     "@types/chrome": "0.0.251",

--- a/tools/devtools/src/devtools/components/Detail.tsx
+++ b/tools/devtools/src/devtools/components/Detail.tsx
@@ -79,6 +79,10 @@ function TreeNode({ node }: { node: FlatTreeNodeInfo }) {
             ${nodeIDToString(node.pos.leftSiblingID)}]`}
           </span>
         </div>
+        <div>
+          <span className="title">size: </span>
+          <span className="desc">{node.size}</span>
+        </div>
         {node.type !== 'text' && (
           <div>
             <span className="title">attrs: </span>

--- a/tools/devtools/src/devtools/components/Detail.tsx
+++ b/tools/devtools/src/devtools/components/Detail.tsx
@@ -51,7 +51,11 @@ function TreeNode({ node }: { node: FlatTreeNodeInfo }) {
 
   return (
     <div
-      className={classNames('tree-node', node.type === 'text' && 'text')}
+      className={classNames(
+        'tree-node',
+        node.type === 'text' && 'text',
+        node.isRemoved && 'removed',
+      )}
       style={{ '--depth': depth } as any}
     >
       <span className="node-item">

--- a/tools/devtools/src/devtools/panel/styles.css
+++ b/tools/devtools/src/devtools/panel/styles.css
@@ -104,6 +104,12 @@
   background: var(--gray-200);
 }
 
+.devtools-history-buttons .history-index {
+  margin-right: 8px;
+  font-size: 10px;
+  color: var(--gray-600);
+}
+
 .devtools-history-buttons button {
   background-color: var(--gray-400);
   color: #fff;
@@ -270,7 +276,7 @@
 }
 
 .selected-content {
-  height: 66%;
+  height: 86%;
   border-top: 1px solid var(--gray-300);
   display: flex;
   flex-direction: column;
@@ -303,6 +309,21 @@
 
 .selected-close-btn:hover {
   color: var(--gray-500);
+}
+
+.toggle-removed-node-btn {
+  border: 1px solid var(--gray-300);
+  border-radius: 4px;
+  color: var(--gray-500);
+  cursor: pointer;
+  font-size: 10px;
+  padding: 2px 4px;
+  vertical-align: top;
+  margin: 0 6px;
+}
+
+.toggle-removed-node-btn:hover {
+  color: var(--gray-600);
 }
 
 .selected-view-tabmenu {
@@ -405,6 +426,14 @@
 
 .tree-node.text .node-item {
   background: var(--gray-100);
+}
+
+.selected-content.hide-removed-node .tree-node.removed .node-item {
+  display: none;
+}
+
+.tree-node.removed .node-item {
+  background: var(--red-light) !important;
 }
 
 .tree-node span {

--- a/tools/devtools/src/devtools/tabs/Document.tsx
+++ b/tools/devtools/src/devtools/tabs/Document.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useEffect, useState } from 'react';
+import classNames from 'classnames';
 import { Primitive } from 'yorkie-js-sdk';
 import { RootTree } from '../components/Tree';
 import { JSONDetail, TreeDetail } from '../components/Detail';
@@ -26,6 +27,7 @@ export function Document({ style }) {
   const currentDocKey = useCurrentDocKey();
   const [doc] = useYorkieDoc();
   const [selectedNode, setSelectedNode] = useSelectedNode();
+  const [hideRemovedNode, setHideRemovedNode] = useState(true);
   const [root, setRoot] = useState(null);
   const [nodeDetail, setNodeDetail] = useState(null);
 
@@ -62,17 +64,32 @@ export function Document({ style }) {
       <div className="content">
         <RootTree root={root} />
         {selectedNode && (
-          <div className="selected-content">
+          <div
+            className={classNames(
+              'selected-content',
+              hideRemovedNode && 'hide-removed-node',
+            )}
+          >
             <div className="selected-title">
               {selectedNode.id}
-              <button
-                className="selected-close-btn"
-                onClick={() => {
-                  setSelectedNode(null);
-                }}
-              >
-                <CloseIcon />
-              </button>
+              <div>
+                <button
+                  className="toggle-removed-node-btn"
+                  onClick={() => {
+                    setHideRemovedNode((v) => !v);
+                  }}
+                >
+                  {hideRemovedNode ? 'Show removed node' : 'Hide removed node'}
+                </button>
+                <button
+                  className="selected-close-btn"
+                  onClick={() => {
+                    setSelectedNode(null);
+                  }}
+                >
+                  <CloseIcon />
+                </button>
+              </div>
             </div>
             <div className="selected-view">
               {selectedNode.type === 'YORKIE_TREE' ? (

--- a/tools/devtools/src/devtools/tabs/History.tsx
+++ b/tools/devtools/src/devtools/tabs/History.tsx
@@ -135,6 +135,9 @@ export function History({
           {openHistory && (
             <span>
               <span className="devtools-history-buttons">
+                <span className="history-index">
+                  {selectedEventIndexInfo.index + 1} / {events.length}
+                </span>
                 <button
                   onClick={() => {
                     setSelectedEventIndexInfo({


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Enhance Tree Data Type in DevTools

- View deleted nodes by clicking the `Show removed node` button to toggle the visibility of deleted nodes.
- Display of the current revision number in the history tab.
- Add the node `size` information in the node detail when hovering over a node in the Tree data type.

https://github.com/yorkie-team/yorkie-js-sdk/assets/81357083/a5154f73-91cf-40bd-829f-f568add1f1ec

#### Any background context you want to provide?

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an indicator to show the size of nodes in the devtools panel.
  - Introduced functionality to hide or show removed nodes based on user interaction.
  - Displayed the current event index and total number of events in the history view.

- **Style**
  - Updated various styling properties including margins, font sizes, colors, and heights for devtools panel elements.
  - Applied specific styles to differentiate removed nodes visually.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->