### PR TITLE
Handle retry for syncLoop and watchLoop

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -316,6 +316,7 @@
           const codemirror = CodeMirror.fromTextArea(textarea, {
             lineNumbers: true,
           });
+          yorkie.setLogLevel(yorkie.LogLevel.Debug);
           devtool.setCodeMirror(codemirror);
 
           // 02-1. create client with RPCAddr.

--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -792,10 +792,12 @@ export class Client {
     }
 
     // NOTE(hackerwins): These errors are retryable.
-    // - Unknown: The error is unknown. It is retryable because it is unknown.
-    // - ResourceExhausted: The resource is exhausted. It is retryable because the resource may be available.
-    // - Unavailable: The server is unavailable. It is retryable because the server may be down.
+    // Connect guide indicates that for error codes like `ResourceExhausted` and
+    // `Unavailable`, retries should be attempted following their guidelines.
+    // Additionally, `Unknown` and `Canceled` are added separately as it
+    // typically occurs when the server is stopped.
     const retryables = [
+      ConnectErrorCode.Canceled,
       ConnectErrorCode.Unknown,
       ConnectErrorCode.ResourceExhausted,
       ConnectErrorCode.Unavailable,

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -25,6 +25,7 @@ import * as Devtools from '@yorkie-js-sdk/src/devtools/types';
 export {
   Client,
   ClientStatus,
+  ClientCondition,
   SyncMode,
   type ClientOptions,
 } from '@yorkie-js-sdk/src/client/client';
@@ -112,7 +113,7 @@ export {
 export { Change } from '@yorkie-js-sdk/src/document/change/change';
 export { converter } from '@yorkie-js-sdk/src/api/converter';
 
-export type { LogLevel } from '@yorkie-js-sdk/src/util/logger';
+export { LogLevel } from '@yorkie-js-sdk/src/util/logger';
 export { setLogLevel } from '@yorkie-js-sdk/src/util/logger';
 
 export {

--- a/src/yorkie.ts
+++ b/src/yorkie.ts
@@ -113,8 +113,8 @@ export {
 export { Change } from '@yorkie-js-sdk/src/document/change/change';
 export { converter } from '@yorkie-js-sdk/src/api/converter';
 
-export { LogLevel } from '@yorkie-js-sdk/src/util/logger';
-export { setLogLevel } from '@yorkie-js-sdk/src/util/logger';
+import { LogLevel, setLogLevel } from '@yorkie-js-sdk/src/util/logger';
+export { LogLevel, setLogLevel } from '@yorkie-js-sdk/src/util/logger';
 
 export {
   EventSourceDevPanel,
@@ -143,6 +143,8 @@ export default {
   Text,
   Counter,
   Tree,
+  LogLevel,
+  setLogLevel,
   IntType: CounterType.IntegerCnt,
   LongType: CounterType.LongCnt,
 };
@@ -156,6 +158,8 @@ if (typeof globalThis !== 'undefined') {
     Text,
     Counter,
     Tree,
+    LogLevel,
+    setLogLevel,
     IntType: CounterType.IntegerCnt,
     LongType: CounterType.LongCnt,
   };


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Handle retry for syncLoop and watchLoop based on ConnectError

This commit addresses the need to retry the `syncLoop` and `watchLoop` functions based on different error codes from `ConnectError`.

The `Connect` guide indicates that for error codes like `ResourceExhausted` and `Unavailable`, retries should be attempted following their guidelines: [Error Codes](https://connectrpc.com/docs/protocol/#error-codes).

Additionally, the `Unknown` and `Canceled` are added separately as it typically occurs when the server is stopped unexpectedly.

To enhance visibility into the status of `syncLoop` and `watchLoop`, `Condition`s has been added.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for network failure retry logic in the client.
  - Introduced `ClientCondition` for better client state management.

- **Improvements**
  - Log level is now configurable and set to `Debug` by default for better troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->