### PR TITLE
Improve performance for creating crdt.TreeNode

### DIFF
--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -1064,16 +1064,12 @@ function fromTreeNodes(
   }
 
   const root = nodes[nodes.length - 1];
+  const depthTable = new Map<number, CRDTTreeNode>();
+  depthTable.set(pbTreeNodes[nodes.length - 1].depth, nodes[nodes.length - 1]);
   for (let i = nodes.length - 2; i >= 0; i--) {
-    let parent: CRDTTreeNode;
-    for (let j = i + 1; j < nodes.length; j++) {
-      if (pbTreeNodes[i].depth - 1 === pbTreeNodes[j].depth) {
-        parent = nodes[j];
-        break;
-      }
-    }
-
+    const parent = depthTable.get(pbTreeNodes[i].depth - 1);
     parent!.prepend(nodes[i]);
+    depthTable.set(pbTreeNodes[i].depth, nodes[i]);
   }
 
   root.updateDescendantsSize();
@@ -1593,6 +1589,8 @@ export const converter = {
   toChangePack,
   fromChangePack,
   fromChanges,
+  toTreeNodes,
+  fromTreeNodes,
   objectToBytes,
   bytesToObject,
   bytesToSnapshot,

--- a/test/bench/tree.bench.ts
+++ b/test/bench/tree.bench.ts
@@ -1,8 +1,8 @@
-import { Document, Tree } from '@yorkie-js-sdk/src/yorkie';
+import { converter, Document, Tree, TreeNode } from '@yorkie-js-sdk/src/yorkie';
 import { MaxTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { describe, bench, assert } from 'vitest';
 
-const benchmarkTree = (size: number) => {
+const benchmarkTreeEdit = (size: number) => {
   const doc = new Document<{ tree: Tree }>('test-doc');
 
   doc.update((root) => {
@@ -16,6 +16,7 @@ const benchmarkTree = (size: number) => {
     }
   });
 };
+
 const benchmarkTreeDeleteAll = (size: number) => {
   const doc = new Document<{ tree: Tree }>('test-doc');
 
@@ -35,6 +36,7 @@ const benchmarkTreeDeleteAll = (size: number) => {
   }, 'delete them');
   assert.equal(doc.getRoot().tree.toXML(), `<doc><p></p></doc>`);
 };
+
 const benchmarkTreeSplitGC = (size: number) => {
   const doc = new Document<{ tree: Tree }>('test-doc');
 
@@ -58,6 +60,7 @@ const benchmarkTreeSplitGC = (size: number) => {
   const empty = 0;
   assert.equal(empty, doc.getGarbageLen());
 };
+
 const benchmarkTreeEditGC = (size: number) => {
   const doc = new Document<{ tree: Tree }>('test-doc');
 
@@ -85,27 +88,48 @@ const benchmarkTreeEditGC = (size: number) => {
   assert.equal(empty, doc.getGarbageLen());
 };
 
-describe('tree', () => {
-  bench('tree 100', () => {
-    benchmarkTree(100);
+const benchmarkTreeConvert = (size: number) => {
+  const doc = new Document<{ tree: Tree }>('test-doc');
+  doc.update((root) => {
+    const children: Array<TreeNode> = [];
+    for (let i = 1; i <= size; i++) {
+      children.push({ type: 'text', value: 'a' });
+    }
+
+    root.tree = new Tree({
+      type: 'doc',
+      children: [{ type: 'p', children: children }],
+    });
   });
 
-  bench('tree 1000', () => {
-    benchmarkTree(1000);
+  const root = doc.getRoot().tree.getIndexTree().getRoot();
+  const pbTreeNodes = converter.toTreeNodes(root);
+  converter.fromTreeNodes(pbTreeNodes);
+};
+
+describe('tree.edit', () => {
+  bench('tree.edit 100', () => {
+    benchmarkTreeEdit(100);
   });
 
-  bench('tree 100', () => {
-    benchmarkTree(100);
+  bench('tree.edit 1000', () => {
+    benchmarkTreeEdit(1000);
   });
 
-  bench('tree 1000', () => {
-    benchmarkTree(1000);
+  bench('tree.edit 100', () => {
+    benchmarkTreeEdit(100);
+  });
+
+  bench('tree.edit 1000', () => {
+    benchmarkTreeEdit(1000);
   });
 
   bench('tree delete all 1000', () => {
     benchmarkTreeDeleteAll(1000);
   });
+});
 
+describe('tree GC', () => {
   bench('tree split GC 100', () => {
     benchmarkTreeSplitGC(100);
   });
@@ -120,5 +144,19 @@ describe('tree', () => {
 
   bench('tree edit GC 1000', () => {
     benchmarkTreeEditGC(1000);
+  });
+});
+
+describe('tree convert', () => {
+  bench('tree convert from/to Protobuf 10000', () => {
+    benchmarkTreeConvert(10000);
+  });
+
+  bench('tree convert from/to Protobuf 20000', () => {
+    benchmarkTreeConvert(20000);
+  });
+
+  bench('tree convert from/to Protobuf 30000', () => {
+    benchmarkTreeConvert(30000);
   });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Enhance tree conversion for better performance

The time complexity of creating converter.fromTreeNodes was O(N^2), potentially causing performance bottlenecks. It's optimized to O(n) with this commit.

While this may not be a significant issue currently, there is a risk that as the number of tree nodes in the protobuf increases, operations will scale quadratically, potentially causing performance bottlenecks.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes yorkie-team/yorkie#930

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
