### PR TITLE
Lock version of `@codemirror/view` to prevent potential issues with Korean character input

### DIFF
--- a/examples/vanilla-codemirror6/package.json
+++ b/examples/vanilla-codemirror6/package.json
@@ -17,7 +17,7 @@
     "@codemirror/highlight": "^0.19.8",
     "@codemirror/lang-markdown": "^6.0.2",
     "@codemirror/language-data": "^6.1.0",
-    "@codemirror/state": "^6.1.2",
+    "@codemirror/state": "^6.4.1",
     "@codemirror/view": "6.23.1",
     "codemirror": "^6.0.1",
     "yorkie-js-sdk": "workspace:*"

--- a/examples/vanilla-codemirror6/package.json
+++ b/examples/vanilla-codemirror6/package.json
@@ -13,12 +13,12 @@
     "vite": "^5.0.12"
   },
   "dependencies": {
-    "@codemirror/commands": "^6.1.2",
+    "@codemirror/commands": "6.1.2",
     "@codemirror/highlight": "^0.19.8",
     "@codemirror/lang-markdown": "^6.0.2",
     "@codemirror/language-data": "^6.1.0",
     "@codemirror/state": "^6.1.2",
-    "@codemirror/view": "^6.3.1",
+    "@codemirror/view": "6.23.1",
     "codemirror": "^6.0.1",
     "yorkie-js-sdk": "workspace:*"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -185,7 +185,7 @@ importers:
   examples/vanilla-codemirror6:
     dependencies:
       '@codemirror/commands':
-        specifier: ^6.1.2
+        specifier: 6.1.2
         version: 6.1.2
       '@codemirror/highlight':
         specifier: ^0.19.8
@@ -195,13 +195,13 @@ importers:
         version: 6.0.5
       '@codemirror/language-data':
         specifier: ^6.1.0
-        version: 6.1.0(@codemirror/state@6.1.4)(@codemirror/view@6.7.1)(@lezer/common@1.0.2)
+        version: 6.1.0(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/state':
         specifier: ^6.1.2
         version: 6.1.4
       '@codemirror/view':
-        specifier: ^6.3.1
-        version: 6.7.1
+        specifier: 6.23.1
+        version: 6.23.1
       codemirror:
         specifier: ^6.0.1
         version: 6.0.1(@lezer/common@1.0.2)
@@ -767,6 +767,9 @@ packages:
   '@codemirror/state@6.1.4':
     resolution: {integrity: sha512-g+3OJuRylV5qsXuuhrc6Cvs1NQluNioepYMM2fhnpYkNk7NgX+j0AFuevKSVKzTDmDyt9+Puju+zPdHNECzCNQ==}
 
+  '@codemirror/state@6.4.1':
+    resolution: {integrity: sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==}
+
   '@codemirror/text@0.19.6':
     resolution: {integrity: sha512-T9jnREMIygx+TPC1bOuepz18maGq/92q2a+n4qTqObKwvNMg+8cMTslb8yxeEDEq7S3kpgGWxgO1UWbQRij0dA==}
     deprecated: As of 0.20.0, this package has been merged into @codemirror/state
@@ -774,8 +777,8 @@ packages:
   '@codemirror/view@0.19.48':
     resolution: {integrity: sha512-0eg7D2Nz4S8/caetCTz61rK0tkHI17V/d15Jy0kLOT8dTLGGNJUponDnW28h2B6bERmPlVHKh8MJIr5OCp1nGw==}
 
-  '@codemirror/view@6.7.1':
-    resolution: {integrity: sha512-kYtS+uqYw/q/0ytYxpkqE1JVuK5NsbmBklWYhwLFTKO9gVuTdh/kDEeZPKorbqHcJ+P+ucrhcsS1czVweOpT2g==}
+  '@codemirror/view@6.23.1':
+    resolution: {integrity: sha512-J2Xnn5lFYT1ZN/5ewEoMBCmLlL71lZ3mBdb7cUEuHhX2ESoSrNEucpsDXpX22EuTGm9LOgC9v4Z0wx+Ez8QmGA==}
 
   '@connectrpc/connect-web@1.4.0':
     resolution: {integrity: sha512-13aO4psFbbm7rdOFGV0De2Za64DY/acMspgloDlcOKzLPPs0yZkhp1OOzAQeiAIr7BM/VOHIA3p8mF0inxCYTA==}
@@ -6097,6 +6100,9 @@ packages:
   style-mod@4.0.0:
     resolution: {integrity: sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw==}
 
+  style-mod@4.1.2:
+    resolution: {integrity: sha512-wnD1HyVqpJUI2+eKZ+eo1UwghftP6yuFheBqqe+bWCotBjC2K1YnteJILRMs3SM4V/0dLEW1SC27MWP5y+mwmw==}
+
   styled-jsx@5.1.1:
     resolution: {integrity: sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==}
     engines: {node: '>= 12.0.0'}
@@ -7102,18 +7108,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@codemirror/autocomplete@6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.7.1)(@lezer/common@1.0.2)':
+  '@codemirror/autocomplete@6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)':
     dependencies:
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
-      '@codemirror/view': 6.7.1
+      '@codemirror/view': 6.23.1
       '@lezer/common': 1.0.2
 
   '@codemirror/commands@6.1.2':
     dependencies:
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
-      '@codemirror/view': 6.7.1
+      '@codemirror/view': 6.23.1
       '@lezer/common': 1.0.2
 
   '@codemirror/highlight@0.19.8':
@@ -7130,9 +7136,9 @@ snapshots:
       '@codemirror/language': 6.3.1
       '@lezer/cpp': 1.0.0
 
-  '@codemirror/lang-css@6.0.1(@codemirror/view@6.7.1)(@lezer/common@1.0.2)':
+  '@codemirror/lang-css@6.0.1(@codemirror/view@6.23.1)(@lezer/common@1.0.2)':
     dependencies:
-      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.7.1)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
       '@lezer/css': 1.1.1
