### PR TITLE
Fix incorrect tree snapshot encoding/decoding

### DIFF
--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -1034,7 +1034,6 @@ function fromTreeNodes(
     nodes.push(fromTreeNode(pbTreeNode));
   }
 
-  // 01. build tree structure
   const root = nodes[nodes.length - 1];
   for (let i = nodes.length - 2; i >= 0; i--) {
     let parent: CRDTTreeNode;
@@ -1048,30 +1047,10 @@ function fromTreeNodes(
     parent!.prepend(nodes[i]);
   }
 
-  // 02. adjust descendant size of all nodes
-  dfs(root);
+  root.updateDescendantsSize();
 
   // build CRDTTree from the root to construct the links between nodes.
   return CRDTTree.create(root, InitialTimeTicket).getRoot();
-}
-
-/**
- * `dfs` calculates the size of the given node and its descendants.
- */
-function dfs(curr: CRDTTreeNode): number {
-  if (curr.isRemoved) {
-    curr.size = 0;
-    return 0;
-  }
-
-  let ret = 0;
-  for (const child of curr._children) {
-    ret += dfs(child);
-  }
-
-  curr.size += ret;
-
-  return curr.paddedSize;
 }
 
 /**

--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -1034,6 +1034,7 @@ function fromTreeNodes(
     nodes.push(fromTreeNode(pbTreeNode));
   }
 
+  // 01. build tree structure
   const root = nodes[nodes.length - 1];
   for (let i = nodes.length - 2; i >= 0; i--) {
     let parent: CRDTTreeNode;
@@ -1047,8 +1048,27 @@ function fromTreeNodes(
     parent!.prepend(nodes[i]);
   }
 
+  // 02. adjust descendant size of all nodes
+  dfs(root);
+
   // build CRDTTree from the root to construct the links between nodes.
   return CRDTTree.create(root, InitialTimeTicket).getRoot();
+}
+
+function dfs(curr: CRDTTreeNode): number {
+  if (curr.isRemoved) {
+    curr.size = 0;
+    return 0;
+  }
+
+  let ret = 0;
+  for (const child of curr._children) {
+    ret += dfs(child);
+  }
+
+  curr.size += ret;
+
+  return curr.paddedSize;
 }
 
 /**

--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -105,7 +105,7 @@ import {
   CRDTTreeNode,
   CRDTTreeNodeID,
 } from '@yorkie-js-sdk/src/document/crdt/tree';
-import { traverse } from '../util/index_tree';
+import { traverseAll } from '../util/index_tree';
 import { TreeStyleOperation } from '../document/operation/tree_style_operation';
 import { RHT } from '../document/crdt/rht';
 
@@ -601,7 +601,7 @@ function toTreeNodes(node: CRDTTreeNode): Array<PbTreeNode> {
   }
 
   const pbTreeNodes: Array<PbTreeNode> = [];
-  traverse(node, (n, depth) => {
+  traverseAll(node, (n, depth) => {
     const pbTreeNode = new PbTreeNode({
       id: toTreeNodeID(n.id),
       type: n.type,

--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -1055,6 +1055,9 @@ function fromTreeNodes(
   return CRDTTree.create(root, InitialTimeTicket).getRoot();
 }
 
+/**
+ * `dfs` calculates the size of the given node and its descendants.
+ */
 function dfs(curr: CRDTTreeNode): number {
   if (curr.isRemoved) {
     curr.size = 0;

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -774,7 +774,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
     this.indexTree = new IndexTree<CRDTTreeNode>(root);
     this.nodeMapByID = new LLRBTree(CRDTTreeNodeID.createComparator());
 
-    this.indexTree.traverse((node) => {
+    this.indexTree.traverseAll((node) => {
       this.nodeMapByID.put(node.id, node);
     });
   }

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -1275,6 +1275,13 @@ export class CRDTTree extends CRDTElement implements GCParent {
   }
 
   /**
+   * `getLLRBTreeSize` returns the size of the LLRBTree.
+   */
+  public getLLRBTreeSize(): number {
+    return this.nodeMapByID.size();
+  }
+
+  /**
    * `getIndexTree` returns the index tree.
    */
   public getIndexTree(): IndexTree<CRDTTreeNode> {

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -1275,9 +1275,9 @@ export class CRDTTree extends CRDTElement implements GCParent {
   }
 
   /**
-   * `getLLRBTreeSize` returns the size of the LLRBTree.
+   * `getNodeSize` returns the size of the LLRBTree.
    */
-  public getLLRBTreeSize(): number {
+  public getNodeSize(): number {
     return this.nodeMapByID.size();
   }
 

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -254,14 +254,14 @@ export class Tree {
   }
 
   /**
-   * `getLLRBTreeSize` returns the size of the LLRB tree of this tree.
+   * `getNodeSize` returns the node size of this tree.
    */
-  public getLLRBTreeSize(): number {
+  public getNodeSize(): number {
     if (!this.context || !this.tree) {
       throw new Error('it is not initialized yet');
     }
 
-    return this.tree.getLLRBTreeSize();
+    return this.tree.getNodeSize();
   }
 
   /**

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -253,6 +253,14 @@ export class Tree {
     return this.tree.getSize();
   }
 
+  public getLLRBTreeSize(): number {
+    if (!this.context || !this.tree) {
+      throw new Error('it is not initialized yet');
+    }
+
+    return this.tree.getLLRBTreeSize();
+  }
+
   /**
    * `getIndexTree` returns the index tree of this tree.
    */

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -253,6 +253,9 @@ export class Tree {
     return this.tree.getSize();
   }
 
+  /**
+   * `getLLRBTreeSize` returns the size of the LLRB tree of this tree.
+   */
   public getLLRBTreeSize(): number {
     if (!this.context || !this.tree) {
       throw new Error('it is not initialized yet');

--- a/src/util/index_tree.ts
+++ b/src/util/index_tree.ts
@@ -286,10 +286,6 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
     this._children.unshift(...newNode);
     for (const node of newNode) {
       node.parent = this as any;
-
-      if (!node.isRemoved) {
-        node.updateAncestorsSize();
-      }
     }
   }
 

--- a/src/util/index_tree.ts
+++ b/src/util/index_tree.ts
@@ -134,7 +134,8 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
   }
 
   /**
-   * `updateAncestorsSize` updates the size of the ancestors.
+   * `updateAncestorsSize` updates the size of the ancestors. It is used when
+   * the size of the node is changed.
    */
   updateAncestorsSize(): void {
     let parent: T | undefined = this.parent;
@@ -144,6 +145,26 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
       parent.size += this.paddedSize * sign;
       parent = parent.parent;
     }
+  }
+
+  /**
+   * `updateDescendantsSize` updates the size of the descendants. It is used when
+   * the tree is newly created and the size of the descendants is not calculated.
+   */
+  updateDescendantsSize(): number {
+    if (this.isRemoved) {
+      this.size = 0;
+      return 0;
+    }
+
+    let sum = 0;
+    for (const child of this._children) {
+      sum += child.updateDescendantsSize();
+    }
+
+    this.size += sum;
+
+    return this.paddedSize;
   }
 
   /**
@@ -276,7 +297,8 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
   }
 
   /**
-   * `prepend` prepends the given nodes to the children.
+   * `prepend` prepends the given nodes to the children. It is only used
+   * for creating a new node from snapshot.
    */
   prepend(...newNode: Array<T>): void {
     if (this.isText) {

--- a/test/unit/api/converter_test.ts
+++ b/test/unit/api/converter_test.ts
@@ -90,47 +90,28 @@ describe('Converter', function () {
       root.tree = new Tree({
         type: 'r',
         children: [
-          {
-            type: 'p',
-            children: [{ type: 'text', value: 'abcd' }],
-          },
-          {
-            type: 'p',
-            children: [
-              {
-                type: 'p',
-                children: [{ type: 'text', value: '1234' }],
-              },
-              {
-                type: 'p',
-                children: [{ type: 'text', value: '5678' }],
-              },
-            ],
-          },
+          { type: 'p', children: [{ type: 'text', value: '12' }] },
+          { type: 'p', children: [{ type: 'text', value: '34' }] },
         ],
       });
 
-      root.tree.editByPath([0, 1], [0, 3]);
-      root.tree.editByPath([1, 0, 2], [1, 1, 2]);
-      assert.equal(
-        root.tree.toXML(),
-        /*html*/ `<r><p>ad</p><p><p>1278</p></p></r>`,
-      );
+      root.tree.editByPath([0, 1], [1, 1]);
+      assert.equal(root.tree.toXML(), /*html*/ `<r><p>14</p></r>`);
     });
 
     const bytes = converter.objectToBytes(doc.getRootObject());
     const obj = converter.bytesToObject(bytes);
 
-    // IndexTree Size Comparison
-    assert.equal(
-      doc.getRoot().tree.getSize(),
-      (obj.get('tree') as any).getSize(),
-    );
-
     // LLRBTree Size Comparison
     assert.equal(
       doc.getRoot().tree.getLLRBTreeSize(),
       (obj.get('tree') as any).getLLRBTreeSize(),
+    );
+
+    // IndexTree Size Comparison
+    assert.equal(
+      doc.getRoot().tree.getSize(),
+      (obj.get('tree') as any).getSize(),
     );
   });
 

--- a/test/unit/api/converter_test.ts
+++ b/test/unit/api/converter_test.ts
@@ -81,7 +81,14 @@ describe('Converter', function () {
     assert.equal(doc.toSortedJSON(), obj.toSortedJSON());
   });
 
-  it.skip('check size', function () {
+  it('convert hex string <-> byte array', function () {
+    const hexString = '0123456789abcdef01234567';
+    const bytes = converter.toUint8Array(hexString);
+    assert.equal(bytes.length, 12);
+    assert.equal(converter.toHexString(bytes), hexString);
+  });
+
+  it('should encode and decode tree properly', function () {
     const doc = new Document<{
       tree: Tree;
     }>('test-doc');
@@ -96,28 +103,21 @@ describe('Converter', function () {
       });
 
       root.tree.editByPath([0, 1], [1, 1]);
-      assert.equal(root.tree.toXML(), /*html*/ `<r><p>14</p></r>`);
-      assert.equal(root.tree.getSize(), 4);
     });
+    assert.equal(doc.getRoot().tree.toXML(), /*html*/ `<r><p>14</p></r>`);
+    assert.equal(doc.getRoot().tree.getSize(), 4);
 
     const bytes = converter.objectToBytes(doc.getRootObject());
     const obj = converter.bytesToObject(bytes);
 
     assert.equal(
-      doc.getRoot().tree.getLLRBTreeSize(),
-      (obj.get('tree') as any).getLLRBTreeSize(),
+      doc.getRoot().tree.getNodeSize(),
+      (obj.get('tree') as unknown as Tree).getNodeSize(),
     );
 
     assert.equal(
       doc.getRoot().tree.getSize(),
-      (obj.get('tree') as any).getSize(),
+      (obj.get('tree') as unknown as Tree).getSize(),
     );
-  });
-
-  it('convert hex string <-> byte array', function () {
-    const hexString = '0123456789abcdef01234567';
-    const bytes = converter.toUint8Array(hexString);
-    assert.equal(bytes.length, 12);
-    assert.equal(converter.toHexString(bytes), hexString);
   });
 });

--- a/test/unit/api/converter_test.ts
+++ b/test/unit/api/converter_test.ts
@@ -97,18 +97,17 @@ describe('Converter', function () {
 
       root.tree.editByPath([0, 1], [1, 1]);
       assert.equal(root.tree.toXML(), /*html*/ `<r><p>14</p></r>`);
+      assert.equal(root.tree.getSize(), 4);
     });
 
     const bytes = converter.objectToBytes(doc.getRootObject());
     const obj = converter.bytesToObject(bytes);
 
-    // LLRBTree Size Comparison
     assert.equal(
       doc.getRoot().tree.getLLRBTreeSize(),
       (obj.get('tree') as any).getLLRBTreeSize(),
     );
 
-    // IndexTree Size Comparison
     assert.equal(
       doc.getRoot().tree.getSize(),
       (obj.get('tree') as any).getSize(),

--- a/test/unit/api/converter_test.ts
+++ b/test/unit/api/converter_test.ts
@@ -81,7 +81,7 @@ describe('Converter', function () {
     assert.equal(doc.toSortedJSON(), obj.toSortedJSON());
   });
 
-  it.only('check size', function () {
+  it.skip('check size', function () {
     const doc = new Document<{
       tree: Tree;
     }>('test-doc');

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       reporter: ['lcov', 'text-summary'],
     },
     onConsoleLog() {
-      return false;
+      // return false;
     },
     environment: 'custom-jsdom',
     globals: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       reporter: ['lcov', 'text-summary'],
     },
     onConsoleLog() {
-      // return false;
+      return false;
     },
     environment: 'custom-jsdom',
     globals: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fix incorrect tree snapshot encoding/decoding

The following issues exist when encoding and ecoding snapshots of Tree:
- Removed nodes are missing
- Update incorrect size

This commit fixes the incorrect tree snapshot encoding/decoding logic.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address #880

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `getNodeSize` method to the `Tree` class for retrieving the size of the tree node.

- **Enhancements**
  - Improved tree size management with new methods for updating descendants' and ancestors' sizes.
  - Enhanced error handling for uninitialized contexts or trees.

- **Tests**
  - Added new test case to verify encoding and decoding of tree structures within a `Document` object.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->