### PR TITLE
Add Root-Only Filter Feature in History Tab

### DIFF
--- a/tools/devtools/src/devtools/contexts/YorkieSource.tsx
+++ b/tools/devtools/src/devtools/contexts/YorkieSource.tsx
@@ -173,34 +173,29 @@ export function useTransactionEvents() {
     );
   }
 
-  // mark presence events as null in the original events
-  const presenceMarkedEvents = useMemo(() => {
-    if (!hidePresenceEvents) {
-      return events;
-    }
-
+  // create an enhanced events with metadata
+  const enhancedEvents = useMemo(() => {
     return events.map((event) => {
-      if (getTransactionEventType(event) === TransactionEventType.Presence) {
-        return null;
-      }
+      const transactionEventType = getTransactionEventType(event);
 
-      return event;
+      return {
+        event,
+        transactionEventType,
+        isFiltered:
+          hidePresenceEvents &&
+          transactionEventType === TransactionEventType.Presence,
+      };
     });
-  }, [events, hidePresenceEvents]);
+  }, [hidePresenceEvents, events]);
 
   // filter out presence events from the original events
-  const presenceFilteredEvents = useMemo(
-    () =>
-      events.filter(
-        (event) =>
-          getTransactionEventType(event) === TransactionEventType.Document,
-      ),
-    [hidePresenceEvents, events],
-  );
+  const presenceFilteredEvents = useMemo(() => {
+    if (!hidePresenceEvents) return enhancedEvents;
+    return enhancedEvents.filter((e) => !e.isFiltered);
+  }, [enhancedEvents]);
 
   return {
-    originalEvents: events,
-    presenceMarkedEvents,
+    originalEvents: enhancedEvents,
     presenceFilteredEvents,
     hidePresenceEvents,
     setHidePresenceEvents,

--- a/tools/devtools/src/devtools/contexts/YorkieSource.tsx
+++ b/tools/devtools/src/devtools/contexts/YorkieSource.tsx
@@ -173,18 +173,35 @@ export function useTransactionEvents() {
     );
   }
 