@@ -7142,12 +7148,12 @@ snapshots:
 
   '@codemirror/lang-html@6.4.0':
     dependencies:
-      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.7.1)(@lezer/common@1.0.2)
-      '@codemirror/lang-css': 6.0.1(@codemirror/view@6.7.1)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
+      '@codemirror/lang-css': 6.0.1(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/lang-javascript': 6.1.2
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
-      '@codemirror/view': 6.7.1
+      '@codemirror/view': 6.23.1
       '@lezer/common': 1.0.2
       '@lezer/css': 1.1.1
       '@lezer/html': 1.2.0
@@ -7159,11 +7165,11 @@ snapshots:
 
   '@codemirror/lang-javascript@6.1.2':
     dependencies:
-      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.7.1)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/language': 6.3.1
       '@codemirror/lint': 6.1.0
       '@codemirror/state': 6.1.4
-      '@codemirror/view': 6.7.1
+      '@codemirror/view': 6.23.1
       '@lezer/common': 1.0.2
       '@lezer/javascript': 1.3.1
 
@@ -7177,7 +7183,7 @@ snapshots:
       '@codemirror/lang-html': 6.4.0
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
-      '@codemirror/view': 6.7.1
+      '@codemirror/view': 6.23.1
       '@lezer/common': 1.0.2
       '@lezer/markdown': 1.0.2
 
@@ -7189,9 +7195,9 @@ snapshots:
       '@lezer/common': 1.0.2
       '@lezer/php': 1.0.0
 
-  '@codemirror/lang-python@6.1.0(@codemirror/state@6.1.4)(@codemirror/view@6.7.1)(@lezer/common@1.0.2)':
+  '@codemirror/lang-python@6.1.0(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)':
     dependencies:
-      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.7.1)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/language': 6.3.1
       '@lezer/python': 1.1.1
     transitivePeerDependencies:
@@ -7204,9 +7210,9 @@ snapshots:
       '@codemirror/language': 6.3.1
       '@lezer/rust': 1.0.0
 
-  '@codemirror/lang-sql@6.3.3(@codemirror/view@6.7.1)(@lezer/common@1.0.2)':
+  '@codemirror/lang-sql@6.3.3(@codemirror/view@6.23.1)(@lezer/common@1.0.2)':
     dependencies:
-      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.7.1)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
       '@lezer/highlight': 1.1.3
@@ -7221,9 +7227,9 @@ snapshots:
       '@lezer/highlight': 1.1.3
       '@lezer/lr': 1.2.5
 
-  '@codemirror/lang-xml@6.0.1(@codemirror/view@6.7.1)':
+  '@codemirror/lang-xml@6.0.1(@codemirror/view@6.23.1)':
     dependencies:
-      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.7.1)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/language': 6.3.1
       '@codemirror/state': 6.1.4
       '@lezer/common': 1.0.2
