### PR TITLE
Fix incorrect indexes in TreeChange

### DIFF
--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -1057,13 +1057,14 @@ function fromTreeNodes(
 function fromTreeNode(pbTreeNode: PbTreeNode): CRDTTreeNode {
   const id = fromTreeNodeID(pbTreeNode.id!);
   const node = CRDTTreeNode.create(id, pbTreeNode.type);
+  const pbAttrs = Object.entries(pbTreeNode.attributes);
   if (node.isText) {
     node.value = pbTreeNode.value;
-  } else {
+  } else if (pbAttrs.length) {
     const attrs = RHT.create();
-    Object.entries(pbTreeNode.attributes).forEach(([key, value]) => {
+    for (const [key, value] of pbAttrs) {
       attrs.set(key, value.value, fromTimeTicket(value.updatedAt)!);
-    });
+    }
     node.attrs = attrs;
   }
 

--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -1202,6 +1202,7 @@ function fromOperation(pbOperation: PbOperation): Operation | undefined {
         fromTimeTicket(pbTreeStyleOperation!.parentCreatedAt)!,
         fromTreePos(pbTreeStyleOperation!.from!),
         fromTreePos(pbTreeStyleOperation!.to!),
+        createdAtMapByActor,
         attributesToRemove,
         fromTimeTicket(pbTreeStyleOperation!.executedAt)!,
       );

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -971,7 +971,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
       fromLeft,
       toParent,
       toLeft,
-      ([node, tokenType]) => {
+      ([node]) => {
         const actorID = node.getCreatedAt().getActorID();
         const maxCreatedAt = maxCreatedAtMapByActor
           ? maxCreatedAtMapByActor!.has(actorID)

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -966,7 +966,6 @@ export class CRDTTree extends CRDTElement implements GCParent {
     const changes: Array<TreeChange> = [];
     const createdAtMapByActor = new Map<string, TimeTicket>();
     const pairs: Array<GCPair> = [];
-    console.error('removeStyle');
     this.traverseInPosRange(
       fromParent,
       fromLeft,
@@ -981,6 +980,12 @@ export class CRDTTree extends CRDTElement implements GCParent {
           : MaxTimeTicket;
 
         if (node.canStyle(editedAt, maxCreatedAt) && attributesToRemove) {
+          const maxCreatedAt = createdAtMapByActor!.get(actorID);
+          const createdAt = node.getCreatedAt();
+          if (!maxCreatedAt || createdAt.after(maxCreatedAt)) {
+            createdAtMapByActor.set(actorID, createdAt);
+          }
+
           if (!node.attrs) {
             node.attrs = new RHT();
           }
@@ -994,13 +999,6 @@ export class CRDTTree extends CRDTElement implements GCParent {
 
           const parentOfNode = node.parent!;
           const previousNode = node.prevSibling || node.parent!;
-
-          console.error(
-            'traverse',
-            node.getCreatedAt().toTestString(),
-            toXML(node),
-            tokenType,
-          );
 
           changes.push({
             actor: editedAt.getActorID()!,

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -360,7 +360,7 @@ export class Tree {
     const toPos = this.tree.findPos(toIdx);
     const ticket = this.context.issueTimeTicket();
 
-    const [pairs] = this.tree!.removeStyle(
+    const [maxCreationMapByActor, pairs] = this.tree!.removeStyle(
       [fromPos, toPos],
       attributesToRemove,
       ticket,
@@ -375,6 +375,7 @@ export class Tree {
         this.tree.getCreatedAt(),
         fromPos,
         toPos,
+        maxCreationMapByActor,
         attributesToRemove,
         ticket,
       ),

--- a/src/document/operation/operation.ts
+++ b/src/document/operation/operation.ts
@@ -150,7 +150,7 @@ export type TreeEditOpInfo = {
   from: number;
   to: number;
   value?: Array<TreeNode>;
-  splitLevel: number;
+  splitLevel?: number;
   fromPath: Array<number>;
   toPath: Array<number>;
 };

--- a/src/document/operation/operation.ts
+++ b/src/document/operation/operation.ts
@@ -164,7 +164,14 @@ export type TreeStyleOpInfo = {
   from: number;
   to: number;
   fromPath: Array<number>;
-  value: { [key: string]: any };
+  toPath: Array<number>;
+  value:
+    | {
+        attributes: Indexable;
+      }
+    | {
+        attributesToRemove: Array<string>;
+      };
 };
 
 /**

--- a/src/document/operation/tree_style_operation.ts
+++ b/src/document/operation/tree_style_operation.ts
@@ -86,6 +86,7 @@ export class TreeStyleOperation extends Operation {
     parentCreatedAt: TimeTicket,
     fromPos: CRDTTreePos,
     toPos: CRDTTreePos,
+    maxCreatedAtMapByActor: Map<string, TimeTicket>,
     attributesToRemove: Array<string>,
     executedAt: TimeTicket,
   ): TreeStyleOperation {
@@ -93,7 +94,7 @@ export class TreeStyleOperation extends Operation {
       parentCreatedAt,
       fromPos,
       toPos,
-      new Map(),
+      maxCreatedAtMapByActor,
       new Map(),
       attributesToRemove,
       executedAt,
@@ -127,7 +128,7 @@ export class TreeStyleOperation extends Operation {
     } else {
       const attributesToRemove = this.attributesToRemove;
 
-      [pairs, changes] = tree.removeStyle(
+      [, pairs, changes] = tree.removeStyle(
         [this.fromPos, this.toPos],
         attributesToRemove,
         this.getExecutedAt(),

--- a/src/document/operation/tree_style_operation.ts
+++ b/src/document/operation/tree_style_operation.ts
@@ -139,13 +139,16 @@ export class TreeStyleOperation extends Operation {
     }
 
     return {
-      opInfos: changes.map(({ from, to, value, fromPath }) => {
+      opInfos: changes.map(({ from, to, value, fromPath, toPath }) => {
         return {
           type: 'tree-style',
           from,
           to,
-          value,
+          value: this.attributes.size
+            ? { attributes: value }
+            : { attributesToRemove: value },
           fromPath,
+          toPath,
           path: root.createPath(this.getParentCreatedAt()),
         } as OperationInfo;
       }),

--- a/src/document/operation/tree_style_operation.ts
+++ b/src/document/operation/tree_style_operation.ts
@@ -132,6 +132,7 @@ export class TreeStyleOperation extends Operation {
         [this.fromPos, this.toPos],
         attributesToRemove,
         this.getExecutedAt(),
+        this.maxCreatedAtMapByActor,
       );
     }
 

--- a/src/util/index_tree.ts
+++ b/src/util/index_tree.ts
@@ -183,6 +183,19 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
   }
 
   /**
+   * `prevSibling` returns the previous sibling of the node.
+   */
+  get prevSibling(): T | undefined {
+    const offset = this.parent!.findOffset(this as any);
+    const sibling = this.parent!.children[offset - 1];
+    if (sibling) {
+      return sibling;
+    }
+
+    return undefined;
+  }
+
+  /**
    * `isRemoved` returns true if the node is removed.
    */
   abstract get isRemoved(): boolean;

--- a/test/integration/tree_concurrency_test.ts
+++ b/test/integration/tree_concurrency_test.ts
@@ -604,7 +604,7 @@ describe('Tree.concurrency', () => {
     const content: TreeNode = {
       type: 'p',
       children: [{ type: 'text', value: 'd' }],
-      attributes: { italic: 'true' },
+      attributes: { italic: 'true', color: 'blue' },
     };
 
     const rangesArr = [
@@ -675,7 +675,7 @@ describe('Tree.concurrency', () => {
         StyleOpCode.StyleRemove,
         'color',
         '',
-        'remove-bold',
+        'remove-color',
       ),
       new StyleOperationType(
         RangeSelector.RangeAll,

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -4645,7 +4645,7 @@ describe('TreeChange', () => {
     }, task.name);
   });
 
-  it.only('Concurrent insert and removeStyle', async function ({ task }) {
+  it('Concurrent insert and removeStyle', async function ({ task }) {
     await withTwoClientsAndDocuments<{ t: Tree }>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root.t = new Tree({
@@ -4704,7 +4704,6 @@ describe('TreeChange', () => {
         toPath: [1, 0],
       };
 
-      console.error('length:', ops1.length, ops2.length);
       assert.deepEqual(ops1, [styleChange, styleChange, editChange]);
       assert.deepEqual(ops2, [editChange, styleChange2, styleChange2]);
     }, task.name);

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -4601,8 +4601,8 @@ describe('TreeChange', () => {
 
       const [ops1, ops2] = subscribeDocs(d1, d2);
 
-      d1.update((root) => root.t.style(0, 1, { value: 'changed' }));
-      d1.update((root) => root.t.style(0, 1, { value: 'changed' }));
+      d1.update((root) => root.t.style(0, 1, { key: 'a' }));
+      d1.update((root) => root.t.style(0, 1, { key: 'a' }));
       d2.update((root) => root.t.edit(0, 0, { type: 'p', children: [] }));
       await c1.sync();
       await c2.sync();
@@ -4610,27 +4610,27 @@ describe('TreeChange', () => {
       assert.equal(d1.getRoot().t.toXML(), d2.getRoot().t.toXML());
       assert.equal(
         d1.getRoot().t.toXML(),
-        /*html*/ `<doc><p></p><p value="changed"></p></doc>`,
+        /*html*/ `<doc><p></p><p key="a"></p></doc>`,
       );
 
       const editChange: TreeEditOpInfo = {
         type: 'tree-edit',
+        path: '$.t',
         from: 0,
         to: 0,
-        value: [{ children: [], type: 'p' }],
         fromPath: [0],
         toPath: [0],
-        path: '$.t',
+        value: [{ children: [], type: 'p' }],
         splitLevel: undefined,
       };
       const styleChange: TreeStyleOpInfo = {
         type: 'tree-style',
+        path: '$.t',
         from: 0,
         to: 1,
         fromPath: [0],
         toPath: [0, 0],
-        path: '$.t',
-        value: { attributes: { value: 'changed' } },
+        value: { attributes: { key: 'a' } },
       };
       const styleChange2: TreeStyleOpInfo = {
         ...styleChange,
@@ -4645,12 +4645,12 @@ describe('TreeChange', () => {
     }, task.name);
   });
 
-  it('Concurrent insert and removeStyle', async function ({ task }) {
+  it.only('Concurrent insert and removeStyle', async function ({ task }) {
     await withTwoClientsAndDocuments<{ t: Tree }>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root.t = new Tree({
           type: 'doc',
-          children: [{ type: 'p', attributes: { key1: 'a' }, children: [] }],
+          children: [{ type: 'p', attributes: { key: 'a' }, children: [] }],
         });
       });
       await c1.sync();
@@ -4658,13 +4658,13 @@ describe('TreeChange', () => {
       assert.equal(d1.getRoot().t.toXML(), d2.getRoot().t.toXML());
       assert.equal(
         d1.getRoot().t.toXML(),
-        /*html*/ `<doc><p key1="a"></p></doc>`,
+        /*html*/ `<doc><p key="a"></p></doc>`,
       );
 
       const [ops1, ops2] = subscribeDocs(d1, d2);
 
-      d1.update((root) => root.t.removeStyle(0, 1, ['key1']));
-      d1.update((root) => root.t.removeStyle(0, 1, ['key1']));
+      d1.update((root) => root.t.removeStyle(0, 1, ['key']));
+      d1.update((root) => root.t.removeStyle(0, 1, ['key']));
       d2.update((root) => root.t.edit(0, 0, { type: 'p', children: [] }));
       await c1.sync();
       await c2.sync();
@@ -4677,23 +4677,23 @@ describe('TreeChange', () => {
 
       const editChange: TreeEditOpInfo = {
         type: 'tree-edit',
+        path: '$.t',
         from: 0,
         to: 0,
-        value: [{ children: [], type: 'p' }],
         fromPath: [0],
         toPath: [0],
-        path: '$.t',
+        value: [{ children: [], type: 'p' }],
         splitLevel: undefined,
       };
       const styleChange: TreeStyleOpInfo = {
         type: 'tree-style',
-        from: 0,
-        fromPath: [0],
         path: '$.t',
+        from: 0,
         to: 1,
+        fromPath: [0],
         toPath: [0, 0],
         value: {
-          attributesToRemove: ['key1'],
+          attributesToRemove: ['key'],
         },
       };
       const styleChange2: TreeStyleOpInfo = {

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -4586,7 +4586,7 @@ describe('TreeChange', () => {
     }, task.name);
   });
 
-  it.only('Concurrent insert and style', async function ({ task }) {
+  it('Concurrent insert and style', async function ({ task }) {
     await withTwoClientsAndDocuments<{ t: Tree }>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root.t = new Tree({
@@ -4645,7 +4645,7 @@ describe('TreeChange', () => {
     }, task.name);
   });
 
-  it.only('Concurrent insert and removeStyle', async function ({ task }) {
+  it('Concurrent insert and removeStyle', async function ({ task }) {
     await withTwoClientsAndDocuments<{ t: Tree }>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root.t = new Tree({

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       reporter: ['lcov', 'text-summary'],
     },
     onConsoleLog() {
-      return false;
+      // return false;
     },
     environment: 'custom-jsdom',
     globals: true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
       reporter: ['lcov', 'text-summary'],
     },
     onConsoleLog() {
-      // return false;
+      return false;
     },
     environment: 'custom-jsdom',
     globals: true,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This commit addresses the issue where indexes of TreeChange returned
during Tree.Style are inaccurately calculated. When executing
Tree.Style, users provide a range, but the actual execution is based
on nodes. This commit corrects the calculation of the TreeChange index
by basing it on nodes, resolving the issue.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Address https://github.com/yorkie-team/yorkie/issues/882
Related https://github.com/yorkie-team/yorkie-android-sdk/pull/193

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
