### PR TITLE
Remove vitest-environment-custom-jsdom from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,8 +65,7 @@
     "vite-plugin-commonjs": "^0.10.1",
     "vite-plugin-dts": "^3.9.1",
     "vite-tsconfig-paths": "^4.2.1",
-    "vitest": "^0.34.5",
-    "vitest-environment-custom-jsdom": "file:test/vitest/env"
+    "vitest": "^0.34.5"
   },
   "dependencies": {
     "@bufbuild/protobuf": "^1.6.0",


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

`vitest-environment-custom-jsdom` is removed in #864, but it remains in devDependencies. So we have to remove it.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed an unused test dependency from the project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->