### PR TITLE
Unify error throwing methods

### DIFF
--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -203,7 +203,7 @@ function toValueType(valueType: PrimitiveType): PbValueType {
       return PbValueType.DATE;
     default:
       throw new YorkieError(
-        Code.ErrUnsupported,
+        Code.ErrInvalidType,
         `unsupported type: ${valueType}`,
       );
   }
@@ -220,7 +220,7 @@ function toCounterType(valueType: CounterType): PbValueType {
       return PbValueType.LONG_CNT;
     default:
       throw new YorkieError(
-        Code.ErrUnsupported,
+        Code.ErrInvalidType,
         `unsupported type: ${valueType}`,
       );
   }
@@ -865,7 +865,7 @@ function fromPresenceChange<P extends Indexable>(
     };
   }
 
-  throw new YorkieError(Code.ErrUnsupported, `unsupported type: ${type}`);
+  throw new YorkieError(Code.ErrInvalidType, `unsupported type: ${type}`);
 }
 
 /**
@@ -1482,7 +1482,7 @@ function bytesToSnapshot<P extends Indexable>(
  */
 function bytesToObject(bytes?: Uint8Array): CRDTObject {
   if (!bytes) {
-    throw new Error('bytes is empty');
+    throw new YorkieError(Code.ErrInvalidArgument, 'bytes is empty');
   }
 
   const pbElement = PbJSONElement.fromBinary(bytes);
@@ -1501,7 +1501,7 @@ function objectToBytes(obj: CRDTObject): Uint8Array {
  */
 function bytesToArray(bytes?: Uint8Array): CRDTArray {
   if (!bytes) {
-    throw new Error('bytes is empty');
+    throw new YorkieError(Code.ErrInvalidArgument, 'bytes is empty');
   }
 
   const pbElement = PbJSONElement.fromBinary(bytes);
@@ -1520,7 +1520,7 @@ function arrayToBytes(array: CRDTArray): Uint8Array {
  */
 function bytesToTree(bytes?: Uint8Array): CRDTTree {
   if (!bytes) {
-    throw new Error('bytes is empty');
+    throw new YorkieError(Code.ErrInvalidArgument, 'bytes is empty');
   }
 
   const pbElement = PbJSONElement.fromBinary(bytes);

--- a/src/api/converter.ts
+++ b/src/api/converter.ts
@@ -202,7 +202,10 @@ function toValueType(valueType: PrimitiveType): PbValueType {
     case PrimitiveType.Date:
       return PbValueType.DATE;
     default:
-      throw new YorkieError(Code.Unsupported, `unsupported type: ${valueType}`);
+      throw new YorkieError(
+        Code.ErrUnsupported,
+        `unsupported type: ${valueType}`,
+      );
   }
 }
 
@@ -216,7 +219,10 @@ function toCounterType(valueType: CounterType): PbValueType {
     case CounterType.LongCnt:
       return PbValueType.LONG_CNT;
     default:
-      throw new YorkieError(Code.Unsupported, `unsupported type: ${valueType}`);
+      throw new YorkieError(
+        Code.ErrUnsupported,
+        `unsupported type: ${valueType}`,
+      );
   }
 }
 
@@ -859,7 +865,7 @@ function fromPresenceChange<P extends Indexable>(
     };
   }
 
-  throw new YorkieError(Code.Unsupported, `unsupported type: ${type}`);
+  throw new YorkieError(Code.ErrUnsupported, `unsupported type: ${type}`);
 }
 
 /**

--- a/src/document/crdt/element_rht.ts
+++ b/src/document/crdt/element_rht.ts
@@ -115,9 +115,9 @@ export class ElementRHT {
    */
   public delete(createdAt: TimeTicket, executedAt: TimeTicket): CRDTElement {
     if (!this.nodeMapByCreatedAt.has(createdAt.toIDString())) {
-      const ERROR_MESSAGE = `fail to find ${createdAt.toIDString()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to find ${createdAt.toIDString()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
     const node = this.nodeMapByCreatedAt.get(createdAt.toIDString())!;
@@ -145,11 +145,11 @@ export class ElementRHT {
       element.getCreatedAt().toIDString(),
     );
     if (!node) {
-      const ERROR_MESSAGE = `fail to find ${element
+      const ErrorMessage = `fail to find ${element
         .getCreatedAt()
         .toIDString()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
     const nodeByKey = this.nodeMapByKey.get(node.getStrKey());

--- a/src/document/crdt/element_rht.ts
+++ b/src/document/crdt/element_rht.ts
@@ -116,7 +116,6 @@ export class ElementRHT {
   public delete(createdAt: TimeTicket, executedAt: TimeTicket): CRDTElement {
     if (!this.nodeMapByCreatedAt.has(createdAt.toIDString())) {
       const ErrorMessage = `fail to find ${createdAt.toIDString()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
@@ -148,7 +147,6 @@ export class ElementRHT {
       const ErrorMessage = `fail to find ${element
         .getCreatedAt()
         .toIDString()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 

--- a/src/document/crdt/element_rht.ts
+++ b/src/document/crdt/element_rht.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
 import { YorkieError, Code } from '@yorkie-js-sdk/src/util/error';

--- a/src/document/crdt/element_rht.ts
+++ b/src/document/crdt/element_rht.ts
@@ -17,6 +17,7 @@
 import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
+import { YorkieError, Code } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * `ElementRHTNode` is a node of ElementRHT.
@@ -114,7 +115,9 @@ export class ElementRHT {
    */
   public delete(createdAt: TimeTicket, executedAt: TimeTicket): CRDTElement {
     if (!this.nodeMapByCreatedAt.has(createdAt.toIDString())) {
-      logger.fatal(`fail to find ${createdAt.toIDString()}`);
+      const ERROR_MESSAGE = `fail to find ${createdAt.toIDString()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
 
     const node = this.nodeMapByCreatedAt.get(createdAt.toIDString())!;
@@ -142,8 +145,11 @@ export class ElementRHT {
       element.getCreatedAt().toIDString(),
     );
     if (!node) {
-      logger.fatal(`fail to find ${element.getCreatedAt().toIDString()}`);
-      return;
+      const ERROR_MESSAGE = `fail to find ${element
+        .getCreatedAt()
+        .toIDString()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
 
     const nodeByKey = this.nodeMapByKey.get(node.getStrKey());

--- a/src/document/crdt/rga_tree_list.ts
+++ b/src/document/crdt/rga_tree_list.ts
@@ -182,7 +182,6 @@ export class RGATreeList {
     let node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
     if (!node) {
       const ErrorMessage = `cant find the given node: ${createdAt.toIDString()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
@@ -236,14 +235,12 @@ export class RGATreeList {
     const prevNode = this.nodeMapByCreatedAt.get(prevCreatedAt.toIDString());
     if (!prevNode) {
       const ErrorMessage = `cant find the given node: ${prevCreatedAt.toIDString()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
     const node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
     if (!node) {
       const ErrorMessage = `cant find the given node: ${createdAt.toIDString()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
@@ -294,7 +291,6 @@ export class RGATreeList {
       const ErrorMessage = `fail to find the given createdAt: ${element
         .getCreatedAt()
         .toIDString()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     this.release(node!);

--- a/src/document/crdt/rga_tree_list.ts
+++ b/src/document/crdt/rga_tree_list.ts
@@ -181,9 +181,9 @@ export class RGATreeList {
   ): RGATreeListNode {
     let node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
     if (!node) {
-      const ERROR_MESSAGE = `cant find the given node: ${createdAt.toIDString()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `cant find the given node: ${createdAt.toIDString()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
     while (
@@ -235,16 +235,16 @@ export class RGATreeList {
   ): void {
     const prevNode = this.nodeMapByCreatedAt.get(prevCreatedAt.toIDString());
     if (!prevNode) {
-      const ERROR_MESSAGE = `cant find the given node: ${prevCreatedAt.toIDString()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `cant find the given node: ${prevCreatedAt.toIDString()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
     const node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
     if (!node) {
-      const ERROR_MESSAGE = `cant find the given node: ${createdAt.toIDString()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `cant find the given node: ${createdAt.toIDString()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
     if (
@@ -291,11 +291,11 @@ export class RGATreeList {
       element.getCreatedAt().toIDString(),
     );
     if (!node) {
-      const ERROR_MESSAGE = `fail to find the given createdAt: ${element
+      const ErrorMessage = `fail to find the given createdAt: ${element
         .getCreatedAt()
         .toIDString()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     this.release(node!);
   }

--- a/src/document/crdt/rga_tree_list.ts
+++ b/src/document/crdt/rga_tree_list.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { SplayNode, SplayTree } from '@yorkie-js-sdk/src/util/splay_tree';
 import {
   InitialTimeTicket,

--- a/src/document/crdt/rga_tree_list.ts
+++ b/src/document/crdt/rga_tree_list.ts
@@ -22,6 +22,7 @@ import {
 } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
 import { Primitive } from '@yorkie-js-sdk/src/document/crdt/primitive';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * `RGATreeListNode` is a node of RGATreeList.
@@ -180,7 +181,9 @@ export class RGATreeList {
   ): RGATreeListNode {
     let node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
     if (!node) {
-      logger.fatal(`cant find the given node: ${createdAt.toIDString()}`);
+      const ERROR_MESSAGE = `cant find the given node: ${createdAt.toIDString()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
 
     while (
@@ -232,12 +235,16 @@ export class RGATreeList {
   ): void {
     const prevNode = this.nodeMapByCreatedAt.get(prevCreatedAt.toIDString());
     if (!prevNode) {
-      logger.fatal(`cant find the given node: ${prevCreatedAt.toIDString()}`);
+      const ERROR_MESSAGE = `cant find the given node: ${prevCreatedAt.toIDString()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
 
     const node = this.nodeMapByCreatedAt.get(createdAt.toIDString());
     if (!node) {
-      logger.fatal(`cant find the given node: ${createdAt.toIDString()}`);
+      const ERROR_MESSAGE = `cant find the given node: ${createdAt.toIDString()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
 
     if (
@@ -284,11 +291,11 @@ export class RGATreeList {
       element.getCreatedAt().toIDString(),
     );
     if (!node) {
-      logger.fatal(
-        `fail to find the given createdAt: ${element
-          .getCreatedAt()
-          .toIDString()}`,
-      );
+      const ERROR_MESSAGE = `fail to find the given createdAt: ${element
+        .getCreatedAt()
+        .toIDString()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     this.release(node!);
   }

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -636,7 +636,6 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
       : this.findFloorNode(absoluteID);
     if (!node) {
       const ErrorMessage = `the node of the given id should be found: ${absoluteID.toTestString()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     const index = this.treeByIndex.indexOf(node!);
@@ -795,7 +794,6 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
     let node = this.findFloorNode(id);
     if (!node) {
       const ErrorMessage = `the node of the given id should be found: ${id.toTestString()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
@@ -849,7 +847,6 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
   ): RGATreeSplitNode<T> | undefined {
     if (offset > node.getContentLength()) {
       const ErrorMessage = `offset should be less than or equal to length`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -26,6 +26,7 @@ import {
   TimeTicketStruct,
 } from '@yorkie-js-sdk/src/document/time/ticket';
 import { GCChild, GCPair, GCParent } from '@yorkie-js-sdk/src/document/crdt/gc';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 export interface ValueChange<T> {
   actor: ActorID;
@@ -634,9 +635,9 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
       ? this.findFloorNodePreferToLeft(absoluteID)
       : this.findFloorNode(absoluteID);
     if (!node) {
-      logger.fatal(
-        `the node of the given id should be found: ${absoluteID.toTestString()}`,
-      );
+      const ERROR_MESSAGE = `the node of the given id should be found: ${absoluteID.toTestString()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     const index = this.treeByIndex.indexOf(node!);
     const offset = node!.isRemoved()
@@ -793,9 +794,9 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
   ): RGATreeSplitNode<T> {
     let node = this.findFloorNode(id);
     if (!node) {
-      logger.fatal(
-        `the node of the given id should be found: ${id.toTestString()}`,
-      );
+      const ERROR_MESSAGE = `the node of the given id should be found: ${id.toTestString()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
 
     if (id.getOffset() > 0 && node!.getID().getOffset() == id.getOffset()) {
@@ -847,7 +848,9 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
     offset: number,
   ): RGATreeSplitNode<T> | undefined {
     if (offset > node.getContentLength()) {
-      logger.fatal('offset should be less than or equal to length');
+      const ERROR_MESSAGE = `offset should be less than or equal to length`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
 
     if (offset === 0) {

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -635,9 +635,9 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
       ? this.findFloorNodePreferToLeft(absoluteID)
       : this.findFloorNode(absoluteID);
     if (!node) {
-      const ERROR_MESSAGE = `the node of the given id should be found: ${absoluteID.toTestString()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `the node of the given id should be found: ${absoluteID.toTestString()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     const index = this.treeByIndex.indexOf(node!);
     const offset = node!.isRemoved()
@@ -794,9 +794,9 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
   ): RGATreeSplitNode<T> {
     let node = this.findFloorNode(id);
     if (!node) {
-      const ERROR_MESSAGE = `the node of the given id should be found: ${id.toTestString()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `the node of the given id should be found: ${id.toTestString()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
     if (id.getOffset() > 0 && node!.getID().getOffset() == id.getOffset()) {
@@ -848,9 +848,9 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
     offset: number,
   ): RGATreeSplitNode<T> | undefined {
     if (offset > node.getContentLength()) {
-      const ERROR_MESSAGE = `offset should be less than or equal to length`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `offset should be less than or equal to length`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
     if (offset === 0) {

--- a/src/document/crdt/rga_tree_split.ts
+++ b/src/document/crdt/rga_tree_split.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { ActorID } from '@yorkie-js-sdk/src/document/time/actor_id';
 import { Comparator } from '@yorkie-js-sdk/src/util/comparator';
 import { SplayNode, SplayTree } from '@yorkie-js-sdk/src/util/splay_tree';

--- a/src/document/crdt/root.ts
+++ b/src/document/crdt/root.ts
@@ -27,6 +27,7 @@ import { CRDTObject } from '@yorkie-js-sdk/src/document/crdt/object';
 import { GCPair } from '@yorkie-js-sdk/src/document/crdt/gc';
 import { CRDTText } from '@yorkie-js-sdk/src/document/crdt/text';
 import { CRDTTree } from '@yorkie-js-sdk/src/document/crdt/tree';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * `CRDTElementPair` is a structure that represents a pair of element and its
@@ -134,7 +135,9 @@ export class CRDTRoot {
       const createdAt = pair.element.getCreatedAt();
       const subPath = pair.parent.subPathOf(createdAt);
       if (subPath === undefined) {
-        logger.fatal(`cant find the given element: ${createdAt.toIDString()}`);
+        const ERROR_MESSAGE = `cant find the given element: ${createdAt.toIDString()}`;
+        logger.fatal(ERROR_MESSAGE);
+        throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
       }
 
       subPaths.unshift(subPath!);

--- a/src/document/crdt/root.ts
+++ b/src/document/crdt/root.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import {
   InitialTimeTicket,
   TimeTicket,
@@ -136,7 +135,6 @@ export class CRDTRoot {
       const subPath = pair.parent.subPathOf(createdAt);
       if (subPath === undefined) {
         const ErrorMessage = `cant find the given element: ${createdAt.toIDString()}`;
-        logger.fatal(ErrorMessage);
         throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
       }
 

--- a/src/document/crdt/root.ts
+++ b/src/document/crdt/root.ts
@@ -135,9 +135,9 @@ export class CRDTRoot {
       const createdAt = pair.element.getCreatedAt();
       const subPath = pair.parent.subPathOf(createdAt);
       if (subPath === undefined) {
-        const ERROR_MESSAGE = `cant find the given element: ${createdAt.toIDString()}`;
-        logger.fatal(ERROR_MESSAGE);
-        throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+        const ErrorMessage = `cant find the given element: ${createdAt.toIDString()}`;
+        logger.fatal(ErrorMessage);
+        throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
       }
 
       subPaths.unshift(subPath!);

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -225,7 +225,7 @@ export class CRDTTreePos {
     let leftNode = tree.findFloorNode(leftSiblingID);
     if (!parentNode || !leftNode) {
       throw new YorkieError(
-        Code.ErrOperationNotPermitted,
+        Code.ErrRefused,
         `cannot find node of CRDTTreePos(${parentID.toTestString()}, ${leftSiblingID.toTestString()})`,
       );
     }

--- a/src/document/crdt/tree.ts
+++ b/src/document/crdt/tree.ts
@@ -43,6 +43,7 @@ import { Indexable } from '@yorkie-js-sdk/src/document/document';
 import type * as Devtools from '@yorkie-js-sdk/src/devtools/types';
 import { escapeString } from '@yorkie-js-sdk/src/document/json/strings';
 import { GCChild, GCPair, GCParent } from '@yorkie-js-sdk/src/document/crdt/gc';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * `TreeNode` represents a node in the tree.
@@ -223,7 +224,8 @@ export class CRDTTreePos {
     const parentNode = tree.findFloorNode(parentID);
     let leftNode = tree.findFloorNode(leftSiblingID);
     if (!parentNode || !leftNode) {
-      throw new Error(
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
         `cannot find node of CRDTTreePos(${parentID.toTestString()}, ${leftSiblingID.toTestString()})`,
       );
     }
@@ -514,7 +516,10 @@ export class CRDTTreeNode
    */
   get value() {
     if (!this.isText) {
-      throw new Error(`cannot get value of element node: ${this.type}`);
+      throw new YorkieError(
+        Code.ErrInvalidType,
+        `cannot get value of element node: ${this.type}`,
+      );
     }
 
     return this._value;
@@ -525,7 +530,10 @@ export class CRDTTreeNode
    */
   set value(v: string) {
     if (!this.isText) {
-      throw new Error(`cannot set value of element node: ${this.type}`);
+      throw new YorkieError(
+        Code.ErrInvalidType,
+        `cannot set value of element node: ${this.type}`,
+      );
     }
 
     this._value = v;
@@ -1217,7 +1225,10 @@ export class CRDTTree extends CRDTElement implements GCParent {
     ticket: TimeTicket,
   ): void {
     // TODO(hackerwins, easylogic): Implement this with keeping references of the nodes.
-    throw new Error(`not implemented: ${target}, ${source}, ${ticket}`);
+    throw new YorkieError(
+      Code.ErrUnimplemented,
+      `not implemented: ${target}, ${source}, ${ticket}`,
+    );
   }
 
   /**

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -1771,14 +1771,14 @@ export class Document<T, P extends Indexable = Indexable> {
   private undo(): void {
     if (this.isUpdating) {
       throw new YorkieError(
-        Code.ErrOperationNotPermitted,
+        Code.ErrRefused,
         'Undo is not allowed during an update',
       );
     }
     const undoOps = this.internalHistory.popUndo();
     if (undoOps === undefined) {
       throw new YorkieError(
-        Code.ErrOperationNotPermitted,
+        Code.ErrRefused,
         'There is no operation to be undone',
       );
     }
@@ -1871,7 +1871,7 @@ export class Document<T, P extends Indexable = Indexable> {
   private redo(): void {
     if (this.isUpdating) {
       throw new YorkieError(
-        Code.ErrOperationNotPermitted,
+        Code.ErrRefused,
         'Redo is not allowed during an update',
       );
     }
@@ -1879,7 +1879,7 @@ export class Document<T, P extends Indexable = Indexable> {
     const redoOps = this.internalHistory.popRedo();
     if (redoOps === undefined) {
       throw new YorkieError(
-        Code.ErrOperationNotPermitted,
+        Code.ErrRefused,
         'There is no operation to be redone',
       );
     }

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -661,12 +661,6 @@ export class Document<T, P extends Indexable = Indexable> {
       // drop clone because it is contaminated.
       this.clone = undefined;
 
-      if (err instanceof YorkieError) {
-        logger.error(err.toString());
-      } else {
-        logger.error(err);
-      }
-
       throw err;
     } finally {
       this.isUpdating = false;

--- a/src/document/document.ts
+++ b/src/document/document.ts
@@ -660,7 +660,13 @@ export class Document<T, P extends Indexable = Indexable> {
     } catch (err) {
       // drop clone because it is contaminated.
       this.clone = undefined;
-      logger.error(err);
+
+      if (err instanceof YorkieError) {
+        logger.error(err.toString());
+      } else {
+        logger.error(err);
+      }
+
       throw err;
     } finally {
       this.isUpdating = false;
@@ -847,7 +853,10 @@ export class Document<T, P extends Indexable = Indexable> {
   ): Unsubscribe {
     if (typeof arg1 === 'string') {
       if (typeof arg2 !== 'function') {
-        throw new Error('Second argument must be a callback function');
+        throw new YorkieError(
+          Code.ErrInvalidArgument,
+          'Second argument must be a callback function',
+        );
       }
       if (arg1 === 'presence') {
         const callback = arg2 as DocEventCallbackMap<P>['presence'];
@@ -1021,7 +1030,7 @@ export class Document<T, P extends Indexable = Indexable> {
         complete,
       );
     }
-    throw new Error(`"${arg1}" is not a valid`);
+    throw new YorkieError(Code.ErrInvalidArgument, `"${arg1}" is not a valid`);
   }
 
   /**
@@ -1761,11 +1770,17 @@ export class Document<T, P extends Indexable = Indexable> {
    */
   private undo(): void {
     if (this.isUpdating) {
-      throw new Error('Undo is not allowed during an update');
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
+        'Undo is not allowed during an update',
+      );
     }
     const undoOps = this.internalHistory.popUndo();
     if (undoOps === undefined) {
-      throw new Error('There is no operation to be undone');
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
+        'There is no operation to be undone',
+      );
     }
 
     this.ensureClone();
@@ -1855,12 +1870,18 @@ export class Document<T, P extends Indexable = Indexable> {
    */
   private redo(): void {
     if (this.isUpdating) {
-      throw new Error('Redo is not allowed during an update');
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
+        'Redo is not allowed during an update',
+      );
     }
 
     const redoOps = this.internalHistory.popRedo();
     if (redoOps === undefined) {
-      throw new Error('There is no operation to be redone');
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
+        'There is no operation to be redone',
+      );
     }
 
     this.ensureClone();

--- a/src/document/json/counter.ts
+++ b/src/document/json/counter.ts
@@ -80,7 +80,6 @@ export class Counter {
   public increase(v: number | Long): Counter {
     if (!this.context || !this.counter) {
       const ErrorMessage = 'Counter is not initialized yet';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 

--- a/src/document/json/counter.ts
+++ b/src/document/json/counter.ts
@@ -106,7 +106,7 @@ export class Counter {
    */
   public toJSForTest(): Devtools.JSONElement {
     if (!this.context || !this.counter) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(Code.ErrOperationNotReady, 'Counter is not ready');
     }
 
     return this.counter.toJSForTest();

--- a/src/document/json/counter.ts
+++ b/src/document/json/counter.ts
@@ -25,6 +25,7 @@ import {
   CRDTCounter,
 } from '@yorkie-js-sdk/src/document/crdt/counter';
 import type * as Devtools from '@yorkie-js-sdk/src/devtools/types';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * `Counter` is a custom data type that is used to counter.
@@ -78,9 +79,9 @@ export class Counter {
    */
   public increase(v: number | Long): Counter {
     if (!this.context || !this.counter) {
-      logger.fatal('it is not initialized yet');
-      // @ts-ignore
-      return;
+      const ERROR_MESSAGE = 'Counter is not initialized yet';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
     }
 
     const ticket = this.context.issueTimeTicket();

--- a/src/document/json/counter.ts
+++ b/src/document/json/counter.ts
@@ -79,9 +79,9 @@ export class Counter {
    */
   public increase(v: number | Long): Counter {
     if (!this.context || !this.counter) {
-      const ERROR_MESSAGE = 'Counter is not initialized yet';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
+      const ErrorMessage = 'Counter is not initialized yet';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
     }
 
     const ticket = this.context.issueTimeTicket();

--- a/src/document/json/counter.ts
+++ b/src/document/json/counter.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
 import { Primitive } from '@yorkie-js-sdk/src/document/crdt/primitive';

--- a/src/document/json/counter.ts
+++ b/src/document/json/counter.ts
@@ -81,7 +81,7 @@ export class Counter {
     if (!this.context || !this.counter) {
       const ErrorMessage = 'Counter is not initialized yet';
       logger.fatal(ErrorMessage);
-      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
+      throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     const ticket = this.context.issueTimeTicket();
@@ -106,7 +106,8 @@ export class Counter {
    */
   public toJSForTest(): Devtools.JSONElement {
     if (!this.context || !this.counter) {
-      throw new YorkieError(Code.ErrOperationNotReady, 'Counter is not ready');
+      const ErrorMessage = 'Counter is not initialized yet';
+      throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     return this.counter.toJSForTest();

--- a/src/document/json/text.ts
+++ b/src/document/json/text.ts
@@ -303,7 +303,10 @@ export class Text<A extends Indexable = Indexable> {
    */
   public toJSON(): string {
     if (!this.context || !this.text) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Text is not initialized yet',
+      );
     }
 
     return this.text.toJSON();
@@ -315,7 +318,10 @@ export class Text<A extends Indexable = Indexable> {
    */
   public toJSForTest(): Devtools.JSONElement {
     if (!this.context || !this.text) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Text is not initialized yet',
+      );
     }
 
     return this.text.toJSForTest();

--- a/src/document/json/text.ts
+++ b/src/document/json/text.ts
@@ -93,15 +93,15 @@ export class Text<A extends Indexable = Indexable> {
     attributes?: A,
   ): [number, number] | undefined {
     if (!this.context || !this.text) {
-      const ERROR_MESSAGE = 'Text is not initialized yet';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
+      const ErrorMessage = 'Text is not initialized yet';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
     }
 
     if (fromIdx > toIdx) {
-      const ERROR_MESSAGE = 'from should be less than or equal to to';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = 'from should be less than or equal to to';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
     const range = this.text.indexRangeToPosRange(fromIdx, toIdx);
@@ -157,15 +157,15 @@ export class Text<A extends Indexable = Indexable> {
    */
   setStyle(fromIdx: number, toIdx: number, attributes: A): boolean {
     if (!this.context || !this.text) {
-      const ERROR_MESSAGE = 'Text is not initialized yet';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
+      const ErrorMessage = 'Text is not initialized yet';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
     }
 
     if (fromIdx > toIdx) {
-      const ERROR_MESSAGE = 'from should be less than or equal to to';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = 'from should be less than or equal to to';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
     const range = this.text.indexRangeToPosRange(fromIdx, toIdx);
@@ -208,9 +208,9 @@ export class Text<A extends Indexable = Indexable> {
    */
   indexRangeToPosRange(range: [number, number]): TextPosStructRange {
     if (!this.context || !this.text) {
-      const ERROR_MESSAGE = 'Text is not initialized yet';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
+      const ErrorMessage = 'Text is not initialized yet';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
     }
 
     const textRange = this.text.indexRangeToPosRange(range[0], range[1]);
@@ -222,9 +222,9 @@ export class Text<A extends Indexable = Indexable> {
    */
   posRangeToIndexRange(range: TextPosStructRange): [number, number] {
     if (!this.context || !this.text) {
-      const ERROR_MESSAGE = 'Text is not initialized yet';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
+      const ErrorMessage = 'Text is not initialized yet';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
     }
 
     const textRange = this.text.findIndexesFromRange([
@@ -240,9 +240,9 @@ export class Text<A extends Indexable = Indexable> {
    */
   toTestString(): string {
     if (!this.context || !this.text) {
-      const ERROR_MESSAGE = 'Text is not initialized yet';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
+      const ErrorMessage = 'Text is not initialized yet';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
     }
 
     return this.text.toTestString();
@@ -253,9 +253,9 @@ export class Text<A extends Indexable = Indexable> {
    */
   values(): Array<TextValueType<A>> {
     if (!this.context || !this.text) {
-      const ERROR_MESSAGE = 'Text is not initialized yet';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
+      const ErrorMessage = 'Text is not initialized yet';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
     }
 
     return this.text.values();
@@ -290,9 +290,9 @@ export class Text<A extends Indexable = Indexable> {
    */
   toString(): string {
     if (!this.context || !this.text) {
-      const ERROR_MESSAGE = 'Text is not initialized yet';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
+      const ErrorMessage = 'Text is not initialized yet';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
     }
 
     return this.text.toString();
@@ -333,9 +333,9 @@ export class Text<A extends Indexable = Indexable> {
    */
   createRangeForTest(fromIdx: number, toIdx: number): RGATreeSplitPosRange {
     if (!this.context || !this.text) {
-      const ERROR_MESSAGE = 'Text is not initialized yet';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
+      const ErrorMessage = 'Text is not initialized yet';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
     }
 
     return this.text.indexRangeToPosRange(fromIdx, toIdx);

--- a/src/document/json/text.ts
+++ b/src/document/json/text.ts
@@ -94,13 +94,11 @@ export class Text<A extends Indexable = Indexable> {
   ): [number, number] | undefined {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     if (fromIdx > toIdx) {
       const ErrorMessage = 'from should be less than or equal to to';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
@@ -158,13 +156,11 @@ export class Text<A extends Indexable = Indexable> {
   setStyle(fromIdx: number, toIdx: number, attributes: A): boolean {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     if (fromIdx > toIdx) {
       const ErrorMessage = 'from should be less than or equal to to';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
@@ -209,7 +205,6 @@ export class Text<A extends Indexable = Indexable> {
   indexRangeToPosRange(range: [number, number]): TextPosStructRange {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
@@ -223,7 +218,6 @@ export class Text<A extends Indexable = Indexable> {
   posRangeToIndexRange(range: TextPosStructRange): [number, number] {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
@@ -241,7 +235,6 @@ export class Text<A extends Indexable = Indexable> {
   toTestString(): string {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
@@ -254,7 +247,6 @@ export class Text<A extends Indexable = Indexable> {
   values(): Array<TextValueType<A>> {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
@@ -291,7 +283,6 @@ export class Text<A extends Indexable = Indexable> {
   toString(): string {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
@@ -334,7 +325,6 @@ export class Text<A extends Indexable = Indexable> {
   createRangeForTest(fromIdx: number, toIdx: number): RGATreeSplitPosRange {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 

--- a/src/document/json/text.ts
+++ b/src/document/json/text.ts
@@ -38,6 +38,7 @@ import { stringifyObjectValues } from '@yorkie-js-sdk/src/util/object';
 import type * as Devtools from '@yorkie-js-sdk/src/devtools/types';
 import { SplayTree } from '@yorkie-js-sdk/src/util/splay_tree';
 import { LLRBTree } from '@yorkie-js-sdk/src/util/llrb_tree';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * `TextPosStruct` represents the structure of RGATreeSplitPos.
@@ -92,13 +93,15 @@ export class Text<A extends Indexable = Indexable> {
     attributes?: A,
   ): [number, number] | undefined {
     if (!this.context || !this.text) {
-      logger.fatal('it is not initialized yet');
-      return;
+      const ERROR_MESSAGE = 'Text is not initialized yet';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
     }
 
     if (fromIdx > toIdx) {
-      logger.fatal('from should be less than or equal to to');
-      return;
+      const ERROR_MESSAGE = 'from should be less than or equal to to';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
 
     const range = this.text.indexRangeToPosRange(fromIdx, toIdx);
@@ -154,13 +157,15 @@ export class Text<A extends Indexable = Indexable> {
    */
   setStyle(fromIdx: number, toIdx: number, attributes: A): boolean {
     if (!this.context || !this.text) {
-      logger.fatal('it is not initialized yet');
-      return false;
+      const ERROR_MESSAGE = 'Text is not initialized yet';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
     }
 
     if (fromIdx > toIdx) {
-      logger.fatal('from should be less than or equal to to');
-      return false;
+      const ERROR_MESSAGE = 'from should be less than or equal to to';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
 
     const range = this.text.indexRangeToPosRange(fromIdx, toIdx);
@@ -203,9 +208,9 @@ export class Text<A extends Indexable = Indexable> {
    */
   indexRangeToPosRange(range: [number, number]): TextPosStructRange {
     if (!this.context || !this.text) {
-      logger.fatal('it is not initialized yet');
-      // @ts-ignore
-      return;
+      const ERROR_MESSAGE = 'Text is not initialized yet';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
     }
 
     const textRange = this.text.indexRangeToPosRange(range[0], range[1]);
@@ -217,9 +222,9 @@ export class Text<A extends Indexable = Indexable> {
    */
   posRangeToIndexRange(range: TextPosStructRange): [number, number] {
     if (!this.context || !this.text) {
-      logger.fatal('it is not initialized yet');
-      // @ts-ignore
-      return;
+      const ERROR_MESSAGE = 'Text is not initialized yet';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
     }
 
     const textRange = this.text.findIndexesFromRange([
@@ -235,9 +240,9 @@ export class Text<A extends Indexable = Indexable> {
    */
   toTestString(): string {
     if (!this.context || !this.text) {
-      logger.fatal('it is not initialized yet');
-      // @ts-ignore
-      return;
+      const ERROR_MESSAGE = 'Text is not initialized yet';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
     }
 
     return this.text.toTestString();
@@ -248,9 +253,9 @@ export class Text<A extends Indexable = Indexable> {
    */
   values(): Array<TextValueType<A>> {
     if (!this.context || !this.text) {
-      logger.fatal('it is not initialized yet');
-      // @ts-ignore
-      return;
+      const ERROR_MESSAGE = 'Text is not initialized yet';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
     }
 
     return this.text.values();
@@ -285,8 +290,9 @@ export class Text<A extends Indexable = Indexable> {
    */
   toString(): string {
     if (!this.context || !this.text) {
-      logger.fatal('it is not initialized yet');
-      return '';
+      const ERROR_MESSAGE = 'Text is not initialized yet';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
     }
 
     return this.text.toString();
@@ -321,9 +327,9 @@ export class Text<A extends Indexable = Indexable> {
    */
   createRangeForTest(fromIdx: number, toIdx: number): RGATreeSplitPosRange {
     if (!this.context || !this.text) {
-      logger.fatal('it is not initialized yet');
-      // @ts-ignore
-      return;
+      const ERROR_MESSAGE = 'Text is not initialized yet';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
     }
 
     return this.text.indexRangeToPosRange(fromIdx, toIdx);

--- a/src/document/json/text.ts
+++ b/src/document/json/text.ts
@@ -95,7 +95,7 @@ export class Text<A extends Indexable = Indexable> {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
       logger.fatal(ErrorMessage);
-      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
+      throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     if (fromIdx > toIdx) {
@@ -159,7 +159,7 @@ export class Text<A extends Indexable = Indexable> {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
       logger.fatal(ErrorMessage);
-      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
+      throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     if (fromIdx > toIdx) {
@@ -210,7 +210,7 @@ export class Text<A extends Indexable = Indexable> {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
       logger.fatal(ErrorMessage);
-      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
+      throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     const textRange = this.text.indexRangeToPosRange(range[0], range[1]);
@@ -224,7 +224,7 @@ export class Text<A extends Indexable = Indexable> {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
       logger.fatal(ErrorMessage);
-      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
+      throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     const textRange = this.text.findIndexesFromRange([
@@ -242,7 +242,7 @@ export class Text<A extends Indexable = Indexable> {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
       logger.fatal(ErrorMessage);
-      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
+      throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     return this.text.toTestString();
@@ -255,7 +255,7 @@ export class Text<A extends Indexable = Indexable> {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
       logger.fatal(ErrorMessage);
-      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
+      throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     return this.text.values();
@@ -292,7 +292,7 @@ export class Text<A extends Indexable = Indexable> {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
       logger.fatal(ErrorMessage);
-      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
+      throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     return this.text.toString();
@@ -304,7 +304,7 @@ export class Text<A extends Indexable = Indexable> {
   public toJSON(): string {
     if (!this.context || !this.text) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Text is not initialized yet',
       );
     }
@@ -319,7 +319,7 @@ export class Text<A extends Indexable = Indexable> {
   public toJSForTest(): Devtools.JSONElement {
     if (!this.context || !this.text) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Text is not initialized yet',
       );
     }
@@ -335,7 +335,7 @@ export class Text<A extends Indexable = Indexable> {
     if (!this.context || !this.text) {
       const ErrorMessage = 'Text is not initialized yet';
       logger.fatal(ErrorMessage);
-      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
+      throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     return this.text.indexRangeToPosRange(fromIdx, toIdx);

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -739,9 +739,9 @@ export class Tree {
     range: [Array<number>, Array<number>],
   ): TreePosStructRange {
     if (!this.context || !this.tree) {
-      const ERROR_MESSAGE = 'Tree is not initialized yet';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
+      const ErrorMessage = 'Tree is not initialized yet';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
     }
 
     const indexRange: [number, number] = [
@@ -757,9 +757,9 @@ export class Tree {
    */
   indexRangeToPosRange(range: [number, number]): TreePosStructRange {
     if (!this.context || !this.tree) {
-      const ERROR_MESSAGE = 'Tree is not initialized yet';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
+      const ErrorMessage = 'Tree is not initialized yet';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
     }
 
     return this.tree.indexRangeToPosStructRange(range);
@@ -770,9 +770,9 @@ export class Tree {
    */
   posRangeToIndexRange(range: TreePosStructRange): [number, number] {
     if (!this.context || !this.tree) {
-      const ERROR_MESSAGE = 'Tree is not initialized yet';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
+      const ErrorMessage = 'Tree is not initialized yet';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
     }
 
     const posRange: [CRDTTreePos, CRDTTreePos] = [
@@ -790,9 +790,9 @@ export class Tree {
     range: TreePosStructRange,
   ): [Array<number>, Array<number>] {
     if (!this.context || !this.tree) {
-      const ERROR_MESSAGE = 'Tree is not initialized yet';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
+      const ErrorMessage = 'Tree is not initialized yet';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
     }
 
     const posRange: [CRDTTreePos, CRDTTreePos] = [

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -258,7 +258,7 @@ export class Tree {
   public getSize(): number {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -272,7 +272,7 @@ export class Tree {
   public getNodeSize(): number {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -286,7 +286,7 @@ export class Tree {
   public getIndexTree(): IndexTree<CRDTTreeNode> {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -300,7 +300,7 @@ export class Tree {
   public styleByPath(path: Array<number>, attributes: { [key: string]: any }) {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -343,7 +343,7 @@ export class Tree {
   ) {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -392,7 +392,7 @@ export class Tree {
   ) {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -508,7 +508,7 @@ export class Tree {
   ): boolean {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -547,7 +547,7 @@ export class Tree {
   ): boolean {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -581,7 +581,7 @@ export class Tree {
   ): boolean {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -614,7 +614,7 @@ export class Tree {
   ): boolean {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -637,7 +637,7 @@ export class Tree {
   public toXML(): string {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -651,7 +651,7 @@ export class Tree {
   public toJSON(): string {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -666,7 +666,7 @@ export class Tree {
   public toJSForTest(): Devtools.JSONElement {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -682,7 +682,7 @@ export class Tree {
   public toJSInfoForTest(): Devtools.TreeNodeInfo {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -696,7 +696,7 @@ export class Tree {
   public getRootTreeNode() {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -710,7 +710,7 @@ export class Tree {
   public indexToPath(index: number): Array<number> {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -724,7 +724,7 @@ export class Tree {
   public pathToIndex(path: Array<number>): number {
     if (!this.context || !this.tree) {
       throw new YorkieError(
-        Code.ErrOperationNotReady,
+        Code.ErrNotInitialized,
         'Tree is not initialized yet',
       );
     }
@@ -741,7 +741,7 @@ export class Tree {
     if (!this.context || !this.tree) {
       const ErrorMessage = 'Tree is not initialized yet';
       logger.fatal(ErrorMessage);
-      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
+      throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     const indexRange: [number, number] = [
@@ -759,7 +759,7 @@ export class Tree {
     if (!this.context || !this.tree) {
       const ErrorMessage = 'Tree is not initialized yet';
       logger.fatal(ErrorMessage);
-      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
+      throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     return this.tree.indexRangeToPosStructRange(range);
@@ -772,7 +772,7 @@ export class Tree {
     if (!this.context || !this.tree) {
       const ErrorMessage = 'Tree is not initialized yet';
       logger.fatal(ErrorMessage);
-      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
+      throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     const posRange: [CRDTTreePos, CRDTTreePos] = [
@@ -792,7 +792,7 @@ export class Tree {
     if (!this.context || !this.tree) {
       const ErrorMessage = 'Tree is not initialized yet';
       logger.fatal(ErrorMessage);
-      throw new YorkieError(Code.ErrOperationNotReady, ErrorMessage);
+      throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
     const posRange: [CRDTTreePos, CRDTTreePos] = [

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -43,6 +43,7 @@ import type {
   CRDTTreeNodeIDStruct,
 } from '@yorkie-js-sdk/src/document/crdt/tree';
 import type * as Devtools from '@yorkie-js-sdk/src/devtools/types';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * NOTE(hackerwins): In normal case, we should define the following types in
@@ -651,9 +652,9 @@ export class Tree {
     range: [Array<number>, Array<number>],
   ): TreePosStructRange {
     if (!this.context || !this.tree) {
-      logger.fatal('it is not initialized yet');
-      // @ts-ignore
-      return;
+      const ERROR_MESSAGE = 'Tree is not initialized yet';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
     }
 
     const indexRange: [number, number] = [
@@ -669,9 +670,9 @@ export class Tree {
    */
   indexRangeToPosRange(range: [number, number]): TreePosStructRange {
     if (!this.context || !this.tree) {
-      logger.fatal('it is not initialized yet');
-      // @ts-ignore
-      return;
+      const ERROR_MESSAGE = 'Tree is not initialized yet';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
     }
 
     return this.tree.indexRangeToPosStructRange(range);
@@ -682,9 +683,9 @@ export class Tree {
    */
   posRangeToIndexRange(range: TreePosStructRange): [number, number] {
     if (!this.context || !this.tree) {
-      logger.fatal('it is not initialized yet');
-      // @ts-ignore
-      return;
+      const ERROR_MESSAGE = 'Tree is not initialized yet';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
     }
 
     const posRange: [CRDTTreePos, CRDTTreePos] = [
@@ -702,9 +703,9 @@ export class Tree {
     range: TreePosStructRange,
   ): [Array<number>, Array<number>] {
     if (!this.context || !this.tree) {
-      logger.fatal('it is not initialized yet');
-      // @ts-ignore
-      return;
+      const ERROR_MESSAGE = 'Tree is not initialized yet';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrOperationNotReady, ERROR_MESSAGE);
     }
 
     const posRange: [CRDTTreePos, CRDTTreePos] = [

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -154,7 +154,10 @@ function createCRDTTreeNode(context: ChangeContext, content: TreeNode) {
  */
 function validateTextNode(textNode: TextNode): boolean {
   if (!textNode.value.length) {
-    throw new Error('text node cannot have empty value');
+    throw new YorkieError(
+      Code.ErrInvalidArgument,
+      'text node cannot have empty value',
+    );
   }
 
   return true;
@@ -173,7 +176,10 @@ function validateTreeNodes(treeNodes: Array<TreeNode>): boolean {
     for (const treeNode of treeNodes) {
       const { type } = treeNode;
       if (type !== DefaultTextType) {
-        throw new Error('element node and text node cannot be passed together');
+        throw new YorkieError(
+          Code.ErrInvalidArgument,
+          'element node and text node cannot be passed together',
+        );
       }
       validateTextNode(treeNode as TextNode);
     }
@@ -181,7 +187,10 @@ function validateTreeNodes(treeNodes: Array<TreeNode>): boolean {
     for (const treeNode of treeNodes) {
       const { type } = treeNode;
       if (type === DefaultTextType) {
-        throw new Error('element node and text node cannot be passed together');
+        throw new YorkieError(
+          Code.ErrInvalidArgument,
+          'element node and text node cannot be passed together',
+        );
       }
     }
   }
@@ -248,7 +257,10 @@ export class Tree {
    */
   public getSize(): number {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
 
     return this.tree.getSize();
@@ -259,7 +271,10 @@ export class Tree {
    */
   public getNodeSize(): number {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
 
     return this.tree.getNodeSize();
@@ -270,7 +285,10 @@ export class Tree {
    */
   public getIndexTree(): IndexTree<CRDTTreeNode> {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
 
     return this.tree.getIndexTree();
@@ -281,11 +299,17 @@ export class Tree {
    */
   public styleByPath(path: Array<number>, attributes: { [key: string]: any }) {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
 
     if (!path.length) {
-      throw new Error('path should not be empty');
+      throw new YorkieError(
+        Code.ErrInvalidArgument,
+        'path should not be empty',
+      );
     }
     const [fromPos, toPos] = this.tree.pathToPosRange(path);
     const ticket = this.context.issueTimeTicket();
@@ -318,11 +342,17 @@ export class Tree {
     attributes: { [key: string]: any },
   ) {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
 
     if (fromIdx > toIdx) {
-      throw new Error('from should be less than or equal to to');
+      throw new YorkieError(
+        Code.ErrInvalidArgument,
+        'from should be less than or equal to to',
+      );
     }
 
     const fromPos = this.tree.findPos(fromIdx);
@@ -361,11 +391,17 @@ export class Tree {
     attributesToRemove: Array<string>,
   ) {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
 
     if (fromIdx > toIdx) {
-      throw new Error('from should be less than or equal to to');
+      throw new YorkieError(
+        Code.ErrInvalidArgument,
+        'from should be less than or equal to to',
+      );
     }
 
     const fromPos = this.tree.findPos(fromIdx);
@@ -471,13 +507,22 @@ export class Tree {
     splitLevel = 0,
   ): boolean {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
     if (fromPath.length !== toPath.length) {
-      throw new Error('path length should be equal');
+      throw new YorkieError(
+        Code.ErrInvalidArgument,
+        'path length should be equal',
+      );
     }
     if (!fromPath.length || !toPath.length) {
-      throw new Error('path should not be empty');
+      throw new YorkieError(
+        Code.ErrInvalidArgument,
+        'path should not be empty',
+      );
     }
 
     const fromPos = this.tree.pathToPos(fromPath);
@@ -501,13 +546,22 @@ export class Tree {
     splitLevel = 0,
   ): boolean {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
     if (fromPath.length !== toPath.length) {
-      throw new Error('path length should be equal');
+      throw new YorkieError(
+        Code.ErrInvalidArgument,
+        'path length should be equal',
+      );
     }
     if (!fromPath.length || !toPath.length) {
-      throw new Error('path should not be empty');
+      throw new YorkieError(
+        Code.ErrInvalidArgument,
+        'path should not be empty',
+      );
     }
 
     const fromPos = this.tree.pathToPos(fromPath);
@@ -526,10 +580,16 @@ export class Tree {
     splitLevel = 0,
   ): boolean {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
     if (fromIdx > toIdx) {
-      throw new Error('from should be less than or equal to to');
+      throw new YorkieError(
+        Code.ErrInvalidArgument,
+        'from should be less than or equal to to',
+      );
     }
 
     const fromPos = this.tree.findPos(fromIdx);
@@ -553,10 +613,16 @@ export class Tree {
     splitLevel = 0,
   ): boolean {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
     if (fromIdx > toIdx) {
-      throw new Error('from should be less than or equal to to');
+      throw new YorkieError(
+        Code.ErrInvalidArgument,
+        'from should be less than or equal to to',
+      );
     }
 
     const fromPos = this.tree.findPos(fromIdx);
@@ -570,7 +636,10 @@ export class Tree {
    */
   public toXML(): string {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
 
     return this.tree.toXML();
@@ -581,7 +650,10 @@ export class Tree {
    */
   public toJSON(): string {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
 
     return this.tree.toJSON();
@@ -593,7 +665,10 @@ export class Tree {
    */
   public toJSForTest(): Devtools.JSONElement {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
 
     return this.tree.toJSForTest();
@@ -606,7 +681,10 @@ export class Tree {
    */
   public toJSInfoForTest(): Devtools.TreeNodeInfo {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
 
     return this.tree.toJSInfoForTest();
@@ -617,7 +695,10 @@ export class Tree {
    */
   public getRootTreeNode() {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
 
     return this.tree.getRootTreeNode();
@@ -628,7 +709,10 @@ export class Tree {
    */
   public indexToPath(index: number): Array<number> {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
 
     return this.tree.indexToPath(index);
@@ -639,7 +723,10 @@ export class Tree {
    */
   public pathToIndex(path: Array<number>): number {
     if (!this.context || !this.tree) {
-      throw new Error('it is not initialized yet');
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'Tree is not initialized yet',
+      );
     }
 
     return this.tree.pathToIndex(path);

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -740,7 +740,6 @@ export class Tree {
   ): TreePosStructRange {
     if (!this.context || !this.tree) {
       const ErrorMessage = 'Tree is not initialized yet';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
@@ -758,7 +757,6 @@ export class Tree {
   indexRangeToPosRange(range: [number, number]): TreePosStructRange {
     if (!this.context || !this.tree) {
       const ErrorMessage = 'Tree is not initialized yet';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
@@ -771,7 +769,6 @@ export class Tree {
   posRangeToIndexRange(range: TreePosStructRange): [number, number] {
     if (!this.context || !this.tree) {
       const ErrorMessage = 'Tree is not initialized yet';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 
@@ -791,7 +788,6 @@ export class Tree {
   ): [Array<number>, Array<number>] {
     if (!this.context || !this.tree) {
       const ErrorMessage = 'Tree is not initialized yet';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrNotInitialized, ErrorMessage);
     }
 

--- a/src/document/json/tree.ts
+++ b/src/document/json/tree.ts
@@ -32,7 +32,6 @@ import { TreeEditOperation } from '@yorkie-js-sdk/src/document/operation/tree_ed
 import { isEmpty, stringifyObjectValues } from '@yorkie-js-sdk/src/util/object';
 import { RHT } from '../crdt/rht';
 import { TreeStyleOperation } from '../operation/tree_style_operation';
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import type {
   ElementNode,
   TextNode,

--- a/src/document/operation/add_operation.ts
+++ b/src/document/operation/add_operation.ts
@@ -62,12 +62,10 @@ export class AddOperation extends Operation {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(parentObject instanceof CRDTArray)) {
       const ErrorMessage = `fail to execute, only array can execute add`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     const array = parentObject as CRDTArray;

--- a/src/document/operation/add_operation.ts
+++ b/src/document/operation/add_operation.ts
@@ -61,14 +61,14 @@ export class AddOperation extends Operation {
   public execute(root: CRDTRoot): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
-      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(parentObject instanceof CRDTArray)) {
-      const ERROR_MESSAGE = `fail to execute, only array can execute add`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to execute, only array can execute add`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     const array = parentObject as CRDTArray;
     const value = this.value.deepcopy();

--- a/src/document/operation/add_operation.ts
+++ b/src/document/operation/add_operation.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';

--- a/src/document/operation/add_operation.ts
+++ b/src/document/operation/add_operation.ts
@@ -23,6 +23,7 @@ import {
   Operation,
   ExecutionResult,
 } from '@yorkie-js-sdk/src/document/operation/operation';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * `AddOperation` is an operation representing adding an element to an Array.
@@ -60,10 +61,14 @@ export class AddOperation extends Operation {
   public execute(root: CRDTRoot): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
-      logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
+      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     if (!(parentObject instanceof CRDTArray)) {
-      logger.fatal(`fail to execute, only array can execute add`);
+      const ERROR_MESSAGE = `fail to execute, only array can execute add`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     const array = parentObject as CRDTArray;
     const value = this.value.deepcopy();

--- a/src/document/operation/edit_operation.ts
+++ b/src/document/operation/edit_operation.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import { RGATreeSplitPos } from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';

--- a/src/document/operation/edit_operation.ts
+++ b/src/document/operation/edit_operation.ts
@@ -85,12 +85,10 @@ export class EditOperation extends Operation {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(parentObject instanceof CRDTText)) {
       const ErrorMessage = `fail to execute, only Text can execute edit`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 

--- a/src/document/operation/edit_operation.ts
+++ b/src/document/operation/edit_operation.ts
@@ -84,14 +84,14 @@ export class EditOperation extends Operation {
   public execute<A extends Indexable>(root: CRDTRoot): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
-      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(parentObject instanceof CRDTText)) {
-      const ERROR_MESSAGE = `fail to execute, only Text can execute edit`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to execute, only Text can execute edit`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
     const text = parentObject as CRDTText<A>;

--- a/src/document/operation/edit_operation.ts
+++ b/src/document/operation/edit_operation.ts
@@ -25,6 +25,7 @@ import {
   ExecutionResult,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { Indexable } from '../document';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * `EditOperation` is an operation representing editing Text. Most of the same as
@@ -83,10 +84,14 @@ export class EditOperation extends Operation {
   public execute<A extends Indexable>(root: CRDTRoot): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
-      logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
+      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     if (!(parentObject instanceof CRDTText)) {
-      logger.fatal(`fail to execute, only Text can execute edit`);
+      const ERROR_MESSAGE = `fail to execute, only Text can execute edit`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
 
     const text = parentObject as CRDTText<A>;

--- a/src/document/operation/increase_operation.ts
+++ b/src/document/operation/increase_operation.ts
@@ -28,6 +28,7 @@ import {
 } from '@yorkie-js-sdk/src/document/crdt/primitive';
 import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { CRDTCounter } from '@yorkie-js-sdk/src/document/crdt/counter';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * `IncreaseOperation` represents an operation that increments a numeric value to Counter.
@@ -62,10 +63,14 @@ export class IncreaseOperation extends Operation {
   public execute(root: CRDTRoot): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
-      logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
+      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     if (!(parentObject instanceof CRDTCounter)) {
-      logger.fatal(`fail to execute, only Counter can execute increase`);
+      const ERROR_MESSAGE = `fail to execute, only Counter can execute increase`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     const counter = parentObject as CRDTCounter;
     const value = this.value.deepcopy() as Primitive;

--- a/src/document/operation/increase_operation.ts
+++ b/src/document/operation/increase_operation.ts
@@ -26,7 +26,6 @@ import {
   Primitive,
   PrimitiveType,
 } from '@yorkie-js-sdk/src/document/crdt/primitive';
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { CRDTCounter } from '@yorkie-js-sdk/src/document/crdt/counter';
 import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 

--- a/src/document/operation/increase_operation.ts
+++ b/src/document/operation/increase_operation.ts
@@ -63,14 +63,14 @@ export class IncreaseOperation extends Operation {
   public execute(root: CRDTRoot): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
-      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(parentObject instanceof CRDTCounter)) {
-      const ERROR_MESSAGE = `fail to execute, only Counter can execute increase`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to execute, only Counter can execute increase`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     const counter = parentObject as CRDTCounter;
     const value = this.value.deepcopy() as Primitive;

--- a/src/document/operation/increase_operation.ts
+++ b/src/document/operation/increase_operation.ts
@@ -64,12 +64,10 @@ export class IncreaseOperation extends Operation {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(parentObject instanceof CRDTCounter)) {
       const ErrorMessage = `fail to execute, only Counter can execute increase`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     const counter = parentObject as CRDTCounter;

--- a/src/document/operation/move_operation.ts
+++ b/src/document/operation/move_operation.ts
@@ -66,12 +66,10 @@ export class MoveOperation extends Operation {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(parentObject instanceof CRDTArray)) {
       const ErrorMessage = `fail to execute, only array can execute move`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     const array = parentObject as CRDTArray;

--- a/src/document/operation/move_operation.ts
+++ b/src/document/operation/move_operation.ts
@@ -65,14 +65,14 @@ export class MoveOperation extends Operation {
   public execute(root: CRDTRoot): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
-      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(parentObject instanceof CRDTArray)) {
-      const ERROR_MESSAGE = `fail to execute, only array can execute move`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to execute, only array can execute move`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     const array = parentObject as CRDTArray;
     const previousIndex = Number(array.subPathOf(this.createdAt));

--- a/src/document/operation/move_operation.ts
+++ b/src/document/operation/move_operation.ts
@@ -22,6 +22,7 @@ import {
   Operation,
   ExecutionResult,
 } from '@yorkie-js-sdk/src/document/operation/operation';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * `MoveOperation` is an operation representing moving an element to an Array.
@@ -64,10 +65,14 @@ export class MoveOperation extends Operation {
   public execute(root: CRDTRoot): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
-      logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
+      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     if (!(parentObject instanceof CRDTArray)) {
-      logger.fatal(`fail to execute, only array can execute move`);
+      const ERROR_MESSAGE = `fail to execute, only array can execute move`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     const array = parentObject as CRDTArray;
     const previousIndex = Number(array.subPathOf(this.createdAt));

--- a/src/document/operation/move_operation.ts
+++ b/src/document/operation/move_operation.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';

--- a/src/document/operation/operation.ts
+++ b/src/document/operation/operation.ts
@@ -211,10 +211,7 @@ export abstract class Operation {
     // it doesn't have an executedAt yet. The executedAt is set when
     // the operation is executed through undo or redo.
     if (!this.executedAt) {
-      throw new YorkieError(
-        Code.ErrOperationNotReady,
-        'executedAt is not set yet',
-      );
+      throw new YorkieError(Code.ErrNotReady, 'executedAt is not set yet');
     }
     return this.executedAt;
   }

--- a/src/document/operation/operation.ts
+++ b/src/document/operation/operation.ts
@@ -19,6 +19,7 @@ import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { TreeNode } from '@yorkie-js-sdk/src/document/crdt/tree';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import { Indexable } from '@yorkie-js-sdk/src/document/document';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * `OpSource` represents the source of the operation. It is used to handle
@@ -210,7 +211,10 @@ export abstract class Operation {
     // it doesn't have an executedAt yet. The executedAt is set when
     // the operation is executed through undo or redo.
     if (!this.executedAt) {
-      throw new Error(`executedAt has not been set yet`);
+      throw new YorkieError(
+        Code.ErrOperationNotReady,
+        'executedAt is not set yet',
+      );
     }
     return this.executedAt;
   }

--- a/src/document/operation/remove_operation.ts
+++ b/src/document/operation/remove_operation.ts
@@ -69,14 +69,14 @@ export class RemoveOperation extends Operation {
       this.getParentCreatedAt(),
     ) as CRDTContainer;
     if (!container) {
-      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(container instanceof CRDTContainer)) {
-      const ERROR_MESSAGE = `only object and array can execute remove: ${container}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `only object and array can execute remove: ${container}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
     // NOTE(chacha912): Handle cases where operation cannot be executed during undo and redo.

--- a/src/document/operation/remove_operation.ts
+++ b/src/document/operation/remove_operation.ts
@@ -30,6 +30,7 @@ import {
 import { CRDTObject } from '@yorkie-js-sdk/src/document/crdt/object';
 import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';
 import { SetOperation } from '@yorkie-js-sdk/src/document/operation/set_operation';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * `RemoveOperation` is an operation that removes an element from `CRDTContainer`.
@@ -68,10 +69,14 @@ export class RemoveOperation extends Operation {
       this.getParentCreatedAt(),
     ) as CRDTContainer;
     if (!container) {
-      logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
+      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     if (!(container instanceof CRDTContainer)) {
-      logger.fatal(`only object and array can execute remove: ${container}`);
+      const ERROR_MESSAGE = `only object and array can execute remove: ${container}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
 
     // NOTE(chacha912): Handle cases where operation cannot be executed during undo and redo.

--- a/src/document/operation/remove_operation.ts
+++ b/src/document/operation/remove_operation.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import {

--- a/src/document/operation/remove_operation.ts
+++ b/src/document/operation/remove_operation.ts
@@ -70,12 +70,10 @@ export class RemoveOperation extends Operation {
     ) as CRDTContainer;
     if (!container) {
       const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(container instanceof CRDTContainer)) {
       const ErrorMessage = `only object and array can execute remove: ${container}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 

--- a/src/document/operation/set_operation.ts
+++ b/src/document/operation/set_operation.ts
@@ -25,6 +25,7 @@ import {
   ExecutionResult,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { RemoveOperation } from '@yorkie-js-sdk/src/document/operation/remove_operation';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * `SetOperation` represents an operation that stores the value corresponding to the
@@ -66,10 +67,14 @@ export class SetOperation extends Operation {
   ): ExecutionResult | undefined {
     const obj = root.findByCreatedAt(this.getParentCreatedAt()) as CRDTObject;
     if (!obj) {
-      logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
+      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     if (!(obj instanceof CRDTObject)) {
-      logger.fatal(`fail to execute, only object can execute set`);
+      const ERROR_MESSAGE = `fail to execute, only object can execute set`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
 
     // NOTE(chacha912): Handle cases where operation cannot be executed during undo and redo.

--- a/src/document/operation/set_operation.ts
+++ b/src/document/operation/set_operation.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';

--- a/src/document/operation/set_operation.ts
+++ b/src/document/operation/set_operation.ts
@@ -67,14 +67,14 @@ export class SetOperation extends Operation {
   ): ExecutionResult | undefined {
     const obj = root.findByCreatedAt(this.getParentCreatedAt()) as CRDTObject;
     if (!obj) {
-      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(obj instanceof CRDTObject)) {
-      const ERROR_MESSAGE = `fail to execute, only object can execute set`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to execute, only object can execute set`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
     // NOTE(chacha912): Handle cases where operation cannot be executed during undo and redo.

--- a/src/document/operation/set_operation.ts
+++ b/src/document/operation/set_operation.ts
@@ -68,12 +68,10 @@ export class SetOperation extends Operation {
     const obj = root.findByCreatedAt(this.getParentCreatedAt()) as CRDTObject;
     if (!obj) {
       const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(obj instanceof CRDTObject)) {
       const ErrorMessage = `fail to execute, only object can execute set`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 

--- a/src/document/operation/style_operation.ts
+++ b/src/document/operation/style_operation.ts
@@ -79,12 +79,10 @@ export class StyleOperation extends Operation {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(parentObject instanceof CRDTText)) {
       const ErrorMessage = `fail to execute, only Text can execute edit`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     const text = parentObject as CRDTText<A>;

--- a/src/document/operation/style_operation.ts
+++ b/src/document/operation/style_operation.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import { RGATreeSplitPos } from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';

--- a/src/document/operation/style_operation.ts
+++ b/src/document/operation/style_operation.ts
@@ -25,6 +25,7 @@ import {
   ExecutionResult,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { Indexable } from '../document';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  *  `StyleOperation` is an operation applies the style of the given range to Text.
@@ -77,10 +78,14 @@ export class StyleOperation extends Operation {
   public execute<A extends Indexable>(root: CRDTRoot): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
-      logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
+      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     if (!(parentObject instanceof CRDTText)) {
-      logger.fatal(`fail to execute, only Text can execute edit`);
+      const ERROR_MESSAGE = `fail to execute, only Text can execute edit`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     const text = parentObject as CRDTText<A>;
     const [, pairs, changes] = text.setStyle(

--- a/src/document/operation/style_operation.ts
+++ b/src/document/operation/style_operation.ts
@@ -78,14 +78,14 @@ export class StyleOperation extends Operation {
   public execute<A extends Indexable>(root: CRDTRoot): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
-      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(parentObject instanceof CRDTText)) {
-      const ERROR_MESSAGE = `fail to execute, only Text can execute edit`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to execute, only Text can execute edit`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     const text = parentObject as CRDTText<A>;
     const [, pairs, changes] = text.setStyle(

--- a/src/document/operation/tree_edit_operation.ts
+++ b/src/document/operation/tree_edit_operation.ts
@@ -28,6 +28,7 @@ import {
   OperationInfo,
   ExecutionResult,
 } from '@yorkie-js-sdk/src/document/operation/operation';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * `TreeEditOperation` is an operation representing Tree editing.
@@ -85,10 +86,14 @@ export class TreeEditOperation extends Operation {
   public execute(root: CRDTRoot): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
-      logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
+      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     if (!(parentObject instanceof CRDTTree)) {
-      logger.fatal(`fail to execute, only Tree can execute edit`);
+      const ERROR_MESSAGE = `fail to execute, only Tree can execute edit`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     const editedAt = this.getExecutedAt();
     const tree = parentObject as CRDTTree;

--- a/src/document/operation/tree_edit_operation.ts
+++ b/src/document/operation/tree_edit_operation.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import {

--- a/src/document/operation/tree_edit_operation.ts
+++ b/src/document/operation/tree_edit_operation.ts
@@ -86,14 +86,14 @@ export class TreeEditOperation extends Operation {
   public execute(root: CRDTRoot): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
-      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(parentObject instanceof CRDTTree)) {
-      const ERROR_MESSAGE = `fail to execute, only Tree can execute edit`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to execute, only Tree can execute edit`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     const editedAt = this.getExecutedAt();
     const tree = parentObject as CRDTTree;

--- a/src/document/operation/tree_edit_operation.ts
+++ b/src/document/operation/tree_edit_operation.ts
@@ -87,12 +87,10 @@ export class TreeEditOperation extends Operation {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(parentObject instanceof CRDTTree)) {
       const ErrorMessage = `fail to execute, only Tree can execute edit`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     const editedAt = this.getExecutedAt();

--- a/src/document/operation/tree_style_operation.ts
+++ b/src/document/operation/tree_style_operation.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import {

--- a/src/document/operation/tree_style_operation.ts
+++ b/src/document/operation/tree_style_operation.ts
@@ -108,14 +108,14 @@ export class TreeStyleOperation extends Operation {
   public execute(root: CRDTRoot): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
-      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(parentObject instanceof CRDTTree)) {
-      const ERROR_MESSAGE = `fail to execute, only Tree can execute edit`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `fail to execute, only Tree can execute edit`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     const tree = parentObject as CRDTTree;
     let changes: Array<TreeChange>;

--- a/src/document/operation/tree_style_operation.ts
+++ b/src/document/operation/tree_style_operation.ts
@@ -28,6 +28,7 @@ import {
   ExecutionResult,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { GCPair } from '@yorkie-js-sdk/src/document/crdt/gc';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 /**
  * `TreeStyleOperation` represents an operation that modifies the style of the
@@ -107,10 +108,14 @@ export class TreeStyleOperation extends Operation {
   public execute(root: CRDTRoot): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
-      logger.fatal(`fail to find ${this.getParentCreatedAt()}`);
+      const ERROR_MESSAGE = `fail to find ${this.getParentCreatedAt()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     if (!(parentObject instanceof CRDTTree)) {
-      logger.fatal(`fail to execute, only Tree can execute edit`);
+      const ERROR_MESSAGE = `fail to execute, only Tree can execute edit`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     const tree = parentObject as CRDTTree;
     let changes: Array<TreeChange>;

--- a/src/document/operation/tree_style_operation.ts
+++ b/src/document/operation/tree_style_operation.ts
@@ -109,12 +109,10 @@ export class TreeStyleOperation extends Operation {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       const ErrorMessage = `fail to find ${this.getParentCreatedAt()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     if (!(parentObject instanceof CRDTTree)) {
       const ErrorMessage = `fail to execute, only Tree can execute edit`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     const tree = parentObject as CRDTTree;

--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -30,7 +30,7 @@ export enum Code {
   // ErrInvalidType is returned when the type is invalid.
   ErrInvalidType = 'ErrInvalidType',
 
-  // ErrDummy is returned when the error is intentional.
+  // ErrDummy is used to verify errors for testing purposes.
   ErrDummy = 'ErrDummy',
 
   // ErrDocumentNotAttached is returned when the document is not attached.
@@ -48,11 +48,14 @@ export enum Code {
   // ErrInvalidArgument is returned when the argument is invalid.
   ErrInvalidArgument = 'ErrInvalidArgument',
 
-  // ErrOperationNotReady is returned when another operation needs to be completed first.
-  ErrOperationNotReady = 'ErrOperationNotReady',
+  // ErrNotInitialized is returned when required initialization has not been completed.
+  ErrNotInitialized = 'ErrNotInitialized',
 
-  // ErrOperationNotPermitted is returned when the operation is not permitted.
-  ErrOperationNotPermitted = 'ErrOperationNotPermitted',
+  // ErrNotReady is returned when execution of following actions is not ready.
+  ErrNotReady = 'ErrNotReady',
+
+  // ErrRefused is returned when the execution is rejected.
+  ErrRefused = 'ErrRefused',
 }
 
 /**

--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -28,7 +28,10 @@ export enum Code {
   ErrUnimplemented = 'ErrUnimplemented',
 
   // Unsupported is returned when the operation is not supported.
-  Unsupported = 'unsupported',
+  ErrUnsupported = 'ErrUnsupported',
+
+  // ErrIntended is returned when the error is intended.
+  ErrIntended = 'ErrIntended',
 
   // ErrDocumentNotAttached is returned when the document is not attached.
   ErrDocumentNotAttached = 'ErrDocumentNotAttached',

--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -27,11 +27,11 @@ export enum Code {
   // ErrUnimplemented is returned when the operation is not implemented.
   ErrUnimplemented = 'ErrUnimplemented',
 
-  // Unsupported is returned when the operation is not supported.
-  ErrUnsupported = 'ErrUnsupported',
+  // ErrInvalidType is returned when the type is invalid.
+  ErrInvalidType = 'ErrInvalidType',
 
-  // ErrIntended is returned when the error is intended.
-  ErrIntended = 'ErrIntended',
+  // ErrDummy is returned when the error is intentional.
+  ErrDummy = 'ErrDummy',
 
   // ErrDocumentNotAttached is returned when the document is not attached.
   ErrDocumentNotAttached = 'ErrDocumentNotAttached',
@@ -51,8 +51,8 @@ export enum Code {
   // ErrOperationNotReady is returned when another operation needs to be completed first.
   ErrOperationNotReady = 'ErrOperationNotReady',
 
-  // ErrOperationBlocked is returned when the operation cannot proceed.
-  ErrOperationBlocked = 'ErrOperationBlocked',
+  // ErrOperationNotPermitted is returned when the operation is not permitted.
+  ErrOperationNotPermitted = 'ErrOperationNotPermitted',
 }
 
 /**
@@ -64,7 +64,6 @@ export class YorkieError extends Error {
 
   constructor(readonly code: Code, readonly message: string) {
     super(message);
-    this.toString = (): string =>
-      `${this.name}: [code=${this.code}]: ${this.message}`;
+    this.toString = (): string => `[code=${this.code}]: ${this.message}`;
   }
 }

--- a/src/util/error.ts
+++ b/src/util/error.ts
@@ -44,6 +44,12 @@ export enum Code {
 
   // ErrInvalidArgument is returned when the argument is invalid.
   ErrInvalidArgument = 'ErrInvalidArgument',
+
+  // ErrOperationNotReady is returned when another operation needs to be completed first.
+  ErrOperationNotReady = 'ErrOperationNotReady',
+
+  // ErrOperationBlocked is returned when the operation cannot proceed.
+  ErrOperationBlocked = 'ErrOperationBlocked',
 }
 
 /**

--- a/src/util/index_tree.ts
+++ b/src/util/index_tree.ts
@@ -15,6 +15,7 @@
  */
 
 import { TimeTicket } from '../yorkie';
+import { Code, YorkieError } from './error';
 
 /**
  * About `index`, `path`, `size` and `TreePos` in crdt.IndexTree.
@@ -129,7 +130,10 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
     this._children = children;
 
     if (this.isText && this._children.length > 0) {
-      throw new Error(`Text node cannot have children: ${this.type}`);
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
+        'Text node cannot have children',
+      );
     }
   }
 
@@ -303,7 +307,10 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   append(...newNode: Array<T>): void {
     if (this.isText) {
-      throw new Error('Text node cannot have children');
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
+        'Text node cannot have children',
+      );
     }
 
     this._children.push(...newNode);
@@ -319,7 +326,10 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   prepend(...newNode: Array<T>): void {
     if (this.isText) {
-      throw new Error('Text node cannot have children');
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
+        'Text node cannot have children',
+      );
     }
 
     this._children.unshift(...newNode);
@@ -333,12 +343,15 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   insertBefore(newNode: T, referenceNode: T): void {
     if (this.isText) {
-      throw new Error('Text node cannot have children');
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
+        'Text node cannot have children',
+      );
     }
 
     const offset = this._children.indexOf(referenceNode);
     if (offset === -1) {
-      throw new Error('child not found');
+      throw new YorkieError(Code.ErrInvalidArgument, 'child not found');
     }
 
     this.insertAtInternal(newNode, offset);
@@ -350,12 +363,15 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   insertAfter(newNode: T, referenceNode: T): void {
     if (this.isText) {
-      throw new Error('Text node cannot have children');
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
+        'Text node cannot have children',
+      );
     }
 
     const offset = this._children.indexOf(referenceNode);
     if (offset === -1) {
-      throw new Error('child not found');
+      throw new YorkieError(Code.ErrInvalidArgument, 'child not found');
     }
 
     this.insertAtInternal(newNode, offset + 1);
@@ -367,7 +383,10 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   insertAt(newNode: T, offset: number): void {
     if (this.isText) {
-      throw new Error('Text node cannot have children');
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
+        'Text node cannot have children',
+      );
     }
 
     this.insertAtInternal(newNode, offset);
@@ -379,12 +398,15 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   removeChild(child: T) {
     if (this.isText) {
-      throw new Error('Text node cannot have children');
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
+        'Text node cannot have children',
+      );
     }
 
     const offset = this._children.indexOf(child);
     if (offset === -1) {
-      throw new Error('child not found');
+      throw new YorkieError(Code.ErrInvalidArgument, 'child not found');
     }
 
     this._children.splice(offset, 1);
@@ -435,12 +457,15 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   insertAfterInternal(newNode: T, referenceNode: T): void {
     if (this.isText) {
-      throw new Error('Text node cannot have children');
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
+        'Text node cannot have children',
+      );
     }
 
     const offset = this._children.indexOf(referenceNode);
     if (offset === -1) {
-      throw new Error('child not found');
+      throw new YorkieError(Code.ErrInvalidArgument, 'child not found');
     }
 
     this.insertAtInternal(newNode, offset + 1);
@@ -452,7 +477,10 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   insertAtInternal(newNode: T, offset: number): void {
     if (this.isText) {
-      throw new Error('Text node cannot have children');
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
+        'Text node cannot have children',
+      );
     }
 
     this._children.splice(offset, 0, newNode);
@@ -465,7 +493,10 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   findOffset(node: T): number {
     if (this.isText) {
-      throw new Error('Text node cannot have children');
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
+        'Text node cannot have children',
+      );
     }
 
     if (node.isRemoved) {
@@ -489,7 +520,10 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   findBranchOffset(node: T): number {
     if (this.isText) {
-      throw new Error('Text node cannot have children');
+      throw new YorkieError(
+        Code.ErrOperationNotPermitted,
+        'Text node cannot have children',
+      );
     }
 
     let current: T | undefined = node;
@@ -577,15 +611,24 @@ function tokensBetween<T extends IndexTreeNode<T>>(
   callback: (token: TreeToken<T>, ended: boolean) => void,
 ) {
   if (from > to) {
-    throw new Error(`from is greater than to: ${from} > ${to}`);
+    throw new YorkieError(
+      Code.ErrInvalidArgument,
+      `from is greater than to: ${from} > ${to}`,
+    );
   }
 
   if (from > root.size) {
-    throw new Error(`from is out of range: ${from} > ${root.size}`);
+    throw new YorkieError(
+      Code.ErrInvalidArgument,
+      `from is out of range: ${from} > ${root.size}`,
+    );
   }
 
   if (to > root.size) {
-    throw new Error(`to is out of range: ${to} > ${root.size}`);
+    throw new YorkieError(
+      Code.ErrInvalidArgument,
+      `to is out of range: ${to} > ${root.size}`,
+    );
   }
 
   if (from === to) {
@@ -663,7 +706,10 @@ function findTreePos<T extends IndexTreeNode<T>>(
   preferText = true,
 ): TreePos<T> {
   if (index > node.size) {
-    throw new Error(`index is out of range: ${index} > ${node.size}`);
+    throw new YorkieError(
+      Code.ErrInvalidArgument,
+      `index is out of range: ${index} > ${node.size}`,
+    );
   }
 
   if (node.isText) {
@@ -764,7 +810,7 @@ export function findLeftmost<T extends IndexTreeNode<T>>(node: T): T {
  */
 function findTextPos<T extends IndexTreeNode<T>>(node: T, pathElement: number) {
   if (node.size < pathElement) {
-    throw new Error('unacceptable path');
+    throw new YorkieError(Code.ErrInvalidArgument, 'unacceptable path');
   }
 
   for (let i = 0; i < node.children.length; i++) {
@@ -834,7 +880,7 @@ export class IndexTree<T extends IndexTreeNode<T>> {
     if (node.isText) {
       const offset = node.parent!.findOffset(node);
       if (offset === -1) {
-        throw new Error('invalid treePos');
+        throw new YorkieError(Code.ErrInvalidArgument, 'invalid treePos');
       }
 
       const sizeOfLeftSiblings = addSizeOfLeftSiblings(
@@ -858,7 +904,7 @@ export class IndexTree<T extends IndexTreeNode<T>> {
     while (node.parent) {
       const offset = node.parent.findOffset(node);
       if (offset === -1) {
-        throw new Error('invalid treePos');
+        throw new YorkieError(Code.ErrInvalidArgument, 'invalid treePos');
       }
 
       path.push(offset);
@@ -882,7 +928,7 @@ export class IndexTree<T extends IndexTreeNode<T>> {
    */
   public pathToTreePos(path: Array<number>): TreePos<T> {
     if (!path.length) {
-      throw new Error('unacceptable path');
+      throw new YorkieError(Code.ErrInvalidArgument, 'unacceptable path');
     }
 
     let node = this.root;
@@ -891,7 +937,7 @@ export class IndexTree<T extends IndexTreeNode<T>> {
       node = node.children[pathElement];
 
       if (!node) {
-        throw new Error('unacceptable path');
+        throw new YorkieError(Code.ErrInvalidArgument, 'unacceptable path');
       }
     }
 
@@ -900,7 +946,7 @@ export class IndexTree<T extends IndexTreeNode<T>> {
     }
 
     if (node.children.length < path[path.length - 1]) {
-      throw new Error('unacceptable path');
+      throw new YorkieError(Code.ErrInvalidArgument, 'unacceptable path');
     }
 
     return {
@@ -965,7 +1011,7 @@ export class IndexTree<T extends IndexTreeNode<T>> {
       const parent = node.parent! as T;
       const offsetOfNode = parent.findOffset(node);
       if (offsetOfNode === -1) {
-        throw new Error('invalid pos');
+        throw new YorkieError(Code.ErrInvalidArgument, 'invalid pos');
       }
 
       size += addSizeOfLeftSiblings(parent, offsetOfNode);
@@ -979,7 +1025,7 @@ export class IndexTree<T extends IndexTreeNode<T>> {
       const parent = node.parent;
       const offsetOfNode = parent.findOffset(node);
       if (offsetOfNode === -1) {
-        throw new Error('invalid pos');
+        throw new YorkieError(Code.ErrInvalidArgument, 'invalid pos');
       }
 
       size += addSizeOfLeftSiblings(parent, offsetOfNode);

--- a/src/util/index_tree.ts
+++ b/src/util/index_tree.ts
@@ -130,10 +130,7 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
     this._children = children;
 
     if (this.isText && this._children.length > 0) {
-      throw new YorkieError(
-        Code.ErrOperationNotPermitted,
-        'Text node cannot have children',
-      );
+      throw new YorkieError(Code.ErrRefused, 'Text node cannot have children');
     }
   }
 
@@ -307,10 +304,7 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   append(...newNode: Array<T>): void {
     if (this.isText) {
-      throw new YorkieError(
-        Code.ErrOperationNotPermitted,
-        'Text node cannot have children',
-      );
+      throw new YorkieError(Code.ErrRefused, 'Text node cannot have children');
     }
 
     this._children.push(...newNode);
@@ -326,10 +320,7 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   prepend(...newNode: Array<T>): void {
     if (this.isText) {
-      throw new YorkieError(
-        Code.ErrOperationNotPermitted,
-        'Text node cannot have children',
-      );
+      throw new YorkieError(Code.ErrRefused, 'Text node cannot have children');
     }
 
     this._children.unshift(...newNode);
@@ -343,10 +334,7 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   insertBefore(newNode: T, referenceNode: T): void {
     if (this.isText) {
-      throw new YorkieError(
-        Code.ErrOperationNotPermitted,
-        'Text node cannot have children',
-      );
+      throw new YorkieError(Code.ErrRefused, 'Text node cannot have children');
     }
 
     const offset = this._children.indexOf(referenceNode);
@@ -363,10 +351,7 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   insertAfter(newNode: T, referenceNode: T): void {
     if (this.isText) {
-      throw new YorkieError(
-        Code.ErrOperationNotPermitted,
-        'Text node cannot have children',
-      );
+      throw new YorkieError(Code.ErrRefused, 'Text node cannot have children');
     }
 
     const offset = this._children.indexOf(referenceNode);
@@ -383,10 +368,7 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   insertAt(newNode: T, offset: number): void {
     if (this.isText) {
-      throw new YorkieError(
-        Code.ErrOperationNotPermitted,
-        'Text node cannot have children',
-      );
+      throw new YorkieError(Code.ErrRefused, 'Text node cannot have children');
     }
 
     this.insertAtInternal(newNode, offset);
@@ -398,10 +380,7 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   removeChild(child: T) {
     if (this.isText) {
-      throw new YorkieError(
-        Code.ErrOperationNotPermitted,
-        'Text node cannot have children',
-      );
+      throw new YorkieError(Code.ErrRefused, 'Text node cannot have children');
     }
 
     const offset = this._children.indexOf(child);
@@ -457,10 +436,7 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   insertAfterInternal(newNode: T, referenceNode: T): void {
     if (this.isText) {
-      throw new YorkieError(
-        Code.ErrOperationNotPermitted,
-        'Text node cannot have children',
-      );
+      throw new YorkieError(Code.ErrRefused, 'Text node cannot have children');
     }
 
     const offset = this._children.indexOf(referenceNode);
@@ -477,10 +453,7 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   insertAtInternal(newNode: T, offset: number): void {
     if (this.isText) {
-      throw new YorkieError(
-        Code.ErrOperationNotPermitted,
-        'Text node cannot have children',
-      );
+      throw new YorkieError(Code.ErrRefused, 'Text node cannot have children');
     }
 
     this._children.splice(offset, 0, newNode);
@@ -493,10 +466,7 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   findOffset(node: T): number {
     if (this.isText) {
-      throw new YorkieError(
-        Code.ErrOperationNotPermitted,
-        'Text node cannot have children',
-      );
+      throw new YorkieError(Code.ErrRefused, 'Text node cannot have children');
     }
 
     if (node.isRemoved) {
@@ -520,10 +490,7 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
    */
   findBranchOffset(node: T): number {
     if (this.isText) {
-      throw new YorkieError(
-        Code.ErrOperationNotPermitted,
-        'Text node cannot have children',
-      );
+      throw new YorkieError(Code.ErrRefused, 'Text node cannot have children');
     }
 
     let current: T | undefined = node;

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -91,7 +91,7 @@ export const logger = {
     }
   },
 
-  fatal: (message: string, ...messages: Array<unknown>): void => {
+  fatal: (...messages: Array<unknown>): void => {
     if (typeof console != 'undefined') {
       if (typeof console.error !== 'undefined') {
         console.error('YORKIE F:', ...messages);

--- a/src/util/logger.ts
+++ b/src/util/logger.ts
@@ -99,8 +99,6 @@ export const logger = {
         console.log('YORKIE F:', ...messages);
       }
     }
-
-    throw new Error(`YORKIE F: ${message}`);
   },
 
   isEnabled: (l: LogLevel): boolean => {

--- a/src/util/observable.ts
+++ b/src/util/observable.ts
@@ -115,7 +115,7 @@ class ObserverProxy<T> implements Observer<T> {
     if (this.finalized) {
       const ErrorMessage = 'observable is finalized due to previous error';
       logger.fatal(ErrorMessage);
-      throw new YorkieError(Code.ErrOperationNotPermitted, ErrorMessage);
+      throw new YorkieError(Code.ErrRefused, ErrorMessage);
     }
 
     if (typeof nextOrObserver === 'object') {

--- a/src/util/observable.ts
+++ b/src/util/observable.ts
@@ -107,15 +107,15 @@ class ObserverProxy<T> implements Observer<T> {
     let observer: Observer<T>;
 
     if (!nextOrObserver) {
-      const ERROR_MESSAGE = 'missing observer';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = 'missing observer';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
     if (this.finalized) {
-      const ERROR_MESSAGE = 'observable is finalized due to previous error';
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrOperationNotPermitted, ERROR_MESSAGE);
+      const ErrorMessage = 'observable is finalized due to previous error';
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrOperationNotPermitted, ErrorMessage);
     }
 
     if (typeof nextOrObserver === 'object') {

--- a/src/util/observable.ts
+++ b/src/util/observable.ts
@@ -115,7 +115,7 @@ class ObserverProxy<T> implements Observer<T> {
     if (this.finalized) {
       const ERROR_MESSAGE = 'observable is finalized due to previous error';
       logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrOperationBlocked, ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrOperationNotPermitted, ERROR_MESSAGE);
     }
 
     if (typeof nextOrObserver === 'object') {

--- a/src/util/observable.ts
+++ b/src/util/observable.ts
@@ -108,13 +108,11 @@ class ObserverProxy<T> implements Observer<T> {
 
     if (!nextOrObserver) {
       const ErrorMessage = 'missing observer';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
 
     if (this.finalized) {
       const ErrorMessage = 'observable is finalized due to previous error';
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrRefused, ErrorMessage);
     }
 

--- a/src/util/observable.ts
+++ b/src/util/observable.ts
@@ -16,6 +16,7 @@
 
 import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { uuid } from '@yorkie-js-sdk/src/util/uuid';
+import { Code, YorkieError } from './error';
 
 export type NextFn<T> = (value: T) => void;
 
@@ -106,11 +107,15 @@ class ObserverProxy<T> implements Observer<T> {
     let observer: Observer<T>;
 
     if (!nextOrObserver) {
-      logger.fatal('missing observer');
+      const ERROR_MESSAGE = 'missing observer';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
 
     if (this.finalized) {
-      logger.fatal('observable is finalized due to previous error');
+      const ERROR_MESSAGE = 'observable is finalized due to previous error';
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrOperationBlocked, ERROR_MESSAGE);
     }
 
     if (typeof nextOrObserver === 'object') {

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -15,6 +15,7 @@
  */
 
 import { logger } from '@yorkie-js-sdk/src/util/logger';
+import { Code, YorkieError } from './error';
 
 /**
  * `SplayNode` is a node of SplayTree.
@@ -206,9 +207,9 @@ export class SplayTree<V> {
       }
     }
     if (pos > node.getLength()) {
-      logger.fatal(
-        `out of index range: pos: ${pos} > node.length: ${node.getLength()}`,
-      );
+      const ERROR_MESSAGE = `out of index range: pos: ${pos} > node.length: ${node.getLength()}`;
+      logger.fatal(ERROR_MESSAGE);
+      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
     }
     return [node, pos];
   }

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -207,9 +207,9 @@ export class SplayTree<V> {
       }
     }
     if (pos > node.getLength()) {
-      const ERROR_MESSAGE = `out of index range: pos: ${pos} > node.length: ${node.getLength()}`;
-      logger.fatal(ERROR_MESSAGE);
-      throw new YorkieError(Code.ErrInvalidArgument, ERROR_MESSAGE);
+      const ErrorMessage = `out of index range: pos: ${pos} > node.length: ${node.getLength()}`;
+      logger.fatal(ErrorMessage);
+      throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     return [node, pos];
   }

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
 import { Code, YorkieError } from './error';
 
 /**

--- a/src/util/splay_tree.ts
+++ b/src/util/splay_tree.ts
@@ -208,7 +208,6 @@ export class SplayTree<V> {
     }
     if (pos > node.getLength()) {
       const ErrorMessage = `out of index range: pos: ${pos} > node.length: ${node.getLength()}`;
-      logger.fatal(ErrorMessage);
       throw new YorkieError(Code.ErrInvalidArgument, ErrorMessage);
     }
     return [node, pos];

--- a/test/bench/tree.bench.ts
+++ b/test/bench/tree.bench.ts
@@ -98,7 +98,7 @@ const benchmarkTreeConvert = (size: number) => {
 
     root.tree = new Tree({
       type: 'doc',
-      children: [{ type: 'p', children: children }],
+      children: [{ type: 'p', children }],
     });
   });
 

--- a/test/helper/helper.ts
+++ b/test/helper/helper.ts
@@ -36,6 +36,7 @@ import { InitialChangeID } from '@yorkie-js-sdk/src/document/change/change_id';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import { CRDTObject } from '@yorkie-js-sdk/src/document/crdt/object';
 import { ElementRHT } from '@yorkie-js-sdk/src/document/crdt/element_rht';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 export type Indexable = Record<string, any>;
 
@@ -66,9 +67,12 @@ export class EventCollector<E = string> {
             resolve();
           } else {
             reject(
-              new Error(`event is not equal ${count}-
-                expected: ${JSON.stringify(event)},
-                actual: ${JSON.stringify(this.events[count - 1])}`),
+              new YorkieError(
+                Code.ErrInvalidArgument,
+                `event is not equal  ${count}-
+              expected: ${JSON.stringify(event)},
+              actual: ${JSON.stringify(this.events[count - 1])}`,
+              ),
             );
           }
           return;

--- a/test/integration/client_test.ts
+++ b/test/integration/client_test.ts
@@ -32,7 +32,7 @@ import {
   withTwoClientsAndDocuments,
 } from '@yorkie-js-sdk/test/integration/integration_helper';
 import { ConnectError, Code as ConnectCode } from '@connectrpc/connect';
-import { Code } from '@yorkie-js-sdk/src/util/error';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 describe.sequential('Client', function () {
   afterEach(() => {
@@ -133,7 +133,7 @@ describe.sequential('Client', function () {
       // Simulate network error with fetch
       vi.stubGlobal('fetch', () => {
         return Promise.resolve().then(() => {
-          throw new Error('Failed to fetch');
+          throw new YorkieError(Code.ErrDummy, 'Failed to fetch');
         });
       });
 
@@ -211,7 +211,7 @@ describe.sequential('Client', function () {
     // Simulate network error
     vi.stubGlobal('fetch', () => {
       return Promise.resolve().then(() => {
-        throw new Error('Failed to fetch');
+        throw new YorkieError(Code.ErrDummy, 'Failed to fetch');
       });
     });
 

--- a/test/integration/object_test.ts
+++ b/test/integration/object_test.ts
@@ -8,7 +8,7 @@ import {
   testRPCAddr,
 } from '@yorkie-js-sdk/test/integration/integration_helper';
 import { toStringHistoryOp } from '@yorkie-js-sdk/test/helper/helper';
-import { YorkieError } from '@yorkie-js-sdk/src/util/error';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 describe('Object', function () {
   it('valid key test', function () {
@@ -63,7 +63,7 @@ describe('Object', function () {
     assert.throws(() => {
       doc.update((root) => {
         root['k2'].push('4');
-        throw new Error('dummy error');
+        throw new YorkieError(Code.ErrDummy, 'dummy error');
       }, 'push "4"');
     }, 'dummy error');
     assert.equal(

--- a/test/integration/primitive_test.ts
+++ b/test/integration/primitive_test.ts
@@ -36,11 +36,11 @@ describe('Primitive', function () {
     });
     assert.equal('{"k1":{"k1-1":1,"k1-2":2}}', doc.toSortedJSON());
     assert.throws(() => {
-      const ERROR_MESSAGE = 'dummy error';
+      const ErrorMessage = 'dummy error';
       doc.update((root) => {
         delete root['k1']['k1-1'];
-        throw new YorkieError(Code.ErrDummy, ERROR_MESSAGE);
-      }, ERROR_MESSAGE);
+        throw new YorkieError(Code.ErrDummy, ErrorMessage);
+      }, ErrorMessage);
     });
     assert.equal('{"k1":{"k1-1":1,"k1-2":2}}', doc.toSortedJSON());
   });

--- a/test/integration/primitive_test.ts
+++ b/test/integration/primitive_test.ts
@@ -3,6 +3,7 @@ import Long from 'long';
 import { Document } from '@yorkie-js-sdk/src/document/document';
 import { InitialCheckpoint } from '@yorkie-js-sdk/src/document/change/checkpoint';
 import { withTwoClientsAndDocuments } from '@yorkie-js-sdk/test/integration/integration_helper';
+import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
 describe('Primitive', function () {
   it('should apply updates of string', function () {
@@ -35,10 +36,11 @@ describe('Primitive', function () {
     });
     assert.equal('{"k1":{"k1-1":1,"k1-2":2}}', doc.toSortedJSON());
     assert.throws(() => {
+      const ERROR_MESSAGE = 'dummy error';
       doc.update((root) => {
         delete root['k1']['k1-1'];
-        throw Error('dummy error');
-      }, 'dummy error');
+        throw new YorkieError(Code.ErrDummy, ERROR_MESSAGE);
+      }, ERROR_MESSAGE);
     });
     assert.equal('{"k1":{"k1-1":1,"k1-2":2}}', doc.toSortedJSON());
   });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR unifies error throwing methods by refactoring the `logger` to focus solely on logging without throwing errors, and use `YorkieError` to throw errors. 

#### Any background context you want to provide?
The current implementation of the `logger` includes both logging and error throwing, which can lead to confusion and type problems. By separating these concerns, we can ensure that the logger is only responsible for logging messages, while errors are thrown explicitly using `YorkieError`.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #696 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Enhanced error handling across various classes and modules, implementing structured error reporting with `YorkieError` and specific error codes.

- **Bug Fixes**
	- Improved clarity of error messages, ensuring that specific errors are thrown instead of generic ones, aiding in debugging and user feedback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->