-  const filteredEvents = useMemo(
+  // mark presence events as null in the original events
+  const presenceMarkedEvents = useMemo(() => {
+    if (!hidePresenceEvents) {
+      return events;
+    }
+
+    return events.map((event) => {
+      if (getTransactionEventType(event) === TransactionEventType.Presence) {
+        return null;
+      }
+
+      return event;
+    });
+  }, [events, hidePresenceEvents]);
+
+  // filter out presence events from the original events
+  const presenceFilteredEvents = useMemo(
     () =>
       events.filter(
         (event) =>
-          !hidePresenceEvents ||
           getTransactionEventType(event) === TransactionEventType.Document,
       ),
-    [events, hidePresenceEvents],
+    [hidePresenceEvents, events],
   );
 
   return {
-    events: filteredEvents,
+    originalEvents: events,
+    presenceMarkedEvents,
+    presenceFilteredEvents,
     hidePresenceEvents,
     setHidePresenceEvents,
   };

--- a/tools/devtools/src/devtools/panel/index.tsx
+++ b/tools/devtools/src/devtools/panel/index.tsx
@@ -28,16 +28,12 @@ import {
 } from '../contexts/YorkieSource';
 import { Document } from '../tabs/Document';
 import { Presence } from '../tabs/Presence';
-import {
-  History,
-  TransactionEventType,
-  getTransactionEventType,
-} from '../tabs/History';
+import { History } from '../tabs/History';
 import { Separator } from '../components/ResizableSeparator';
 
 const Panel = () => {
   const currentDocKey = useCurrentDocKey();
-  const events = useTransactionEvents();
+  const { events } = useTransactionEvents();
   const [, setDoc] = useYorkieDoc();
   const [selectedEventIndexInfo, setSelectedEventIndexInfo] = useState({
     index: null,
@@ -62,25 +58,8 @@ const Panel = () => {
   });
   const [hidePresenceTab, setHidePresenceTab] = useState(false);
 
-  // filter out presence events in History tab
-  const [hidePresenceEvent, setHidePresenceEvent] = useState(false);
-  const filteredEvents = useMemo(
-    () =>
-      events.filter((event) => {
-        if (!hidePresenceEvent) {
-          return true;
-        }
-
-        if (getTransactionEventType(event) === TransactionEventType.Presence) {
-          return false;
-        }
-        return true;
-      }),
-    [events, hidePresenceEvent],
-  );
-
   useEffect(() => {
-    if (filteredEvents.length === 0) {
+    if (events.length === 0) {
       // NOTE(chacha912): If there are no events, reset the SelectedEventIndexInfo.
       setSelectedEventIndexInfo({
         index: null,
@@ -91,21 +70,21 @@ const Panel = () => {
 
     if (selectedEventIndexInfo.isLast) {
       setSelectedEventIndexInfo({
-        index: filteredEvents.length - 1,
+        index: events.length - 1,
         isLast: true,
       });
     }
-  }, [filteredEvents]);
+  }, [events]);
 
   useEffect(() => {
     if (selectedEventIndexInfo.index === null) return;
     const doc = new yorkie.Document(currentDocKey);
     for (let i = 0; i <= selectedEventIndexInfo.index; i++) {
-      doc.applyTransactionEvent(filteredEvents[i]);
+      doc.applyTransactionEvent(events[i]);
     }
 
     setDoc(doc);
-    setSelectedEvent(filteredEvents[selectedEventIndexInfo.index]);
+    setSelectedEvent(events[selectedEventIndexInfo.index]);
   }, [selectedEventIndexInfo]);
 
   if (!currentDocKey) {
@@ -137,9 +116,6 @@ const Panel = () => {
         selectedEvent={selectedEvent}
         selectedEventIndexInfo={selectedEventIndexInfo}
         setSelectedEventIndexInfo={setSelectedEventIndexInfo}
-        hidePresenceEvent={hidePresenceEvent}
-        setHidePresenceEvent={setHidePresenceEvent}
-        events={filteredEvents}
       />
 
       <Separator

--- a/tools/devtools/src/devtools/panel/index.tsx
+++ b/tools/devtools/src/devtools/panel/index.tsx
@@ -60,6 +60,7 @@ const Panel = () => {
     axis: 'x',
     initial: 300,
   });
+  const [hidePresenceTab, setHidePresenceTab] = useState(false);
 
   // filter out presence events in History tab
   const [hidePresenceEvent, setHidePresenceEvent] = useState(false);
@@ -151,19 +152,29 @@ const Panel = () => {
         <SelectedNodeProvider>
           <Document
             style={{
-              width: documentW,
+              width: hidePresenceTab ? '100%' : documentW,
+              maxWidth: hidePresenceTab ? '100%' : '90%',
+              borderRight: hidePresenceTab
+                ? 'none'
+                : '1px solid var(--gray-300)',
             }}
+            hidePresenceTab={hidePresenceTab}
+            setHidePresenceTab={setHidePresenceTab}
           />
         </SelectedNodeProvider>
 
-        <Separator
-          isDragging={isDocumentDragging}
-          {...documentSeparatorProps}
-        />
+        {!hidePresenceTab && (
+          <>
+            <Separator
+              isDragging={isDocumentDragging}
+              {...documentSeparatorProps}
+            />
 
-        <SelectedPresenceProvider>
-          <Presence />
-        </SelectedPresenceProvider>
+            <SelectedPresenceProvider>
+              <Presence />
+            </SelectedPresenceProvider>
+          </>
+        )}
       </div>
     </div>
   );

--- a/tools/devtools/src/devtools/panel/index.tsx
+++ b/tools/devtools/src/devtools/panel/index.tsx
@@ -33,12 +33,8 @@ import { Separator } from '../components/ResizableSeparator';
 
 const Panel = () => {
   const currentDocKey = useCurrentDocKey();
-  const {
-    originalEvents,
-    presenceMarkedEvents,
-    presenceFilteredEvents,
-    hidePresenceEvents,
-  } = useTransactionEvents();
+  const { originalEvents, presenceFilteredEvents, hidePresenceEvents } =
+    useTransactionEvents();
   const [, setDoc] = useYorkieDoc();
   const [selectedEventIndexInfo, setSelectedEventIndexInfo] = useState({
     index: null,
@@ -90,20 +86,17 @@ const Panel = () => {
     let eventIndex = 0;
     let filteredEventIndex = 0;
 
-    while (
-      eventIndex < originalEvents.length &&
-      filteredEventIndex <= selectedEventIndexInfo.index
-    ) {
-      if (presenceMarkedEvents[eventIndex] !== null) {
+    while (filteredEventIndex <= selectedEventIndexInfo.index) {
+      if (!originalEvents[eventIndex].isFiltered) {
         filteredEventIndex++;
       }
 
-      doc.applyTransactionEvent(originalEvents[eventIndex]);
+      doc.applyTransactionEvent(originalEvents[eventIndex].event);
       eventIndex++;
     }
 
     setDoc(doc);
-    setSelectedEvent(events[selectedEventIndexInfo.index]);
+    setSelectedEvent(events[selectedEventIndexInfo.index].event);
   }, [selectedEventIndexInfo]);
 
   if (!currentDocKey) {

--- a/tools/devtools/src/devtools/panel/index.tsx
+++ b/tools/devtools/src/devtools/panel/index.tsx
@@ -15,7 +15,7 @@
  */
 
 import { createRoot } from 'react-dom/client';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import yorkie from 'yorkie-js-sdk';
 import { useResizable } from 'react-resizable-layout';
 import { SelectedNodeProvider } from '../contexts/SelectedNode';
@@ -33,7 +33,12 @@ import { Separator } from '../components/ResizableSeparator';
 
 const Panel = () => {
   const currentDocKey = useCurrentDocKey();
-  const { events } = useTransactionEvents();
+  const {
+    originalEvents,
+    presenceMarkedEvents,
+    presenceFilteredEvents,
+    hidePresenceEvents,
+  } = useTransactionEvents();
   const [, setDoc] = useYorkieDoc();
   const [selectedEventIndexInfo, setSelectedEventIndexInfo] = useState({
     index: null,
@@ -57,6 +62,7 @@ const Panel = () => {
     initial: 300,
   });
   const [hidePresenceTab, setHidePresenceTab] = useState(false);
+  const events = hidePresenceEvents ? presenceFilteredEvents : originalEvents;
 
   useEffect(() => {
     if (events.length === 0) {
@@ -78,9 +84,22 @@ const Panel = () => {
 
   useEffect(() => {
     if (selectedEventIndexInfo.index === null) return;
+
     const doc = new yorkie.Document(currentDocKey);
-    for (let i = 0; i <= selectedEventIndexInfo.index; i++) {
-      doc.applyTransactionEvent(events[i]);
+
+    let eventIndex = 0;
+    let filteredEventIndex = 0;
+
+    while (
+      eventIndex < originalEvents.length &&
+      filteredEventIndex <= selectedEventIndexInfo.index
+    ) {
+      if (presenceMarkedEvents[eventIndex] !== null) {
+        filteredEventIndex++;
+      }
+
+      doc.applyTransactionEvent(originalEvents[eventIndex]);
+      eventIndex++;
     }
 
     setDoc(doc);

--- a/tools/devtools/src/devtools/panel/slider.css
+++ b/tools/devtools/src/devtools/panel/slider.css
@@ -91,3 +91,7 @@
 .rc-slider-mark-text-active .mark-remote {
   color: var(--blue-0);
 }
+
+.history-slider-wrap[data-length='1'] .rc-slider-rail {
+  display: none;
+}

--- a/tools/devtools/src/devtools/panel/styles.css
+++ b/tools/devtools/src/devtools/panel/styles.css
@@ -83,13 +83,13 @@
   width: 100%;
 }
 
-.devtools-history-toolbar {
+.devtools-tab-toolbar {
   display: flex;
   justify-content: space-between;
   align-items: center;
 }
 
-.toggle-history-btn {
+.toggle-tab-btn {
   margin-left: 4px;
   padding: 2px 6px;
   border: 1px solid var(--gray-300);
@@ -100,7 +100,7 @@
   font-size: 10px;
 }
 
-.toggle-history-btn:hover {
+.toggle-tab-btn:hover {
   background: var(--gray-200);
 }
 

--- a/tools/devtools/src/devtools/panel/styles.css
+++ b/tools/devtools/src/devtools/panel/styles.css
@@ -152,9 +152,6 @@
 
 .yorkie-root {
   min-width: 10%;
-  max-width: 90%;
-  width: 60%;
-  border-right: 1px solid var(--gray-300);
 }
 
 .yorkie-presence {

--- a/tools/devtools/src/devtools/tabs/Document.tsx
+++ b/tools/devtools/src/devtools/tabs/Document.tsx
@@ -68,7 +68,7 @@ export function Document({ style, hidePresenceTab, setHidePresenceTab }) {
             setHidePresenceTab((v: boolean) => !v);
           }}
         >
-          {hidePresenceTab ? '⏴' : '⏵'}
+          {hidePresenceTab ? '◂' : '▸'}
         </button>
       </div>
 

--- a/tools/devtools/src/devtools/tabs/Document.tsx
+++ b/tools/devtools/src/devtools/tabs/Document.tsx
@@ -23,7 +23,7 @@ import { useSelectedNode } from '../contexts/SelectedNode';
 import { useCurrentDocKey, useYorkieDoc } from '../contexts/YorkieSource';
 import { CloseIcon } from '../icons';
 
-export function Document({ style }) {
+export function Document({ style, hidePresenceTab, setHidePresenceTab }) {
   const currentDocKey = useCurrentDocKey();
   const [doc] = useYorkieDoc();
   const [selectedNode, setSelectedNode] = useSelectedNode();
@@ -60,7 +60,18 @@ export function Document({ style }) {
 
   return (
     <div className="yorkie-root content-wrap" style={{ ...style }}>
-      <div className="title">{currentDocKey || 'Document'}</div>
+      <div className="devtools-tab-toolbar">
+        <span className="title">{currentDocKey || 'Document'}</span>
+        <button
+          className="toggle-tab-btn"
+          onClick={() => {
+            setHidePresenceTab((v: boolean) => !v);
+          }}
+        >
+          {hidePresenceTab ? '⏴' : '⏵'}
+        </button>
+      </div>
+
       <div className="content">
         <RootTree root={root} />
         {selectedNode && (

--- a/tools/devtools/src/devtools/tabs/History.tsx
+++ b/tools/devtools/src/devtools/tabs/History.tsx
@@ -218,7 +218,7 @@ export function History({
                 marks={sliderMarks}
                 max={events.length - 1}
                 value={selectedEventIndexInfo.index}
-                step={0}
+                step={1}
                 onChange={handleSliderEvent}
                 style={{
                   width: events.length * SLIDER_MARK_WIDTH + 'px',

--- a/tools/devtools/src/devtools/tabs/History.tsx
+++ b/tools/devtools/src/devtools/tabs/History.tsx
@@ -21,7 +21,6 @@ import { JSONView } from '../components/JsonView';
 import { CursorIcon, DocumentIcon } from '../icons';
 import {
   TransactionEventType,
-  getTransactionEventType,
   useTransactionEvents,
 } from '../contexts/YorkieSource';
 
@@ -109,8 +108,8 @@ export function History({
 
     const marks = {};
     for (const [index, event] of events.entries()) {
-      const source = event[0].source;
-      const transactionEventType = getTransactionEventType(event);
+      const source = event.event[0].source;
+      const transactionEventType = event.transactionEventType;
 
       marks[index] = (
         <span

--- a/tools/devtools/src/devtools/tabs/History.tsx
+++ b/tools/devtools/src/devtools/tabs/History.tsx
@@ -197,7 +197,14 @@ export function History({
                 >
                   ⇥
                 </button>
-                <button onClick={toggleHidePresenceEvent}>
+                <button
+                  onClick={toggleHidePresenceEvent}
+                  title={
+                    hidePresenceEvents
+                      ? 'Show only root changes'
+                      : 'Show all changes'
+                  }
+                >
                   {hidePresenceEvents ? '¥' : 'Y'}
                 </button>
               </span>

--- a/tools/devtools/src/devtools/tabs/History.tsx
+++ b/tools/devtools/src/devtools/tabs/History.tsx
@@ -149,11 +149,11 @@ export function History({
       }}
     >
       <div className="content-wrap">
-        <div className="devtools-history-toolbar">
+        <div className="devtools-tab-toolbar">
           <span className="title">
             History
             <button
-              className="toggle-history-btn"
+              className="toggle-tab-btn"
               onClick={() => {
                 setOpenHistory((v) => !v);
               }}

--- a/tools/devtools/src/devtools/tabs/History.tsx
+++ b/tools/devtools/src/devtools/tabs/History.tsx
@@ -203,6 +203,8 @@ export function History({
             <div
               ref={scrollRef}
               style={{ width: '100%', overflowX: 'auto', minHeight: '46px' }}
+              className="history-slider-wrap"
+              data-length={events.length}
             >
               <Slider
                 dots

--- a/tools/devtools/src/devtools/tabs/History.tsx
+++ b/tools/devtools/src/devtools/tabs/History.tsx
@@ -71,8 +71,14 @@ export function History({
   const [openHistory, setOpenHistory] = useState(false);
   const [sliderMarks, setSliderMarks] = useState({});
   const scrollRef = useRef(null);
-  const { events, hidePresenceEvents, setHidePresenceEvents } =
-    useTransactionEvents();
+  const {
+    originalEvents,
+    presenceFilteredEvents,
+    hidePresenceEvents,
+    setHidePresenceEvents,
+  } = useTransactionEvents();
+
+  const events = hidePresenceEvents ? presenceFilteredEvents : originalEvents;
 
   const handleSliderEvent = (value) => {
     setSelectedEventIndexInfo({

--- a/tools/devtools/src/devtools/tabs/History.tsx
+++ b/tools/devtools/src/devtools/tabs/History.tsx
@@ -19,6 +19,11 @@ import { DocEventType, Change, type TransactionEvent } from 'yorkie-js-sdk';
 import Slider from 'rc-slider';
 import { JSONView } from '../components/JsonView';
 import { CursorIcon, DocumentIcon } from '../icons';
+import {
+  TransactionEventType,
+  getTransactionEventType,
+  useTransactionEvents,
+} from '../contexts/YorkieSource';
 
 const SLIDER_MARK_WIDTH = 24;
 
@@ -57,40 +62,17 @@ const getEventInfo = (event: TransactionEvent) => {
   return info;
 };
 
-export enum TransactionEventType {
-  Document = 'document',
-  Presence = 'presence',
-}
-
-export const getTransactionEventType = (
-  event: TransactionEvent,
-): TransactionEventType => {
-  for (const docEvent of event) {
-    if (
-      docEvent.type === DocEventType.StatusChanged ||
-      docEvent.type === DocEventType.Snapshot ||
-      docEvent.type === DocEventType.LocalChange ||
-      docEvent.type === DocEventType.RemoteChange
-    ) {
-      return TransactionEventType.Document;
-    }
-  }
-
-  return TransactionEventType.Presence;
-};
-
 export function History({
   style,
   selectedEvent,
   selectedEventIndexInfo,
   setSelectedEventIndexInfo,
-  hidePresenceEvent,
-  setHidePresenceEvent,
-  events,
 }) {
   const [openHistory, setOpenHistory] = useState(false);
   const [sliderMarks, setSliderMarks] = useState({});
   const scrollRef = useRef(null);
+  const { events, hidePresenceEvents, setHidePresenceEvents } =
+    useTransactionEvents();
 
   const handleSliderEvent = (value) => {
     setSelectedEventIndexInfo({
@@ -104,7 +86,7 @@ export function History({
       index: null,
       isLast: true,
     });
-    setHidePresenceEvent((prev: boolean) => !prev);
+    setHidePresenceEvents((prev: boolean) => !prev);
   };
 
   useEffect(() => {
@@ -210,7 +192,7 @@ export function History({
                   ⇥
                 </button>
                 <button onClick={toggleHidePresenceEvent}>
-                  {hidePresenceEvent ? '¥' : 'Y'}
+                  {hidePresenceEvents ? '¥' : 'Y'}
                 </button>
               </span>
             </span>


### PR DESCRIPTION


<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This pull request adds a Root-Only Filter in the History tab, allowing users to focus exclusively on changes to the Root of the Document. Currently, the History tab logs both content changes and Presence events (such as cursor movements), which can result in a high volume of events that may not always be relevant for debugging content changes.

#### Any background context you want to provide?



#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #854

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a button in the History tab to toggle the visibility of the Presence tab.
	- Enhanced the Document component to dynamically manage the visibility of the Presence tab.
	- Added categorization for transaction events in the History component.
	- Improved context management to filter transaction events based on user preferences.

- **Style**
	- Updated layout and appearance by removing specific width and border styles from elements.
	- Renamed classes for improved clarity in the styles.
	- Adjusted the display of the slider component to reduce visual clutter when only one history item is present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->