@@ -7231,21 +7237,21 @@ snapshots:
     transitivePeerDependencies:
       - '@codemirror/view'
 
-  '@codemirror/language-data@6.1.0(@codemirror/state@6.1.4)(@codemirror/view@6.7.1)(@lezer/common@1.0.2)':
+  '@codemirror/language-data@6.1.0(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)':
     dependencies:
       '@codemirror/lang-cpp': 6.0.2
-      '@codemirror/lang-css': 6.0.1(@codemirror/view@6.7.1)(@lezer/common@1.0.2)
+      '@codemirror/lang-css': 6.0.1(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/lang-html': 6.4.0
       '@codemirror/lang-java': 6.0.1
       '@codemirror/lang-javascript': 6.1.2
       '@codemirror/lang-json': 6.0.1
       '@codemirror/lang-markdown': 6.0.5
       '@codemirror/lang-php': 6.0.1
-      '@codemirror/lang-python': 6.1.0(@codemirror/state@6.1.4)(@codemirror/view@6.7.1)(@lezer/common@1.0.2)
+      '@codemirror/lang-python': 6.1.0(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/lang-rust': 6.0.1
-      '@codemirror/lang-sql': 6.3.3(@codemirror/view@6.7.1)(@lezer/common@1.0.2)
+      '@codemirror/lang-sql': 6.3.3(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/lang-wast': 6.0.1
-      '@codemirror/lang-xml': 6.0.1(@codemirror/view@6.7.1)
+      '@codemirror/lang-xml': 6.0.1(@codemirror/view@6.23.1)
       '@codemirror/language': 6.3.1
       '@codemirror/legacy-modes': 6.3.1
     transitivePeerDependencies:
@@ -7264,7 +7270,7 @@ snapshots:
   '@codemirror/language@6.3.1':
     dependencies:
       '@codemirror/state': 6.1.4
-      '@codemirror/view': 6.7.1
+      '@codemirror/view': 6.23.1
       '@lezer/common': 1.0.2
       '@lezer/highlight': 1.1.3
       '@lezer/lr': 1.2.5
@@ -7277,7 +7283,7 @@ snapshots:
   '@codemirror/lint@6.1.0':
     dependencies:
       '@codemirror/state': 6.1.4
-      '@codemirror/view': 6.7.1
+      '@codemirror/view': 6.23.1
       crelt: 1.0.5
 
   '@codemirror/rangeset@0.19.9':
@@ -7287,7 +7293,7 @@ snapshots:
   '@codemirror/search@6.2.3':
     dependencies:
       '@codemirror/state': 6.1.4
-      '@codemirror/view': 6.7.1
+      '@codemirror/view': 6.23.1
       crelt: 1.0.5
 
   '@codemirror/state@0.19.9':
@@ -7295,6 +7301,8 @@ snapshots:
       '@codemirror/text': 0.19.6
 
   '@codemirror/state@6.1.4': {}
+
+  '@codemirror/state@6.4.1': {}
 
   '@codemirror/text@0.19.6': {}
 
@@ -7306,10 +7314,10 @@ snapshots:
       style-mod: 4.0.0
       w3c-keyname: 2.2.6
 
-  '@codemirror/view@6.7.1':
+  '@codemirror/view@6.23.1':
     dependencies:
-      '@codemirror/state': 6.1.4
-      style-mod: 4.0.0
+      '@codemirror/state': 6.4.1
+      style-mod: 4.1.2
       w3c-keyname: 2.2.6
 
   '@connectrpc/connect-web@1.4.0(@bufbuild/protobuf@1.10.0)(@connectrpc/connect@1.4.0(@bufbuild/protobuf@1.10.0))':
@@ -10588,13 +10596,13 @@ snapshots:
 
   codemirror@6.0.1(@lezer/common@1.0.2):
     dependencies:
-      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.7.1)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/commands': 6.1.2
       '@codemirror/language': 6.3.1
       '@codemirror/lint': 6.1.0
       '@codemirror/search': 6.2.3
       '@codemirror/state': 6.1.4
-      '@codemirror/view': 6.7.1
+      '@codemirror/view': 6.23.1
     transitivePeerDependencies:
       - '@lezer/common'
 
@@ -13418,6 +13426,8 @@ snapshots:
       acorn: 8.10.0
 
   style-mod@4.0.0: {}
+
+  style-mod@4.1.2: {}
 
   styled-jsx@5.1.1(react@18.2.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -195,10 +195,10 @@ importers:
         version: 6.0.5
       '@codemirror/language-data':
         specifier: ^6.1.0
-        version: 6.1.0(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
+        version: 6.1.0(@codemirror/state@6.4.1)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/state':
-        specifier: ^6.1.2
-        version: 6.1.4
+        specifier: ^6.4.1
+        version: 6.4.1
       '@codemirror/view':
         specifier: 6.23.1
         version: 6.23.1
@@ -763,9 +763,6 @@ packages:
 
   '@codemirror/state@0.19.9':
     resolution: {integrity: sha512-psOzDolKTZkx4CgUqhBQ8T8gBc0xN5z4gzed109aF6x7D7umpDRoimacI/O6d9UGuyl4eYuDCZmDFr2Rq7aGOw==}
-
-  '@codemirror/state@6.1.4':
-    resolution: {integrity: sha512-g+3OJuRylV5qsXuuhrc6Cvs1NQluNioepYMM2fhnpYkNk7NgX+j0AFuevKSVKzTDmDyt9+Puju+zPdHNECzCNQ==}
 
   '@codemirror/state@6.4.1':
     resolution: {integrity: sha512-QkEyUiLhsJoZkbumGZlswmAhA7CBU02Wrz7zvH4SrcifbsqwlXShVXg65f3v/ts57W3dqyamEriMhij1Z3Zz4A==}
@@ -7108,17 +7105,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@codemirror/autocomplete@6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)':
+  '@codemirror/autocomplete@6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.4.1)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)':
     dependencies:
       '@codemirror/language': 6.3.1
-      '@codemirror/state': 6.1.4
+      '@codemirror/state': 6.4.1
       '@codemirror/view': 6.23.1
       '@lezer/common': 1.0.2
 
   '@codemirror/commands@6.1.2':
     dependencies:
       '@codemirror/language': 6.3.1
-      '@codemirror/state': 6.1.4
+      '@codemirror/state': 6.4.1
       '@codemirror/view': 6.23.1
       '@lezer/common': 1.0.2
 
@@ -7138,9 +7135,9 @@ snapshots:
 
   '@codemirror/lang-css@6.0.1(@codemirror/view@6.23.1)(@lezer/common@1.0.2)':
     dependencies:
-      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.4.1)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/language': 6.3.1
-      '@codemirror/state': 6.1.4
+      '@codemirror/state': 6.4.1
       '@lezer/css': 1.1.1
     transitivePeerDependencies:
       - '@codemirror/view'
@@ -7148,11 +7145,11 @@ snapshots:
 
   '@codemirror/lang-html@6.4.0':
     dependencies:
-      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.4.1)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/lang-css': 6.0.1(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/lang-javascript': 6.1.2
       '@codemirror/language': 6.3.1
-      '@codemirror/state': 6.1.4
+      '@codemirror/state': 6.4.1
       '@codemirror/view': 6.23.1
       '@lezer/common': 1.0.2
       '@lezer/css': 1.1.1
@@ -7165,10 +7162,10 @@ snapshots:
 
   '@codemirror/lang-javascript@6.1.2':
     dependencies:
-      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.4.1)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/language': 6.3.1
       '@codemirror/lint': 6.1.0
