### PR TITLE
Adjust Default LogLevel to Warn

### DIFF
--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -23,7 +23,7 @@ export enum LogLevel {
   Fatal,
 }
 
-let level = LogLevel.Info;
+let level = LogLevel.Error;
 
 /**
  * `setLogLevel` sets log level.

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -23,7 +23,7 @@ export enum LogLevel {
   Fatal,
 }
 
-let level = LogLevel.Error;
+let level = LogLevel.Warn;
 
 /**
  * `setLogLevel` sets log level.


### PR DESCRIPTION

<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This pull request adjusts default loglevel from `Info` to `Error`. Currently, various events such as PushPull are being logged, which may not be necessary for developers using the yorkie-js-sdk. By adjusting default loglevel, we can reduce the verbosity of these logs and make them more relevant for developers.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #851

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated default log level from 'Info' to 'Warn' for more pertinent log messaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->