### PR TITLE
Update examples version to v0.4.23

### DIFF
--- a/examples/nextjs-scheduler/package.json
+++ b/examples/nextjs-scheduler/package.json
@@ -13,7 +13,7 @@
     "react": "18.2.0",
     "react-calendar": "^4.6.0",
     "react-dom": "18.2.0",
-    "yorkie-js-sdk": "^0.4.22"
+    "yorkie-js-sdk": "^0.4.23"
   },
   "devDependencies": {
     "@types/node": "20.4.2",

--- a/examples/profile-stack/package.json
+++ b/examples/profile-stack/package.json
@@ -12,6 +12,6 @@
     "vite": "^3.2.7"
   },
   "dependencies": {
-    "yorkie-js-sdk": "^0.4.22"
+    "yorkie-js-sdk": "^0.4.23"
   }
 }

--- a/examples/react-tldraw/package.json
+++ b/examples/react-tldraw/package.json
@@ -16,7 +16,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "unique-names-generator": "^4.7.1",
-    "yorkie-js-sdk": "^0.4.22"
+    "yorkie-js-sdk": "^0.4.23"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.198",

--- a/examples/react-todomvc/package.json
+++ b/examples/react-todomvc/package.json
@@ -13,7 +13,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "todomvc-app-css": "^2.4.2",
-    "yorkie-js-sdk": "^0.4.22"
+    "yorkie-js-sdk": "^0.4.23"
   },
   "devDependencies": {
     "@types/react": "^18.0.24",

--- a/examples/simultaneous-cursors/package.json
+++ b/examples/simultaneous-cursors/package.json
@@ -11,7 +11,7 @@
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "yorkie-js-sdk": "^0.4.22"
+    "yorkie-js-sdk": "^0.4.23"
   },
   "devDependencies": {
     "@types/react": "^18.0.37",

--- a/examples/vanilla-codemirror6/package.json
+++ b/examples/vanilla-codemirror6/package.json
@@ -20,6 +20,6 @@
     "@codemirror/state": "^6.1.2",
     "@codemirror/view": "^6.3.1",
     "codemirror": "^6.0.1",
-    "yorkie-js-sdk": "^0.4.22"
+    "yorkie-js-sdk": "^0.4.23"
   }
 }

--- a/examples/vanilla-quill/package.json
+++ b/examples/vanilla-quill/package.json
@@ -19,6 +19,6 @@
     "quill": "^1.3.7",
     "quill-cursors": "^4.0.0",
     "quill-delta": "^5.0.0",
-    "yorkie-js-sdk": "^0.4.22"
+    "yorkie-js-sdk": "^0.4.23"
   }
 }

--- a/examples/vuejs-kanban/package.json
+++ b/examples/vuejs-kanban/package.json
@@ -8,7 +8,7 @@
   },
   "dependencies": {
     "vue": "^3.2.41",
-    "yorkie-js-sdk": "^0.4.22"
+    "yorkie-js-sdk": "^0.4.23"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "^3.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yorkie-js-sdk",
-  "version": "0.4.22",
+  "version": "0.4.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yorkie-js-sdk",
-      "version": "0.4.22",
+      "version": "0.4.23",
       "license": "Apache-2.0",
       "workspaces": [
         "examples/*"
@@ -58,7 +58,7 @@
         "react": "18.2.0",
         "react-calendar": "^4.6.0",
         "react-dom": "18.2.0",
-        "yorkie-js-sdk": "^0.4.22"
+        "yorkie-js-sdk": "^0.4.23"
       },
       "devDependencies": {
         "@types/node": "20.4.2",
@@ -97,25 +97,10 @@
         "node": ">=4.2.0"
       }
     },
-    "examples/nextjs-scheduler/node_modules/yorkie-js-sdk": {
-      "version": "0.4.22",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.22.tgz",
-      "integrity": "sha512-JfDhIQFp9Wbfru7LP2Asg8Q5LAsczIJgAo/61HtumAW3zL5X2C0BWFUfuA/eaiyaBIH3YESey1rrSELuSArWvA==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
-      }
-    },
     "examples/profile-stack": {
       "version": "0.0.0",
       "dependencies": {
-        "yorkie-js-sdk": "^0.4.22"
+        "yorkie-js-sdk": "^0.4.23"
       },
       "devDependencies": {
         "vite": "^3.2.7"
@@ -170,21 +155,6 @@
         }
       }
     },
-    "examples/profile-stack/node_modules/yorkie-js-sdk": {
-      "version": "0.4.22",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.22.tgz",
-      "integrity": "sha512-JfDhIQFp9Wbfru7LP2Asg8Q5LAsczIJgAo/61HtumAW3zL5X2C0BWFUfuA/eaiyaBIH3YESey1rrSELuSArWvA==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
-      }
-    },
     "examples/react-tldraw": {
       "version": "0.1.0",
       "dependencies": {
@@ -195,7 +165,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "unique-names-generator": "^4.7.1",
-        "yorkie-js-sdk": "^0.4.22"
+        "yorkie-js-sdk": "^0.4.23"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.198",
@@ -256,21 +226,6 @@
         }
       }
     },
