### PR TITLE
Handle local changes correctly when receiving snapshot

### DIFF
--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -1072,6 +1072,14 @@ export class Document<T, P extends Indexable = Indexable> {
       this.localChanges.shift();
     }
 
+    // NOTE(hackerwins): If the document has local changes, we need to apply
+    // them after applying the snapshot. We need to treat the local changes
+    // as remote changes because the application should apply the local
+    // changes to their own document.
+    if (pack.hasSnapshot()) {
+      this.applyChanges(this.localChanges, OpSource.Remote);
+    }
+
     // 03. Update the checkpoint.
     this.checkpoint = this.checkpoint.forward(pack.getCheckpoint());
 

--- a/test/integration/snapshot_test.ts
+++ b/test/integration/snapshot_test.ts
@@ -38,8 +38,8 @@ describe('Snapshot', function () {
       await c1.sync();
       await c2.sync();
 
-      // 01. Updates 700 changes over snapshot threshold by c1.
-      for (let idx = 0; idx < 700; idx++) {
+      // 01. Updates 500 changes over snapshot threshold by c1.
+      for (let idx = 0; idx < 500; idx++) {
         d1.update((root) => {
           root.k1.edit(idx, idx, 'x');
         });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Handle local changes correctly when receiving snapshot

This commit addresses the issue where unsent local changes were
missing from `Document.Root` when receiving a snapshot from the server.

To resolve this problem, the local changes are now applied to
`Document.Root` after applying the snapshot.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Ensured local changes are applied correctly as remote changes when a document has a snapshot.

- **Tests**
  - Added a test case to verify handling of local changes with snapshots.
  - Adjusted the number of changes over the snapshot threshold in tests for better accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->