### PR TITLE
Update docker compose command to V2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
       - run: npm run lint
       - run: npm run build
       - run: npm run build:examples
-      - run: docker-compose -f docker/docker-compose-ci.yml up --build -d
+      - run: docker compose -f docker/docker-compose-ci.yml up --build -d
       - run: npm run test:ci
 
       - name: Upload coverage to Codecov

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,7 @@ $ npm run build:proto
 Start MongoDB, Yorkie in a terminal session.
 
 ```bash
-$ docker-compose -f docker/docker-compose.yml up --build -d
+$ docker compose -f docker/docker-compose.yml up --build -d
 ```
 
 Start the test in another terminal session.
@@ -79,7 +79,7 @@ To get the latest server locally, run the command below then restart containers 
 
 ```bash
 $ docker pull yorkieteam/yorkie:latest
-$ docker-compose -f docker/docker-compose.yml up --build -d
+$ docker compose -f docker/docker-compose.yml up --build -d
 ```
 
 To print specific console logs, delete the line `return false` in the `onConsoleLog()` function within [`vitest.config.ts`](https://github.com/yorkie-team/yorkie-js-sdk/blob/main/vitest.config.ts#L16).
@@ -116,7 +116,7 @@ $ npm run test {test file path} # e.g. npm run test integration/tree_test.ts
 Start MongoDB and Yorkie in a terminal session.
 
 ```bash
-$ docker-compose -f docker/docker-compose.yml up --build -d
+$ docker compose -f docker/docker-compose.yml up --build -d
 ```
 
 Start the webpack-dev-server in another terminal session.

--- a/examples/README.md
+++ b/examples/README.md
@@ -8,7 +8,7 @@ All examples need to run the Yorkie server. So you should run the server before 
 
 ```bash
 # In the root directory of the repository.
-$ docker-compose -f docker/docker-compose.yml up --build -d
+$ docker compose -f docker/docker-compose.yml up --build -d
 ```
 
 The examples have own local dependencies. So you should install dependencies before running examples.

--- a/examples/nextjs-scheduler/README.md
+++ b/examples/nextjs-scheduler/README.md
@@ -13,7 +13,7 @@
 At project root, run below command to start Yorkie server.
 
 ```bash
-$ docker-compose -f docker/docker-compose.yml up --build -d
+$ docker compose -f docker/docker-compose.yml up --build -d
 ```
 
 Then install dependencies and run the demo.

--- a/examples/profile-stack/README.md
+++ b/examples/profile-stack/README.md
@@ -13,7 +13,7 @@
 At project root, run below command to start Yorkie.
 
 ```bash
-$ docker-compose -f docker/docker-compose.yml up --build -d
+$ docker compose -f docker/docker-compose.yml up --build -d
 ```
 
 Install dependencies

--- a/examples/react-tldraw/README.md
+++ b/examples/react-tldraw/README.md
@@ -13,7 +13,7 @@
 At project root, run below command to start Yorkie server.
 
 ```bash
-$ docker-compose -f docker/docker-compose.yml up --build -d
+$ docker compose -f docker/docker-compose.yml up --build -d
 ```
 
 Then install dependencies and run the demo.

--- a/examples/react-todomvc/README.md
+++ b/examples/react-todomvc/README.md
@@ -13,7 +13,7 @@
 At project root, run below command to start Yorkie server.
 
 ```bash
-$ docker-compose -f docker/docker-compose.yml up --build -d
+$ docker compose -f docker/docker-compose.yml up --build -d
 ```
 
 Then install dependencies and run the demo.

--- a/examples/simultaneous-cursors/README.md
+++ b/examples/simultaneous-cursors/README.md
@@ -44,7 +44,7 @@ $ npm install
 At project root, run below command to start Yorkie server.
 
 ```bash
-$ docker-compose -f docker/docker-compose.yml up --build -d
+$ docker compose -f docker/docker-compose.yml up --build -d
 ```
 
 Update the `.env` file like so:

--- a/examples/vanilla-codemirror6/README.md
+++ b/examples/vanilla-codemirror6/README.md
@@ -13,7 +13,7 @@
 At project root, run below command to start Yorkie.
 
 ```bash
-$ docker-compose -f docker/docker-compose.yml up --build -d
+$ docker compose -f docker/docker-compose.yml up --build -d
 ```
 
 Install dependencies

--- a/examples/vanilla-quill/README.md
+++ b/examples/vanilla-quill/README.md
@@ -44,7 +44,7 @@ $ npm install
 At project root, run below command to start Yorkie.
 
 ```bash
-$ docker-compose -f docker/docker-compose.yml up --build -d
+$ docker compose -f docker/docker-compose.yml up --build -d
 ```
 
 Update the `.env` file like so:

--- a/examples/vuejs-kanban/README.md
+++ b/examples/vuejs-kanban/README.md
@@ -13,7 +13,7 @@
 At project root, run below command to start Yorkie server.
 
 ```bash
-$ docker-compose -f docker/docker-compose.yml up --build -d
+$ docker compose -f docker/docker-compose.yml up --build -d
 ```
 
 Install dependencies


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR changes the command in docker compose V1 that was being used by the CI workflow to the V2 command, so that the CI workflow no longer fails.
Also, all V1 commands used in the documentation have been changed to V2 commands.

#### Any background context you want to provide?

This issue is caused by ubuntu images in the actions runner no longer supporting docker compose V1.
More context is provided in https://github.com/yorkie-team/yorkie/issues/949

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated all documentation to reflect the latest Docker CLI command syntax, transitioning from `docker-compose` to `docker compose` for improved clarity and consistency.
  
- **Documentation**
	- Revised instructions in multiple README files and the contributing guide to ensure users are informed of the current best practices for using Docker commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->