### PR TITLE
Remove node from indexes during GC

### DIFF
--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -660,11 +660,17 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
   }
 
   /**
-   * `checkWeight` returns false when there is an incorrect weight node.
-   * for debugging purpose.
+   * `getTreeByIndex` returns the tree by index for debugging purpose.
    */
-  public checkWeight(): boolean {
-    return this.treeByIndex.checkWeight();
+  public getTreeByIndex(): SplayTree<T> {
+    return this.treeByIndex;
+  }
+
+  /**
+   * `getTreeByID` returns the tree by ID for debugging purpose.
+   */
+  public getTreeByID(): LLRBTree<RGATreeSplitNodeID, RGATreeSplitNode<T>> {
+    return this.treeByID;
   }
 
   /**

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -1012,6 +1012,9 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
    * `purge` physically purges the given node from RGATreeSplit.
    */
   public purge(node: RGATreeSplitNode<T>): void {
+    this.treeByIndex.delete(node);
+    this.treeByID.remove(node.getID());
+
     const prev = node.getPrev();
     const next = node.getNext();
     const insPrev = node.getInsPrev();

--- a/src/document/crdt/text.ts
+++ b/src/document/crdt/text.ts
@@ -25,6 +25,7 @@ import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
 import {
   RGATreeSplit,
   RGATreeSplitNode,
+  RGATreeSplitNodeID,
   RGATreeSplitPosRange,
   ValueChange,
 } from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';
@@ -32,6 +33,8 @@ import { escapeString } from '@yorkie-js-sdk/src/document/json/strings';
 import { parseObjectValues } from '@yorkie-js-sdk/src/util/object';
 import type * as Devtools from '@yorkie-js-sdk/src/devtools/types';
 import { GCChild, GCPair } from '@yorkie-js-sdk/src/document/crdt/gc';
+import { SplayTree } from '@yorkie-js-sdk/src/util/splay_tree';
+import { LLRBTree } from '@yorkie-js-sdk/src/util/llrb_tree';
 
 /**
  * `TextChangeType` is the type of TextChange.
@@ -361,11 +364,20 @@ export class CRDTText<A extends Indexable = Indexable> extends CRDTElement {
   }
 
   /**
-   * `checkWeight` returns false when there is an incorrect weight node.
-   * for debugging purpose.
+   * `getTreeByIndex` returns the tree by index for debugging.
    */
-  public checkWeight(): boolean {
-    return this.rgaTreeSplit.checkWeight();
+  public getTreeByIndex(): SplayTree<CRDTTextValue> {
+    return this.rgaTreeSplit.getTreeByIndex();
+  }
+
+  /**
+   * `getTreeByID` returns the tree by ID for debugging.
+   */
+  public getTreeByID(): LLRBTree<
+    RGATreeSplitNodeID,
+    RGATreeSplitNode<CRDTTextValue>
+  > {
+    return this.rgaTreeSplit.getTreeByID();
   }
 
   /**

--- a/src/document/json/text.ts
+++ b/src/document/json/text.ts
@@ -22,14 +22,22 @@ import {
 } from '@yorkie-js-sdk/src/document/time/ticket';
 import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
 import {
+  RGATreeSplitNode,
+  RGATreeSplitNodeID,
   RGATreeSplitPos,
   RGATreeSplitPosRange,
 } from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';
-import { CRDTText, TextValueType } from '@yorkie-js-sdk/src/document/crdt/text';
+import {
+  CRDTText,
+  CRDTTextValue,
+  TextValueType,
+} from '@yorkie-js-sdk/src/document/crdt/text';
 import { EditOperation } from '@yorkie-js-sdk/src/document/operation/edit_operation';
 import { StyleOperation } from '@yorkie-js-sdk/src/document/operation/style_operation';
 import { stringifyObjectValues } from '@yorkie-js-sdk/src/util/object';
 import type * as Devtools from '@yorkie-js-sdk/src/devtools/types';
+import { SplayTree } from '@yorkie-js-sdk/src/util/splay_tree';
+import { LLRBTree } from '@yorkie-js-sdk/src/util/llrb_tree';
 
 /**
  * `TextPosStruct` represents the structure of RGATreeSplitPos.
@@ -256,11 +264,20 @@ export class Text<A extends Indexable = Indexable> {
   }
 
   /**
-   * `checkWeight` returns false when there is an incorrect weight node.
-   * for debugging purpose.
+   * `getTreeByIndex` returns IndexTree of the text for testing purpose.
    */
-  public checkWeight(): boolean {
-    return this.text!.checkWeight();
+  public getTreeByIndex(): SplayTree<CRDTTextValue> {
+    return this.text!.getTreeByIndex();
+  }
+
+  /**
+   * `getTreeByID` returns IDTree of the text for testing purpose.
+   */
+  public getTreeByID(): LLRBTree<
+    RGATreeSplitNodeID,
+    RGATreeSplitNode<CRDTTextValue>
+  > {
+    return this.text!.getTreeByID();
   }
 
   /**

--- a/test/integration/text_test.ts
+++ b/test/integration/text_test.ts
@@ -405,8 +405,8 @@ describe('Text', function () {
       await c2.sync();
       await c1.sync();
 
-      // assert.isOk(d1.getRoot().k1.checkWeight());
-      // assert.isOk(d2.getRoot().k1.checkWeight());
+      // assert.isOk(d1.getRoot().k1.getTreeByIndex().checkWeight());
+      // assert.isOk(d2.getRoot().k1.getTreeByIndex().checkWeight());
     }, task.name);
   });
 });

--- a/test/integration/text_test.ts
+++ b/test/integration/text_test.ts
@@ -405,8 +405,8 @@ describe('Text', function () {
       await c2.sync();
       await c1.sync();
 
-      // assert.isOk(d1.getRoot().k1.getTreeByIndex().checkWeight());
-      // assert.isOk(d2.getRoot().k1.getTreeByIndex().checkWeight());
+      assert.isOk(d1.getRoot().k1.getTreeByIndex().checkWeight());
+      assert.isOk(d2.getRoot().k1.getTreeByIndex().checkWeight());
     }, task.name);
   });
 });

--- a/test/unit/document/document_test.ts
+++ b/test/unit/document/document_test.ts
@@ -1238,6 +1238,21 @@ describe.sequential('Document', function () {
     assert.equal(0, doc.getGarbageLen());
   });
 
+  it('should purge node from indexes during GC', function () {
+    const doc = new Document<{ k1: Text }>('test-doc');
+    doc.update((root) => (root.k1 = new Text()));
+    assert.equal(doc.getRoot().k1.getTreeByID().size(), 1);
+
+    doc.update((root) => root.k1.edit(0, 0, 'ABC'));
+    assert.equal(doc.getRoot().k1.getTreeByID().size(), 2);
+
+    doc.update((root) => root.k1.edit(1, 3, ''));
+    assert.equal(doc.getRoot().k1.getTreeByID().size(), 3);
+
+    doc.garbageCollect(MaxTimeTicket);
+    assert.equal(doc.getRoot().k1.getTreeByID().size(), 2);
+  });
+
   it('should handle escape string for strings containing single quotes', function () {
     const doc = new Document<{ [key: string]: any }>('test-doc');
     doc.update((root) => (root.str = `I'm yorkie`));


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Remove node from indexes during GC

While improving GC structure, we missed removing nodes from internal
indexes of Text when purging tombstones.

https://github.com/yorkie-team/yorkie/pull/866

This commit fixes this issue.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Addresses yorkie-team/yorkie#914
Related to https://github.com/yorkie-team/yorkie/pull/866

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved debugging capabilities by adding new methods to access tree structures within the document.

- **Tests**
  - Updated integration tests to reflect changes in method calls for weight checking.
  - Added unit tests to ensure proper node purging during garbage collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->