### PR TITLE
Fix miscalculation of tree size in concurrent editing

### DIFF
--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -550,11 +550,7 @@ export class CRDTTreeNode
     }
 
     if (alived) {
-      if (!this.parent!.removedAt) {
-        this.updateAncestorsSize();
-      } else {
-        this.parent!.size -= this.paddedSize;
-      }
+      this.updateAncestorsSize();
     }
   }
 

--- a/src/util/index_tree.ts
+++ b/src/util/index_tree.ts
@@ -143,6 +143,10 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
 
     while (parent) {
       parent.size += this.paddedSize * sign;
+      if (parent.isRemoved) {
+        break;
+      }
+
       parent = parent.parent;
     }
   }
@@ -152,17 +156,17 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    * the tree is newly created and the size of the descendants is not calculated.
    */
   updateDescendantsSize(): number {
-    if (this.isRemoved) {
-      this.size = 0;
-      return 0;
-    }
-
-    let sum = 0;
+    let size = 0;
     for (const child of this._children) {
-      sum += child.updateDescendantsSize();
+      const childSize = child.updateDescendantsSize();
+      if (child.isRemoved) {
+        continue;
+      }
+
+      size += childSize;
     }
 
-    this.size += sum;
+    this.size += size;
 
     return this.paddedSize;
   }

--- a/test/integration/tree_test.ts
+++ b/test/integration/tree_test.ts
@@ -4122,6 +4122,41 @@ describe('Tree(edge cases)', () => {
     }, task.name);
   });
 
+  it('Can calculate size of index tree correctly during concurrent editing', async function ({
+    task,
+  }) {
+    await withTwoClientsAndDocuments<{ t: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.t = new Tree({
+          type: 'doc',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'hello' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+      assert.equal(d1.getRoot().t.toXML(), /*html*/ `<doc><p>hello</p></doc>`);
+      assert.equal(d2.getRoot().t.toXML(), /*html*/ `<doc><p>hello</p></doc>`);
+
+      d1.update((root) => root.t.editByPath([0], [1]));
+      d2.update((root) =>
+        root.t.editByPath([0, 0], [0, 1], { type: 'text', value: 'p' }),
+      );
+      assert.equal(d1.getRoot().t.toXML(), /*html*/ `<doc></doc>`);
+      assert.equal(0, d1.getRoot().t.getSize());
+      assert.equal(d2.getRoot().t.toXML(), /*html*/ `<doc><p>pello</p></doc>`);
+      assert.equal(7, d2.getRoot().t.getSize());
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(d1.getRoot().t.toXML(), /*html*/ `<doc></doc>`);
+      assert.equal(d2.getRoot().t.toXML(), /*html*/ `<doc></doc>`);
+      assert.equal(d2.getRoot().t.getSize(), d1.getRoot().t.getSize());
+    }, task.name);
+  });
+
   it('Can split and merge with empty paragraph: left', async function ({
     task,
   }) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fix miscalculation of tree size in concurrent editing

This commit addresses the issue where the `updateAncestorsSize` method
subtracts the size of a tombstoned node from its ancestors' sizes when
the node is removed. However, the previous logic did not consider
cases where ancestors node are tombstoned. In such cases, the update
should not propagate to the parent's ancestors. This commit introduces
recursive checks on ancestors and stops updating process if a
tombstoned ancestor is encountered.

Furthermore, the PR ensures consistency between the size maintenance
policies of updateDescendantsSize and updateAncestorsSize.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Address https://github.com/yorkie-team/yorkie/issues/889

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved accuracy in size calculations when child nodes are removed in the index tree.

- **Tests**
  - Added new test cases for concurrent editing and snapshot consistency of the index tree.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->