-      '@codemirror/state': 6.1.4
+      '@codemirror/state': 6.4.1
       '@codemirror/view': 6.23.1
       '@lezer/common': 1.0.2
       '@lezer/javascript': 1.3.1
@@ -7182,7 +7179,7 @@ snapshots:
     dependencies:
       '@codemirror/lang-html': 6.4.0
       '@codemirror/language': 6.3.1
-      '@codemirror/state': 6.1.4
+      '@codemirror/state': 6.4.1
       '@codemirror/view': 6.23.1
       '@lezer/common': 1.0.2
       '@lezer/markdown': 1.0.2
@@ -7191,13 +7188,13 @@ snapshots:
     dependencies:
       '@codemirror/lang-html': 6.4.0
       '@codemirror/language': 6.3.1
-      '@codemirror/state': 6.1.4
+      '@codemirror/state': 6.4.1
       '@lezer/common': 1.0.2
       '@lezer/php': 1.0.0
 
-  '@codemirror/lang-python@6.1.0(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)':
+  '@codemirror/lang-python@6.1.0(@codemirror/state@6.4.1)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)':
     dependencies:
-      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.4.1)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/language': 6.3.1
       '@lezer/python': 1.1.1
     transitivePeerDependencies:
@@ -7212,9 +7209,9 @@ snapshots:
 
   '@codemirror/lang-sql@6.3.3(@codemirror/view@6.23.1)(@lezer/common@1.0.2)':
     dependencies:
