### PR TITLE
Remove reattach test code

### DIFF
--- a/test/integration/document_test.ts
+++ b/test/integration/document_test.ts
@@ -51,12 +51,6 @@ describe('Document', function () {
     await client1.detach(doc1);
     await client2.detach(doc2);
 
-    await client1.attach(doc1, { syncMode: SyncMode.Manual });
-    await client2.attach(doc2, { syncMode: SyncMode.Manual });
-
-    await client1.detach(doc1);
-    await client2.detach(doc2);
-
     await client1.deactivate();
     await client2.deactivate();
   });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Remove reattach test code

Recently, when attaching a detached document, an ErrAlreadyDetached error was returned. This test code is no longer valid, so this commit removes it.

Related to https://github.com/yorkie-team/yorkie/issues/904, https://github.com/yorkie-team/yorkie/pull/908

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated integration tests for improved coverage and reliability.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->