### PR TITLE
Introduce broadcast API for event sharing

### DIFF
--- a/packages/sdk/src/client/attachment.ts
+++ b/packages/sdk/src/client/attachment.ts
@@ -112,6 +112,6 @@ export class Attachment<T, P extends Indexable> {
    * `unsetClient` unsets the client of the document.
    */
   public unsetClient(): void {
-    this.doc.setClient(null);
+    this.doc.setClient();
   }
 }

--- a/packages/sdk/src/client/attachment.ts
+++ b/packages/sdk/src/client/attachment.ts
@@ -1,5 +1,6 @@
 import { Document, Indexable } from '@yorkie-js-sdk/src/document/document';
 import { SyncMode } from '@yorkie-js-sdk/src/client/client';
+import { Unsubscribe } from '../yorkie';
 
 /**
  * `WatchStream` is a stream that watches the changes of the document.
@@ -21,17 +22,21 @@ export class Attachment<T, P extends Indexable> {
   watchLoopTimerID?: ReturnType<typeof setTimeout>;
   watchAbortController?: AbortController;
 
+  unsubscribeBroadcastEvent: Unsubscribe;
+
   constructor(
     reconnectStreamDelay: number,
     doc: Document<T, P>,
     docID: string,
     syncMode: SyncMode,
+    unsubscribeBroacastEvent: Unsubscribe,
   ) {
     this.reconnectStreamDelay = reconnectStreamDelay;
     this.doc = doc;
     this.docID = docID;
     this.syncMode = syncMode;
     this.remoteChangeEventReceived = false;
+    this.unsubscribeBroadcastEvent = unsubscribeBroacastEvent;
   }
 
   /**
@@ -106,12 +111,5 @@ export class Attachment<T, P extends Indexable> {
     }
     clearTimeout(this.watchLoopTimerID);
     this.watchLoopTimerID = undefined;
-  }
-
-  /**
-   * `unsetClient` unsets the client of the document.
-   */
-  public unsetClient(): void {
-    this.doc.setClient();
   }
 }

--- a/packages/sdk/src/client/attachment.ts
+++ b/packages/sdk/src/client/attachment.ts
@@ -107,4 +107,11 @@ export class Attachment<T, P extends Indexable> {
     clearTimeout(this.watchLoopTimerID);
     this.watchLoopTimerID = undefined;
   }
