### PR TITLE
Add RHTNode removal to converter for consistency

### DIFF
--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -596,16 +596,16 @@ function toTreeNodesWhenEdit(nodes: Array<CRDTTreeNode>): Array<PbTreeNodes> {
  * `toRHT` converts the given model to Protobuf format.
  */
 function toRHT(rht: RHT): { [key: string]: PbNodeAttr } {
-  const pbAttrs: { [key: string]: PbNodeAttr } = {};
-  for (const [key, rhtNode] of rht.getNodeMapByKey()) {
-    pbAttrs[key] = new PbNodeAttr({
-      value: rhtNode.getValue(),
-      updatedAt: toTimeTicket(rhtNode.getUpdatedAt()),
-      isRemoved: rhtNode.isRemoved(),
+  const pbRHT: { [key: string]: PbNodeAttr } = {};
+  for (const node of rht) {
+    pbRHT[node.getKey()] = new PbNodeAttr({
+      value: node.getValue(),
+      updatedAt: toTimeTicket(node.getUpdatedAt()),
+      isRemoved: node.isRemoved(),
     });
   }
 
-  return pbAttrs;
+  return pbRHT;
 }
 
 /**
@@ -1069,14 +1069,14 @@ function fromTreeNodes(
  */
 function fromRHT(pbRHT: { [key: string]: PbNodeAttr }): RHT {
   const rht = RHT.create();
-  Object.entries(pbRHT).forEach(([key, rhtNode]) => {
+  for (const [key, pbRHTNode] of Object.entries(pbRHT)) {
     rht.setInternal(
       key,
-      rhtNode.value,
-      fromTimeTicket(rhtNode.updatedAt)!,
-      rhtNode.isRemoved,
+      pbRHTNode.value,
+      fromTimeTicket(pbRHTNode.updatedAt)!,
+      pbRHTNode.isRemoved,
     );
-  });
+  }
 
   return rht;
 }

--- a/src/api/yorkie/v1/resources.proto
+++ b/src/api/yorkie/v1/resources.proto
@@ -226,6 +226,7 @@ message RGANode {
 message NodeAttr {
   string value = 1;
   TimeTicket updated_at = 2;
+  bool is_removed = 3;
 }
 
 message TextNode {

--- a/src/api/yorkie/v1/resources_pb.d.ts
+++ b/src/api/yorkie/v1/resources_pb.d.ts
@@ -1228,6 +1228,11 @@ export declare class NodeAttr extends Message<NodeAttr> {
    */
   updatedAt?: TimeTicket;
 
+  /**
+   * @generated from field: bool is_removed = 3;
+   */
+  isRemoved: boolean;
+
   constructor(data?: PartialMessage<NodeAttr>);
 
   static readonly runtime: typeof proto3;

--- a/src/api/yorkie/v1/resources_pb.js
+++ b/src/api/yorkie/v1/resources_pb.js
@@ -436,6 +436,7 @@ const NodeAttr = proto3.makeMessageType(
   () => [
     { no: 1, name: "value", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "updated_at", kind: "message", T: TimeTicket },
+    { no: 3, name: "is_removed", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
   ],
 );
 

--- a/src/document/crdt/rht.ts
+++ b/src/document/crdt/rht.ts
@@ -119,6 +119,13 @@ export class RHT {
   }
 
   /**
+   * `getNodeMapByKey` returns the hashtable of RHT.
+   */
+  public getNodeMapByKey(): Map<string, RHTNode> {
+    return this.nodeMapByKey;
+  }
+
+  /**
    * `set` sets the value of the given key.
    */
   public set(

--- a/src/document/crdt/rht.ts
+++ b/src/document/crdt/rht.ts
@@ -150,6 +150,23 @@ export class RHT {
   }
 
   /**
+   * SetInternal sets the value of the given key internally.
+   */
+  public setInternal(
+    key: string,
+    value: string,
+    executedAt: TimeTicket,
+    removed: boolean,
+  ) {
+    const node = RHTNode.of(key, value, executedAt, removed);
+    this.nodeMapByKey.set(key, node);
+
+    if (removed) {
+      this.numberOfRemovedElement++;
+    }
+  }
+
+  /**
    * `remove` removes the Element of the given key.
    */
   public remove(key: string, executedAt: TimeTicket): Array<RHTNode> {
@@ -213,7 +230,12 @@ export class RHT {
   public deepcopy(): RHT {
     const rht = new RHT();
     for (const [, node] of this.nodeMapByKey) {
-      rht.set(node.getKey(), node.getValue(), node.getUpdatedAt());
+      rht.setInternal(
+        node.getKey(),
+        node.getValue(),
+        node.getUpdatedAt(),
+        node.isRemoved(),
+      );
     }
     return rht;
   }

--- a/test/unit/api/converter_test.ts
+++ b/test/unit/api/converter_test.ts
@@ -103,8 +103,13 @@ describe('Converter', function () {
       });
 
       root.tree.editByPath([0, 1], [1, 1]);
+
+      root.tree.style(0, 1, { b: 't', i: 't' });
+      assert.equal(root.tree.toXML(), '<r><p b="t" i="t">14</p></r>');
+
+      root.tree.removeStyle(0, 1, ['i']);
     });
-    assert.equal(doc.getRoot().tree.toXML(), /*html*/ `<r><p>14</p></r>`);
+    assert.equal(doc.getRoot().tree.toXML(), /*html*/ `<r><p b="t">14</p></r>`);
     assert.equal(doc.getRoot().tree.getSize(), 4);
 
     const bytes = converter.objectToBytes(doc.getRootObject());
@@ -118,6 +123,10 @@ describe('Converter', function () {
     assert.equal(
       doc.getRoot().tree.getSize(),
       (obj.get('tree') as unknown as Tree).getSize(),
+    );
+    assert.equal(
+      doc.getRoot().tree.toXML(),
+      (obj.get('tree') as unknown as Tree).toXML(),
     );
   });
 });

--- a/test/unit/document/crdt/rht_test.ts
+++ b/test/unit/document/crdt/rht_test.ts
@@ -121,6 +121,16 @@ describe('RHT interface', function () {
     assert.equal(jsonObj.testKey2, testData.testKey2);
     assert.equal(jsonObj.testKey3, testData.testKey3);
   });
+
+  it('should deepcopy correctly', function () {
+    const rht = RHT.create();
+    rht.set('key1', 'value1', timeT());
+    rht.remove('key2', timeT());
+
+    const rht2 = rht.deepcopy();
+    assert.equal(rht.toJSON(), rht2.toJSON());
+    assert.equal(rht.size(), rht2.size());
+  });
 });
 
 describe('RHT', () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Add RHTNode removal to converter for consistency

This commit addresses the missing `isRemoved` encoding in the RHT.
Similar to other CRDTs like ElementRHT, including tombstone nodes like
`isRemoved` during encoding is crucial. However, the RHT did not
include tombstone nodes in its encoding, leading to inconsistencies in
snapshots.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

- Address https://github.com/yorkie-team/yorkie/issues/889
- Related to https://github.com/yorkie-team/yorkie/pull/888

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced new methods to manage key-value pairs internally within the class.
  - Added a boolean field `is_removed` to enhance data structure functionality.

- **Tests**
  - Updated test cases for tree node styling and attribute management.
  - Added a new test case to verify the `deepcopy` method functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->