### PR TITLE
Simplify type checking for style attributes in TreeStyleOpInfo

### DIFF
--- a/src/document/operation/operation.ts
+++ b/src/document/operation/operation.ts
@@ -165,13 +165,10 @@ export type TreeStyleOpInfo = {
   to: number;
   fromPath: Array<number>;
   toPath: Array<number>;
-  value:
-    | {
-        attributes: Indexable;
-      }
-    | {
-        attributesToRemove: Array<string>;
-      };
+  value: {
+    attributes?: Indexable;
+    attributesToRemove?: Array<string>;
+  };
 };
 
 /**

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -75,6 +75,8 @@ export type {
   MoveOpInfo,
   EditOpInfo,
   StyleOpInfo,
+  TreeEditOpInfo,
+  TreeStyleOpInfo,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 export { OpSource } from '@yorkie-js-sdk/src/document/operation/operation';
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

While the union type clearly separated the different styles, it made the code more challenging to use. For now, we simplify the type checking for style attributes by combining the `attributes` and `attributesToRemove` options into a single type.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced flexibility in document operations by allowing optional attributes in the `TreeStyleOpInfo` type.

- **Refactor**
  - Updated export declarations to include `TreeEditOpInfo` and `TreeStyleOpInfo` for improved type management and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->