+
+  /**
+   * `unsetClient` unsets the client of the document.
+   */
+  public unsetClient(): void {
+    this.doc.setClient(null);
+  }
 }

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -305,13 +305,16 @@ export class Client {
     doc.setActor(this.id!);
     doc.update((_, p) => p.set(options.initialPresence || {}));
     const unsubscribeBroacastEvent = doc.subscribe(
-      'broadcast',
-      (topic, payload, onBroadcastError) => {
+      'local-broadcast',
+      (event) => {
+        const { topic, payload } = event.value;
+        const errorFn = event.error;
+
         try {
           this.broadcast(doc.getKey(), topic, payload);
-        } catch (e: unknown) {
-          if (e instanceof Error) {
-            onBroadcastError?.(e);
+        } catch (error: unknown) {
+          if (error instanceof Error) {
+            errorFn?.(error);
           }
         }
       },

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -304,7 +304,12 @@ export class Client {
     }
     doc.setActor(this.id!);
     doc.update((_, p) => p.set(options.initialPresence || {}));
-    doc.setClient(this);
+    const unsubscribeBroacastEvent = doc.subscribe(
+      'broadcast',
+      (topic, payload) => {
+        this.broadcast(doc.getKey(), topic, payload);
+      },
+    );
 
     const syncMode = options.syncMode ?? SyncMode.Realtime;
     return this.enqueueTask(async () => {
@@ -331,6 +336,7 @@ export class Client {
               doc,
               res.documentId,
               syncMode,
+              unsubscribeBroacastEvent,
             ),
           );
 
@@ -802,8 +808,8 @@ export class Client {
       return;
     }
 
-    attachment.unsetClient();
     attachment.cancelWatchStream();
+    attachment.unsubscribeBroadcastEvent();
     this.attachmentMap.delete(docKey);
   }
 

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -42,6 +42,7 @@ import {
 import { OpSource } from '@yorkie-js-sdk/src/document/operation/operation';
 import { createAuthInterceptor } from '@yorkie-js-sdk/src/client/auth_interceptor';
 import { createMetricInterceptor } from '@yorkie-js-sdk/src/client/metric_interceptor';
+import { validateSerializable } from '../util/validator';
 
 /**
  * `SyncMode` defines synchronization modes for the PushPullChanges API.
@@ -603,6 +604,13 @@ export class Client {
       throw new YorkieError(
         Code.ErrDocumentNotAttached,
         `${doc.getKey()} is not attached`,
+      );
+    }
+
+    if (!validateSerializable(payload)) {
+      throw new YorkieError(
+        Code.ErrInvalidArgument,
+        'payload is not serializable',
       );
     }
 

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -306,8 +306,14 @@ export class Client {
     doc.update((_, p) => p.set(options.initialPresence || {}));
     const unsubscribeBroacastEvent = doc.subscribe(
       'broadcast',
-      (topic, payload) => {
-        this.broadcast(doc.getKey(), topic, payload);
+      (topic, payload, onBroadcastError) => {
+        try {
+          this.broadcast(doc.getKey(), topic, payload);
+        } catch (e: unknown) {
+          if (e instanceof Error) {
+            onBroadcastError?.(e);
+          }
+        }
       },
     );
 

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -1550,9 +1550,11 @@ export class Document<T, P extends Indexable = Indexable> {
       } else if (type === PbDocEventType.DOCUMENT_BROADCAST) {
         if (resp.body.value.body) {
           const { topic, payload } = resp.body.value.body;
+          const decoder = new TextDecoder();
+
           event.push({
             type: DocEventType.Broadcast,
-            value: { topic, payload },
+            value: { topic, payload: JSON.parse(decoder.decode(payload)) },
           });
         }
       }

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -1061,7 +1061,7 @@ export class Document<T, P extends Indexable = Indexable> {
   ): Unsubscribe {
     this.broadcastEventHandlers.set(topic, handler);
 
-    this.eventStream.subscribe((event) => {
+    const unsubscribe = this.eventStream.subscribe((event) => {
       for (const docEvent of event) {
         if (docEvent.type !== DocEventType.Broadcast) {
           continue;
@@ -1074,6 +1074,7 @@ export class Document<T, P extends Indexable = Indexable> {
     }, error);
 
     return () => {
+      unsubscribe();
       this.broadcastEventHandlers.delete(topic);
     };
   }

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -626,7 +626,7 @@ export class Document<T, P extends Indexable = Indexable> {
     DocEventCallbackMap<P>['broadcast']
   >;
 
-  private client: Client | null = null;
+  private client?: Client;
 
   constructor(key: string, opts?: DocumentOptions) {
     this.opts = opts || {};
@@ -864,10 +864,7 @@ export class Document<T, P extends Indexable = Indexable> {
    * The callback will be called when the document is changed.
    */
   public subscribe(
-    type: {
-      type: 'broadcast';
-      topic: string;
-    },
+    type: BroadcastSubscribePair,
     next: DocEventCallbackMap<P>['broadcast'],
     error?: ErrorFn,
   ): Unsubscribe;
@@ -1333,12 +1330,12 @@ export class Document<T, P extends Indexable = Indexable> {
     return this.root.getGarbageLen();
   }
 
-  /*
+  /**
    * `setClient` sets the client of this document.
    *
    * @internal
    */
-  public setClient(client: Client | null): void {
+  public setClient(client?: Client): void {
     this.client = client;
   }
 
@@ -2087,11 +2084,7 @@ export class Document<T, P extends Indexable = Indexable> {
    */
   public broadcast(topic: string, payload: any): Promise<void> {
     if (this.client) {
-      try {
-        return this.client.broadcast(this.getKey(), topic, payload);
-      } catch (e) {
-        throw e;
-      }
+      return this.client.broadcast(this.getKey(), topic, payload);
     }
 
     throw new YorkieError(

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -78,7 +78,6 @@ import {
 import { History, HistoryOperation } from '@yorkie-js-sdk/src/document/history';
 import { setupDevtools } from '@yorkie-js-sdk/src/devtools';
 import * as Devtools from '@yorkie-js-sdk/src/devtools/types';
-import { Client } from '@yorkie-js-sdk/src/client/client';
 
 /**
  * `DocumentOptions` are the options to create a new document.
@@ -601,8 +600,6 @@ export class Document<T, P extends Indexable = Indexable> {
    * used to prevent the updater from calling undo/redo.
    */
   private isUpdating: boolean;
-
-  private client?: Client;
 
   constructor(key: string, opts?: DocumentOptions) {
     this.opts = opts || {};
@@ -1284,15 +1281,6 @@ export class Document<T, P extends Indexable = Indexable> {
    */
   public getGarbageLen(): number {
     return this.root.getGarbageLen();
-  }
-
-  /**
-   * `setClient` sets the client of this document.
-   *
-   * @internal
-   */
-  public setClient(client?: Client): void {
-    this.client = client;
   }
 
   /**
@@ -2030,14 +2018,12 @@ export class Document<T, P extends Indexable = Indexable> {
   /**
    * `broadcast` the payload to the given topic.
    */
-  public broadcast(topic: string, payload: any): Promise<void> {
-    if (this.client) {
-      return this.client.broadcast(this.getKey(), topic, payload);
-    }
+  public broadcast(topic: string, payload: any) {
+    const broadcastEvent: BroadcastEvent = {
+      type: DocEventType.Broadcast,
+      value: { topic, payload },
+    };
 
-    throw new YorkieError(
-      Code.ErrClientNotFound,
-      'Document is not attached to a client',
-    );
+    this.publish([broadcastEvent]);
   }
 }

--- a/packages/sdk/src/util/validator.ts
+++ b/packages/sdk/src/util/validator.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2024 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * `validateSerializable` returns whether the given value is serializable or not.
+ */
+export const validateSerializable = (value: any): boolean => {
+  try {
+    const serialized = JSON.stringify(value);
+
+    if (serialized === undefined) {
+      return false;
+    }
+  } catch (error) {
+    return false;
+  }
+  return true;
+};

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -876,9 +876,7 @@ describe.sequential('Client', function () {
     const broadcastTopic = 'test';
     const payload = { a: 1, b: '2' };
 
-    expect(async () =>
-      cli.broadcast(doc, broadcastTopic, payload),
-    ).not.toThrow();
+    expect(async () => doc.broadcast(broadcastTopic, payload)).not.toThrow();
 
     await cli.deactivate();
   });
@@ -897,7 +895,7 @@ describe.sequential('Client', function () {
     const broadcastTopic = 'test';
 
     expect(async () =>
-      cli.broadcast(doc, broadcastTopic, payload),
+      doc.broadcast(broadcastTopic, payload),
     ).rejects.toThrowErrorCode(Code.ErrInvalidArgument);
 
     await cli.deactivate();
@@ -918,7 +916,7 @@ it('Should trigger the handler for a subscribed broadcast event', async ({
       );
 
       const payload = { a: 1, b: '2' };
-      await c1.broadcast(d1, broadcastTopic, payload);
+      await d1.broadcast(broadcastTopic, payload);
 
       // Assuming that every subscriber can receive the broadcast event within 1000ms.
       await new Promise((res) => setTimeout(res, 1000));
@@ -950,7 +948,7 @@ it('Should not trigger the handler for an unsubscribed broadcast event', async (
       );
 
       const payload = { a: 1, b: '2' };
-      await c1.broadcast(d1, broadcastTopic1, payload);
+      await d1.broadcast(broadcastTopic1, payload);
 
       // Assuming that every subscriber can receive the broadcast event within 1000ms.
       await new Promise((res) => setTimeout(res, 1000));
@@ -978,7 +976,7 @@ it('Should not trigger the handler for a broadcast event after unsubscribing', a
       );
 
       const payload = { a: 1, b: '2' };
-      await c1.broadcast(d1, broadcastTopic, payload);
+      await d1.broadcast(broadcastTopic, payload);
 
       // Assuming that every subscriber can receive the broadcast event within 1000ms.
       await new Promise((res) => setTimeout(res, 1000));
@@ -987,7 +985,7 @@ it('Should not trigger the handler for a broadcast event after unsubscribing', a
 
       unsubscribe();
 
-      await c1.broadcast(d1, broadcastTopic, payload);
+      await d1.broadcast(broadcastTopic, payload);
 
       // Assuming that every subscriber can receive the broadcast event within 1000ms.
       await new Promise((res) => setTimeout(res, 1000));

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -881,6 +881,30 @@ describe.sequential('Client', function () {
     await cli.deactivate();
   });
 
+  it('Should throw error when broadcasting unserializeable payload', async ({
+    task,
+  }) => {
+    const spy = vi.fn();
+    const cli = new yorkie.Client(testRPCAddr);
+    await cli.activate();
+
+    const doc = new yorkie.Document<{ t: Text }>(toDocKey(`${task.name}`));
+    await cli.attach(doc);
+
+    // broadcast unserializable payload
+    const payload = () => {};
+    const broadcastTopic = 'test';
+
+    doc.broadcast(broadcastTopic, payload, spy);
+
+    // Assuming that every subscriber can receive the broadcast event within 1000ms.
+    await new Promise((res) => setTimeout(res, 1000));
+
+    expect(spy).toBeCalledTimes(1);
+
+    await cli.deactivate();
+  });
+
   it('Should trigger the handler for a subscribed broadcast event', async ({
     task,
   }) => {

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -881,26 +881,6 @@ describe.sequential('Client', function () {
     await cli.deactivate();
   });
 
-  it('Should throw error when broadcasting unserializeable payload', async ({
-    task,
-  }) => {
-    const cli = new yorkie.Client(testRPCAddr);
-    await cli.activate();
-
-    const doc = new yorkie.Document<{ t: Text }>(toDocKey(`${task.name}`));
-    await cli.attach(doc);
-
-    // broadcast unserializable payload
-    const payload = () => {};
-    const broadcastTopic = 'test';
-
-    expect(async () =>
-      doc.broadcast(broadcastTopic, payload),
-    ).rejects.toThrowErrorCode(Code.ErrInvalidArgument);
-
-    await cli.deactivate();
-  });
-
   it('Should trigger the handler for a subscribed broadcast event', async ({
     task,
   }) => {
@@ -915,7 +895,7 @@ describe.sequential('Client', function () {
         });
 
         const payload = { a: 1, b: '2' };
-        await d1.broadcast(broadcastTopic, payload);
+        d1.broadcast(broadcastTopic, payload);
         await eventCollector.waitAndVerifyNthEvent(1, [
           broadcastTopic,
           payload,
@@ -946,7 +926,7 @@ describe.sequential('Client', function () {
         });
 
         const payload = { a: 1, b: '2' };
-        await d1.broadcast(broadcastTopic1, payload);
+        d1.broadcast(broadcastTopic1, payload);
         await eventCollector.waitAndVerifyNthEvent(1, [
           broadcastTopic1,
           payload,
@@ -975,7 +955,8 @@ describe.sequential('Client', function () {
         });
 
         const payload = { a: 1, b: '2' };
-        await d1.broadcast(broadcastTopic, payload);
+
+        d1.broadcast(broadcastTopic, payload);
         await eventCollector.waitAndVerifyNthEvent(1, [
           broadcastTopic,
           payload,
@@ -983,7 +964,7 @@ describe.sequential('Client', function () {
 
         unsubscribe();
 
-        await d1.broadcast(broadcastTopic, payload);
+        d1.broadcast(broadcastTopic, payload);
 
         // Assuming that every subscriber can receive the broadcast event within 1000ms.
         await new Promise((res) => setTimeout(res, 1000));

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -907,18 +907,18 @@ it('Should trigger the handler for a subscribed broadcast event', async ({
 }) => {
   await withTwoClientsAndDocuments<{ t: Text }>(
     async (c1, d1, c2, d2) => {
-      const eventCollector = new EventCollector<[string, any]>();
+      const eventCollector = new EventCollector<[any]>();
       const broadcastTopic = 'test';
       const unsubscribe = d2.subscribe(
         { type: 'broadcast', topic: broadcastTopic },
-        (topic, payload) => {
-          eventCollector.add([topic, payload]);
+        (payload) => {
+          eventCollector.add([payload]);
         },
       );
 
       const payload = { a: 1, b: '2' };
       await d1.broadcast(broadcastTopic, payload);
-      await eventCollector.waitAndVerifyNthEvent(1, [broadcastTopic, payload]);
+      await eventCollector.waitAndVerifyNthEvent(1, [payload]);
 
       unsubscribe();
     },
@@ -964,19 +964,19 @@ it('Should not trigger the handler for a broadcast event after unsubscribing', a
     async (c1, d1, c2, d2) => {
       const spy = vi.fn();
 
-      const eventCollector = new EventCollector<[string, any]>();
+      const eventCollector = new EventCollector<[any]>();
       const broadcastTopic = 'test';
       const unsubscribe = d2.subscribe(
         { type: 'broadcast', topic: broadcastTopic },
-        (topic, payload) => {
+        (payload) => {
           spy();
-          eventCollector.add([topic, payload]);
+          eventCollector.add([payload]);
         },
       );
 
       const payload = { a: 1, b: '2' };
       await d1.broadcast(broadcastTopic, payload);
-      await eventCollector.waitAndVerifyNthEvent(1, [broadcastTopic, payload]);
+      await eventCollector.waitAndVerifyNthEvent(1, [payload]);
 
       unsubscribe();
 

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -912,7 +912,10 @@ it('Should trigger the handler for a subscribed broadcast event', async ({
       const spy = vi.fn();
 
       const broadcastTopic = 'test';
-      const unsubscribe = d2.subscribeBroadcastEvent(broadcastTopic, spy);
+      const unsubscribe = d2.subscribe(
+        { type: 'broadcast', topic: broadcastTopic },
+        spy,
+      );
 
       const payload = { a: 1, b: '2' };
       await c1.broadcast(d1, broadcastTopic, payload);
@@ -941,7 +944,10 @@ it('Should not trigger the handler for an unsubscribed broadcast event', async (
       const broadcastTopic1 = 'test1';
       const broadcastTopic2 = 'test2';
 
-      const unsubscribe = d2.subscribeBroadcastEvent(broadcastTopic2, spy);
+      const unsubscribe = d2.subscribe(
+        { type: 'broadcast', topic: broadcastTopic2 },
+        spy,
+      );
 
       const payload = { a: 1, b: '2' };
       await c1.broadcast(d1, broadcastTopic1, payload);
@@ -966,7 +972,10 @@ it('Should not trigger the handler for a broadcast event after unsubscribing', a
       const spy = vi.fn();
 
       const broadcastTopic = 'test';
-      const unsubscribe = d2.subscribeBroadcastEvent(broadcastTopic, spy);
+      const unsubscribe = d2.subscribe(
+        { type: 'broadcast', topic: broadcastTopic },
+        spy,
+      );
 
       const payload = { a: 1, b: '2' };
       await c1.broadcast(d1, broadcastTopic, payload);

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -864,6 +864,23 @@ describe.sequential('Client', function () {
     }, task.name);
   });
 
+  it('Successfully broadcast serializeable payload', async ({ task }) => {
+    const cli = new yorkie.Client(testRPCAddr);
+    await cli.activate();
+
+    const doc = new yorkie.Document<{ t: Text }>(toDocKey(`${task.name}`));
+    await cli.attach(doc);
+
+    const broadcastTopic = 'test';
+    const payload = { a: 1, b: '2' };
+
+    expect(async () =>
+      cli.broadcast(doc, broadcastTopic, payload),
+    ).not.toThrow();
+
+    await cli.deactivate();
+  });
+
   it('Throw error when broadcasting unserializeable payload', async ({
     task,
   }) => {

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -863,4 +863,24 @@ describe.sequential('Client', function () {
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
     }, task.name);
   });
+
+  it('Throw error when broadcasting unserializeable payload', async ({
+    task,
+  }) => {
+    const cli = new yorkie.Client(testRPCAddr);
+    await cli.activate();
+
+    const doc = new yorkie.Document<{ t: Text }>(toDocKey(`${task.name}`));
+    await cli.attach(doc);
+
+    // broadcast unserializable payload
+    const payload = () => {};
+    const broadcastTopic = 'test';
+
+    expect(async () =>
+      cli.broadcast(doc, broadcastTopic, payload),
+    ).rejects.toThrowErrorCode(Code.ErrInvalidArgument);
+
+    await cli.deactivate();
+  });
 });

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -906,18 +906,20 @@ describe.sequential('Client', function () {
   }) => {
     await withTwoClientsAndDocuments<{ t: Text }>(
       async (c1, d1, c2, d2) => {
-        const eventCollector = new EventCollector<any>();
+        const eventCollector = new EventCollector<[string, any]>();
         const broadcastTopic = 'test';
-        const unsubscribe = d2.subscribe(
-          { type: 'broadcast', topic: broadcastTopic },
-          (payload) => {
-            eventCollector.add(payload);
-          },
-        );
+        const unsubscribe = d2.subscribe('broadcast', (topic, payload) => {
+          if (topic === broadcastTopic) {
+            eventCollector.add([topic, payload]);
+          }
+        });
 
         const payload = { a: 1, b: '2' };
         await d1.broadcast(broadcastTopic, payload);
-        await eventCollector.waitAndVerifyNthEvent(1, payload);
+        await eventCollector.waitAndVerifyNthEvent(1, [
+          broadcastTopic,
+          payload,
+        ]);
 
         unsubscribe();
       },
@@ -931,23 +933,26 @@ describe.sequential('Client', function () {
   }) => {
     await withTwoClientsAndDocuments<{ t: Text }>(
       async (c1, d1, c2, d2) => {
-        const spy = vi.fn();
-
+        const eventCollector = new EventCollector<[string, any]>();
         const broadcastTopic1 = 'test1';
         const broadcastTopic2 = 'test2';
 
-        const unsubscribe = d2.subscribe(
-          { type: 'broadcast', topic: broadcastTopic2 },
-          spy,
-        );
+        const unsubscribe = d2.subscribe('broadcast', (topic, payload) => {
+          if (topic === broadcastTopic1) {
+            eventCollector.add([topic, payload]);
+          } else if (topic === broadcastTopic2) {
+            eventCollector.add([topic, payload]);
+          }
+        });
 
         const payload = { a: 1, b: '2' };
         await d1.broadcast(broadcastTopic1, payload);
+        await eventCollector.waitAndVerifyNthEvent(1, [
+          broadcastTopic1,
+          payload,
+        ]);
 
-        // Assuming that every subscriber can receive the broadcast event within 1000ms.
-        await new Promise((res) => setTimeout(res, 1000));
-
-        expect(spy.mock.calls.length).toBe(0);
+        assert.equal(eventCollector.getLength(), 1);
 
         unsubscribe();
       },
@@ -961,18 +966,20 @@ describe.sequential('Client', function () {
   }) => {
     await withTwoClientsAndDocuments<{ t: Text }>(
       async (c1, d1, c2, d2) => {
-        const eventCollector = new EventCollector<any>();
+        const eventCollector = new EventCollector<[string, any]>();
         const broadcastTopic = 'test';
-        const unsubscribe = d2.subscribe(
-          { type: 'broadcast', topic: broadcastTopic },
-          (payload) => {
-            eventCollector.add(payload);
-          },
-        );
+        const unsubscribe = d2.subscribe('broadcast', (topic, payload) => {
+          if (topic === broadcastTopic) {
+            eventCollector.add([topic, payload]);
+          }
+        });
 
         const payload = { a: 1, b: '2' };
         await d1.broadcast(broadcastTopic, payload);
-        await eventCollector.waitAndVerifyNthEvent(1, payload);
+        await eventCollector.waitAndVerifyNthEvent(1, [
+          broadcastTopic,
+          payload,
+        ]);
 
         unsubscribe();
 

--- a/packages/sdk/test/integration/integration_helper.ts
+++ b/packages/sdk/test/integration/integration_helper.ts
@@ -21,6 +21,7 @@ export async function withTwoClientsAndDocuments<T>(
     d2: Document<T>,
   ) => Promise<void>,
   title: string,
+  syncMode: SyncMode = SyncMode.Manual,
 ): Promise<void> {
   const client1 = new yorkie.Client(testRPCAddr);
   const client2 = new yorkie.Client(testRPCAddr);
@@ -31,8 +32,8 @@ export async function withTwoClientsAndDocuments<T>(
   const doc1 = new yorkie.Document<T>(docKey);
   const doc2 = new yorkie.Document<T>(docKey);
 
-  await client1.attach(doc1, { syncMode: SyncMode.Manual });
-  await client2.attach(doc2, { syncMode: SyncMode.Manual });
+  await client1.attach(doc1, { syncMode });
+  await client2.attach(doc2, { syncMode });
 
   await callback(client1, doc1, client2, doc2);
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR implements a broadcast API, which enables the sharing of a broader range of general events beyond the current document and presence events in Yorkie's Publish-Subscribe model.

#### Any background context you want to provide?
**1. Broadcast Events:**

Users can now broadcast custom events with a specified topic and payload.
The payload can be of any type, as long as it is serializable.

```javascript
// Broadcast an event with a topic and payload
const payload = 'hello';
doc.broadcast('TOPIC_NAME', payload);
```

**2. Subscribe to Broadcast Events:**

Users can subscribe to specific topics and handle the events via a callback function.
The callback is triggered whenever an event with the corresponding topic is broadcast.

```javascript
// Subscribe to a specific topic for broadcast events
doc.subscribe('broadcast', ({value: {topic, payload, clientID}}) => {
    // Handle the broadcast event for the specified topic
});
```

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to https://github.com/yorkie-team/yorkie/issues/628

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced a `broadcast` method in the Client class to send messages to specified topics.
	- Added new event types `Broadcast` and `LocalBroadcast` to enable clients to subscribe to broadcast messages.
	- Implemented a method to validate the serializability of payloads for broadcasting.
	- Enhanced the Document class with a `subscribe` method for clients to register handlers for broadcast events.

- **Bug Fixes**
	- Improved error handling for broadcasting unserializable payloads within the Client class.

- **Tests**
	- Added test cases to verify successful broadcasting of serializable payloads and error handling for invalid payloads.
	- Increased test coverage for event subscriptions related to broadcast events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->