-    "examples/react-tldraw/node_modules/yorkie-js-sdk": {
-      "version": "0.4.22",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.22.tgz",
-      "integrity": "sha512-JfDhIQFp9Wbfru7LP2Asg8Q5LAsczIJgAo/61HtumAW3zL5X2C0BWFUfuA/eaiyaBIH3YESey1rrSELuSArWvA==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
-      }
-    },
     "examples/react-todomvc": {
       "version": "0.0.0",
       "dependencies": {
@@ -278,7 +233,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "todomvc-app-css": "^2.4.2",
-        "yorkie-js-sdk": "^0.4.22"
+        "yorkie-js-sdk": "^0.4.23"
       },
       "devDependencies": {
         "@types/react": "^18.0.24",
@@ -337,21 +292,6 @@
         }
       }
     },
-    "examples/react-todomvc/node_modules/yorkie-js-sdk": {
-      "version": "0.4.22",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.22.tgz",
-      "integrity": "sha512-JfDhIQFp9Wbfru7LP2Asg8Q5LAsczIJgAo/61HtumAW3zL5X2C0BWFUfuA/eaiyaBIH3YESey1rrSELuSArWvA==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
-      }
-    },
     "examples/simple-tldraw": {
       "extraneous": true,
       "dependencies": {
@@ -363,7 +303,7 @@
       "dependencies": {
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "yorkie-js-sdk": "^0.4.22"
+        "yorkie-js-sdk": "^0.4.23"
       },
       "devDependencies": {
         "@types/react": "^18.0.37",
@@ -389,21 +329,6 @@
         "vite": "^4.2.0"
       }
     },
-    "examples/simultaneous-cursors/node_modules/yorkie-js-sdk": {
-      "version": "0.4.22",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.22.tgz",
-      "integrity": "sha512-JfDhIQFp9Wbfru7LP2Asg8Q5LAsczIJgAo/61HtumAW3zL5X2C0BWFUfuA/eaiyaBIH3YESey1rrSELuSArWvA==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
-      }
-    },
     "examples/vanilla-codemirror6": {
       "version": "0.0.0",
       "dependencies": {
@@ -414,7 +339,7 @@
         "@codemirror/state": "^6.1.2",
         "@codemirror/view": "^6.3.1",
         "codemirror": "^6.0.1",
-        "yorkie-js-sdk": "^0.4.22"
+        "yorkie-js-sdk": "^0.4.23"
       },
       "devDependencies": {
         "typescript": "^4.6.4",
@@ -470,21 +395,6 @@
         }
       }
     },
-    "examples/vanilla-codemirror6/node_modules/yorkie-js-sdk": {
-      "version": "0.4.22",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.22.tgz",
-      "integrity": "sha512-JfDhIQFp9Wbfru7LP2Asg8Q5LAsczIJgAo/61HtumAW3zL5X2C0BWFUfuA/eaiyaBIH3YESey1rrSELuSArWvA==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
-      }
-    },
     "examples/vanilla-quill": {
       "version": "0.0.0",
       "dependencies": {
@@ -492,7 +402,7 @@
         "quill": "^1.3.7",
         "quill-cursors": "^4.0.0",
         "quill-delta": "^5.0.0",
-        "yorkie-js-sdk": "^0.4.22"
+        "yorkie-js-sdk": "^0.4.23"
       },
       "devDependencies": {
         "@types/color-hash": "^1.0.2",
@@ -562,26 +472,11 @@
         }
       }
     },
-    "examples/vanilla-quill/node_modules/yorkie-js-sdk": {
-      "version": "0.4.22",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.22.tgz",
-      "integrity": "sha512-JfDhIQFp9Wbfru7LP2Asg8Q5LAsczIJgAo/61HtumAW3zL5X2C0BWFUfuA/eaiyaBIH3YESey1rrSELuSArWvA==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
-      }
-    },
     "examples/vuejs-kanban": {
       "version": "0.0.0",
       "dependencies": {
         "vue": "^3.2.41",
-        "yorkie-js-sdk": "^0.4.22"
+        "yorkie-js-sdk": "^0.4.23"
       },
       "devDependencies": {
         "@vitejs/plugin-vue": "^3.1.2",
@@ -635,21 +530,6 @@
         "terser": {
           "optional": true
         }
-      }
-    },
-    "examples/vuejs-kanban/node_modules/yorkie-js-sdk": {
-      "version": "0.4.22",
-      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.22.tgz",
-      "integrity": "sha512-JfDhIQFp9Wbfru7LP2Asg8Q5LAsczIJgAo/61HtumAW3zL5X2C0BWFUfuA/eaiyaBIH3YESey1rrSELuSArWvA==",
-      "dependencies": {
-        "@bufbuild/protobuf": "^1.6.0",
-        "@connectrpc/connect": "^1.2.0",
-        "@connectrpc/connect-web": "^1.2.0",
-        "long": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=7.1.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -9737,6 +9617,21 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/yorkie-js-sdk": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/yorkie-js-sdk/-/yorkie-js-sdk-0.4.23.tgz",
+      "integrity": "sha512-GWsFJHK4K7h8kMjHuT9PKTKtGVPhK63/j6+zu9G2mwK5WjqIsarNpj03idZW4QvwVkVqayHAzatVpNrcI9XJzQ==",
+      "dependencies": {
+        "@bufbuild/protobuf": "^1.6.0",
+        "@connectrpc/connect": "^1.2.0",
+        "@connectrpc/connect-web": "^1.2.0",
+        "long": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=7.1.0"
       }
     },
     "node_modules/z-schema": {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Update examples version to v0.4.23

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated `yorkie-js-sdk` dependency to version `0.4.23` across multiple examples (`nextjs-scheduler`, `profile-stack`, `react-tldraw`, `react-todomvc`, `simultaneous-cursors`, `vanilla-codemirror6`, `vanilla-quill`, `vuejs-kanban`).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->