-      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.4.1)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/language': 6.3.1
-      '@codemirror/state': 6.1.4
+      '@codemirror/state': 6.4.1
       '@lezer/highlight': 1.1.3
       '@lezer/lr': 1.2.5
     transitivePeerDependencies:
@@ -7229,15 +7226,15 @@ snapshots:
 
   '@codemirror/lang-xml@6.0.1(@codemirror/view@6.23.1)':
     dependencies:
-      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.4.1)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/language': 6.3.1
-      '@codemirror/state': 6.1.4
+      '@codemirror/state': 6.4.1
       '@lezer/common': 1.0.2
       '@lezer/xml': 1.0.0
     transitivePeerDependencies:
       - '@codemirror/view'
 
-  '@codemirror/language-data@6.1.0(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)':
+  '@codemirror/language-data@6.1.0(@codemirror/state@6.4.1)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)':
     dependencies:
       '@codemirror/lang-cpp': 6.0.2
       '@codemirror/lang-css': 6.0.1(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
@@ -7247,7 +7244,7 @@ snapshots:
       '@codemirror/lang-json': 6.0.1
       '@codemirror/lang-markdown': 6.0.5
       '@codemirror/lang-php': 6.0.1
-      '@codemirror/lang-python': 6.1.0(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
+      '@codemirror/lang-python': 6.1.0(@codemirror/state@6.4.1)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/lang-rust': 6.0.1
       '@codemirror/lang-sql': 6.3.3(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/lang-wast': 6.0.1
@@ -7269,7 +7266,7 @@ snapshots:
 
   '@codemirror/language@6.3.1':
     dependencies:
-      '@codemirror/state': 6.1.4
+      '@codemirror/state': 6.4.1
       '@codemirror/view': 6.23.1
       '@lezer/common': 1.0.2
       '@lezer/highlight': 1.1.3
@@ -7282,7 +7279,7 @@ snapshots:
 
   '@codemirror/lint@6.1.0':
     dependencies:
-      '@codemirror/state': 6.1.4
+      '@codemirror/state': 6.4.1
       '@codemirror/view': 6.23.1
       crelt: 1.0.5
 
@@ -7292,15 +7289,13 @@ snapshots:
 
   '@codemirror/search@6.2.3':
     dependencies:
-      '@codemirror/state': 6.1.4
+      '@codemirror/state': 6.4.1
       '@codemirror/view': 6.23.1
       crelt: 1.0.5
 
   '@codemirror/state@0.19.9':
     dependencies:
       '@codemirror/text': 0.19.6
-
-  '@codemirror/state@6.1.4': {}
 
   '@codemirror/state@6.4.1': {}
 
@@ -10596,12 +10591,12 @@ snapshots:
 
   codemirror@6.0.1(@lezer/common@1.0.2):
     dependencies:
-      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.1.4)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
+      '@codemirror/autocomplete': 6.3.4(@codemirror/language@6.3.1)(@codemirror/state@6.4.1)(@codemirror/view@6.23.1)(@lezer/common@1.0.2)
       '@codemirror/commands': 6.1.2
       '@codemirror/language': 6.3.1
       '@codemirror/lint': 6.1.0
       '@codemirror/search': 6.2.3
-      '@codemirror/state': 6.1.4
+      '@codemirror/state': 6.4.1
       '@codemirror/view': 6.23.1
     transitivePeerDependencies:
       - '@lezer/common'


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Lock the version of `@codemirror/commands` and `@codemirror/view`
- `@codemirror/commands`: `6.1.2`
- `@codemirror/view`: `6.23.1`

And to address compatibility issues, the A dependency was also updated.
- `@codemirror/state`: `^6.4.1`


#### Any background context you want to provide?
With recent updates to `@codemirror/view`, there is a potential issue where the input of Korean consonants and vowels may lead to incorrect position updates, even though it is not currently occurring. To mitigate the risk of future incidents, it is necessary to explicitly lock the version of `@codemirror/view` and related packages to prevent unintended upgrades due to Semantic Versioning.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #889 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated dependencies for the CodeMirror library to enhance stability and introduce potential new features.
- **Bug Fixes**
	- Improved compatibility and performance by specifying exact versions for critical dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->