### PR TITLE
Add tree test to figure out miscalculation of tree size

### DIFF
--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -550,11 +550,7 @@ export class CRDTTreeNode
     }
 
     if (alived) {
-      if (!this.parent!.removedAt) {
-        this.updateAncestorsSize();
-      } else {
-        this.parent!.size -= this.paddedSize;
-      }
+      this.updateAncestorsSize();
     }
   }
 
@@ -1103,6 +1099,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
 
     // 02. Delete: delete the nodes that are marked as removed.
     const pairs: Array<GCPair> = [];
+    // nodesToBeRemoved.reverse();
     for (const node of nodesToBeRemoved) {
       node.remove(editedAt);
       if (node.isRemoved) {

--- a/src/util/index_tree.ts
+++ b/src/util/index_tree.ts
@@ -143,6 +143,10 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
 
     while (parent) {
       parent.size += this.paddedSize * sign;
+      if (parent.isRemoved) {
+        break;
+      }
+
       parent = parent.parent;
     }
   }
@@ -152,14 +156,17 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    * the tree is newly created and the size of the descendants is not calculated.
    */
   updateDescendantsSize(): number {
-    if (this.isRemoved) {
-      this.size = 0;
-      return 0;
-    }
+    // if (this.isRemoved) {
+    //   this.size = 0;
+    //   return 0;
+    // }
 
     let sum = 0;
     for (const child of this._children) {
-      sum += child.updateDescendantsSize();
+      const toAdd = child.updateDescendantsSize();
+      if (!child.isRemoved) {
+        sum += toAdd;
+      }
     }
 
     this.size += sum;

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -4122,7 +4122,9 @@ describe('Tree(edge cases)', () => {
     }, task.name);
   });
 
-  it.skip('Can update its size correctly', async function ({ task }) {
+  it.skip('Can calculate size of index tree correctly during concurrent editing', async function ({
+    task,
+  }) {
     await withTwoClientsAndDocuments<{ t: Tree }>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
         root.t = new Tree({


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Add test-case to figure out miscalculation of indextree size during concurrent tree editing

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added a new test case to verify correct index tree size calculation during concurrent editing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->