### PR TITLE
Add taskQueue to handle each request one by one

### DIFF
--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -1,4 +1,4 @@
-import { describe, it, assert, vi, afterEach } from 'vitest';
+import { describe, it, assert, vi, afterEach, expect } from 'vitest';
 
 import yorkie, {
   Counter,
@@ -747,5 +747,20 @@ describe.sequential('Client', function () {
     unsub2();
     await c1.deactivate();
     await c2.deactivate();
+  });
+
+  it('Should handle each request one by one', async function ({ task }) {
+    for (let i = 0; i < 10; i++) {
+      const cli = new yorkie.Client(testRPCAddr);
+      await cli.activate();
+
+      const doc = new yorkie.Document<{ t: Text }>(
+        toDocKey(`${task.name}-${new Date().getTime()}-{i}`),
+      );
+      await cli.attach(doc);
+
+      expect(cli.detach(doc)).resolves.toBeDefined();
+      await cli.deactivate();
+    }
   });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Add taskQueue to handle each request one by one

When using JS SDK in environments like React, it is possible to assign Client to React Components. However, when Component Unmount is executed by moving location, resources like `yorkie.Client` need to be `deactivated` or `yorkie.Document` need to be `detached`. The challenge arises when it is not possible to await asynchronous requests while deactivating one by one due to some reasons.

To address this issue, this commit introduces a task queue in `Client` to handle all requests one by one, ensuring proper deactivation or detachment.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Addresses https://github.com/yorkie-team/codepair/issues/220

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced improved task management for better execution flow.

- **Tests**
  - Added a new test case to ensure sequential handling of requests in the `Client` class.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->