### PR TITLE
Restrict presence object type to JSON serializable values

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -8,3 +8,6 @@ packages/sdk/src/api/yorkie/v1/resources_grpc_web_pb.d.ts
 packages/sdk/src/api/yorkie/v1/resources_pb.d.ts
 packages/sdk/test/vitest.d.ts
 packages/sdk/lib
+
+# react-tldraw
+examples/react-tldraw/src/tldraw.d.ts

--- a/.eslintignore
+++ b/.eslintignore
@@ -9,5 +9,5 @@ packages/sdk/src/api/yorkie/v1/resources_pb.d.ts
 packages/sdk/test/vitest.d.ts
 packages/sdk/lib
 
-# react-tldraw
+# examples
 examples/react-tldraw/src/tldraw.d.ts

--- a/examples/react-tldraw/src/tldraw.d.ts
+++ b/examples/react-tldraw/src/tldraw.d.ts
@@ -1,0 +1,6 @@
+import { Indexable, Json } from '@yorkie-js-sdk/src/document/document';
+import { TDUser } from '@tldraw/tldraw';
+
+declare module '@tldraw/tldraw' {
+  interface TDUser extends Indexable {}
+}

--- a/examples/vanilla-quill/src/main.ts
+++ b/examples/vanilla-quill/src/main.ts
@@ -29,7 +29,7 @@ function toDeltaOperation<T extends TextValueType>(
 ): DeltaOperation {
   const { embed, ...restAttributes } = textValue.attributes ?? {};
   if (embed) {
-    return { insert: JSON.parse(embed), attributes: restAttributes };
+    return { insert: embed, attributes: restAttributes };
   }
 
   return {

--- a/examples/vanilla-quill/src/type.ts
+++ b/examples/vanilla-quill/src/type.ts
@@ -7,5 +7,5 @@ export type YorkieDoc = {
 export type YorkiePresence = {
   username: string;
   color: string;
-  selection: TextPosStructRange | undefined;
+  selection?: TextPosStructRange;
 };

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -43,6 +43,7 @@ import { OpSource } from '@yorkie-js-sdk/src/document/operation/operation';
 import { createAuthInterceptor } from '@yorkie-js-sdk/src/client/auth_interceptor';
 import { createMetricInterceptor } from '@yorkie-js-sdk/src/client/metric_interceptor';
 import { validateSerializable } from '../util/validator';
+import { Json } from '@yorkie-js-sdk/src/document/document';
 
 /**
  * `SyncMode` defines synchronization modes for the PushPullChanges API.
@@ -607,7 +608,7 @@ export class Client {
   public broadcast(
     docKey: DocumentKey,
     topic: string,
-    payload: any,
+    payload: Json,
   ): Promise<void> {
     if (!this.isActive()) {
       throw new YorkieError(

--- a/packages/sdk/src/devtools/types.ts
+++ b/packages/sdk/src/devtools/types.ts
@@ -17,20 +17,7 @@
 import type { PrimitiveValue } from '@yorkie-js-sdk/src/document/crdt/primitive';
 import type { CRDTTreePosStruct } from '@yorkie-js-sdk/src/document/crdt/tree';
 import { CounterValue } from '@yorkie-js-sdk/src/document/crdt/counter';
-
-/**
- * `Json` represents a JSON value.
- *
- * TODO(hackerwins): We need to replace `Indexable` with `Json`.
- */
-export type Json =
-  | string
-  | number
-  | boolean
-  // eslint-disable-next-line @typescript-eslint/ban-types
-  | null
-  | { [key: string]: Json }
-  | Array<Json>;
+import { Json } from '@yorkie-js-sdk/src/document/document';
 
 /**
  * `Client` represents a client value in devtools.

--- a/packages/sdk/src/document/change/context.ts
+++ b/packages/sdk/src/document/change/context.ts
@@ -159,7 +159,7 @@ export class ChangeContext<P extends Indexable = Indexable> {
 
     const reversePresence: Partial<P> = {};
     for (const key of this.reversePresenceKeys) {
-      reversePresence[key as keyof P] = this.previousPresence[key];
+      reversePresence[key as keyof P] = this.previousPresence[key as keyof P];
     }
     return reversePresence;
   }

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -420,11 +420,18 @@ export type DocEventTopic = keyof DocEventCallbackMap<never>;
 export type DocEventCallback<P extends Indexable> =
   DocEventCallbackMap<P>[DocEventTopic];
 
+type Json = JsonScalar | JsonArray | JsonObject;
+
+// eslint-disable-next-line @typescript-eslint/ban-types
+type JsonScalar = string | number | boolean | null;
+type JsonArray = Json[];
+type JsonObject = { [key: string]: Json | undefined };
+
 /**
  * Indexable key, value
  * @public
  */
-export type Indexable = Record<string, any>;
+export type Indexable = Record<string, Json>;
 
 /**
  * Document key type
@@ -438,14 +445,14 @@ export type DocumentKey = string;
 type OperationInfoOfElement<TElement> = TElement extends Text
   ? TextOperationInfo
   : TElement extends Counter
-    ? CounterOperationInfo
-    : TElement extends Tree
-      ? TreeOperationInfo
-      : TElement extends BaseArray<any>
-        ? ArrayOperationInfo
-        : TElement extends BaseObject<any>
-          ? ObjectOperationInfo
-          : OperationInfo;
+  ? CounterOperationInfo
+  : TElement extends Tree
+  ? TreeOperationInfo
+  : TElement extends BaseArray<any>
+  ? ArrayOperationInfo
+  : TElement extends BaseObject<any>
+  ? ObjectOperationInfo
+  : OperationInfo;
 
 /**
  * `OperationInfoOfInternal` represents the type of the operation info of the
@@ -466,24 +473,24 @@ type OperationInfoOfInternal<
 > = TDepth extends 0
   ? TElement
   : TKeyOrPath extends `${infer TFirst}.${infer TRest}`
-    ? TFirst extends keyof TElement
-      ? TElement[TFirst] extends BaseArray<unknown>
-        ? OperationInfoOfInternal<
-            TElement[TFirst],
-            number,
-            DecreasedDepthOf<TDepth>
-          >
-        : OperationInfoOfInternal<
-            TElement[TFirst],
-            TRest,
-            DecreasedDepthOf<TDepth>
-          >
-      : OperationInfo
-    : TKeyOrPath extends keyof TElement
-      ? TElement[TKeyOrPath] extends BaseArray<unknown>
-        ? ArrayOperationInfo
-        : OperationInfoOfElement<TElement[TKeyOrPath]>
-      : OperationInfo;
+  ? TFirst extends keyof TElement
+    ? TElement[TFirst] extends BaseArray<unknown>
+      ? OperationInfoOfInternal<
+          TElement[TFirst],
+          number,
+          DecreasedDepthOf<TDepth>
+        >
+      : OperationInfoOfInternal<
+          TElement[TFirst],
+          TRest,
+          DecreasedDepthOf<TDepth>
+        >
+    : OperationInfo
+  : TKeyOrPath extends keyof TElement
+  ? TElement[TKeyOrPath] extends BaseArray<unknown>
+    ? ArrayOperationInfo
+    : OperationInfoOfElement<TElement[TKeyOrPath]>
+  : OperationInfo;
 
 /**
  * `DecreasedDepthOf` represents the type of the decreased depth of the given depth.
@@ -491,24 +498,24 @@ type OperationInfoOfInternal<
 type DecreasedDepthOf<Depth extends number = 0> = Depth extends 10
   ? 9
   : Depth extends 9
-    ? 8
-    : Depth extends 8
-      ? 7
-      : Depth extends 7
-        ? 6
-        : Depth extends 6
-          ? 5
-          : Depth extends 5
-            ? 4
-            : Depth extends 4
-              ? 3
-              : Depth extends 3
-                ? 2
-                : Depth extends 2
-                  ? 1
-                  : Depth extends 1
-                    ? 0
-                    : -1;
+  ? 8
+  : Depth extends 8
+  ? 7
+  : Depth extends 7
+  ? 6
+  : Depth extends 6
+  ? 5
+  : Depth extends 5
+  ? 4
+  : Depth extends 4
+  ? 3
+  : Depth extends 3
+  ? 2
+  : Depth extends 2
+  ? 1
+  : Depth extends 1
+  ? 0
+  : -1;
 
 /**
  * `PathOfInternal` represents the type of the path of the given element.
@@ -520,29 +527,29 @@ type PathOfInternal<
 > = Depth extends 0
   ? Prefix
   : TElement extends Record<string, any>
-    ? {
-        [TKey in keyof TElement]: TElement[TKey] extends LeafElement
-          ? `${Prefix}${TKey & string}`
-          : TElement[TKey] extends BaseArray<infer TArrayElement>
-            ?
-                | `${Prefix}${TKey & string}`
-                | `${Prefix}${TKey & string}.${number}`
-                | PathOfInternal<
-                    TArrayElement,
-                    `${Prefix}${TKey & string}.${number}.`,
-                    DecreasedDepthOf<Depth>
-                  >
-            :
-                | `${Prefix}${TKey & string}`
-                | PathOfInternal<
-                    TElement[TKey],
-                    `${Prefix}${TKey & string}.`,
-                    DecreasedDepthOf<Depth>
-                  >;
-      }[keyof TElement]
-    : Prefix extends `${infer TRest}.`
-      ? TRest
-      : Prefix;
+  ? {
+      [TKey in keyof TElement]: TElement[TKey] extends LeafElement
+        ? `${Prefix}${TKey & string}`
+        : TElement[TKey] extends BaseArray<infer TArrayElement>
+        ?
+            | `${Prefix}${TKey & string}`
+            | `${Prefix}${TKey & string}.${number}`
+            | PathOfInternal<
+                TArrayElement,
+                `${Prefix}${TKey & string}.${number}.`,
+                DecreasedDepthOf<Depth>
+              >
+        :
+            | `${Prefix}${TKey & string}`
+            | PathOfInternal<
+                TElement[TKey],
+                `${Prefix}${TKey & string}.`,
+                DecreasedDepthOf<Depth>
+              >;
+    }[keyof TElement]
+  : Prefix extends `${infer TRest}.`
+  ? TRest
+  : Prefix;
 
 /**
  * `OperationInfoOf` represents the type of the operation info of the given

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -424,7 +424,7 @@ type Json = JsonScalar | JsonArray | JsonObject;
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type JsonScalar = string | number | boolean | null;
-type JsonArray = Json[];
+type JsonArray = Array<Json>;
 type JsonObject = { [key: string]: Json | undefined };
 
 /**
@@ -445,14 +445,14 @@ export type DocumentKey = string;
 type OperationInfoOfElement<TElement> = TElement extends Text
   ? TextOperationInfo
   : TElement extends Counter
-  ? CounterOperationInfo
-  : TElement extends Tree
-  ? TreeOperationInfo
-  : TElement extends BaseArray<any>
-  ? ArrayOperationInfo
-  : TElement extends BaseObject<any>
-  ? ObjectOperationInfo
-  : OperationInfo;
+    ? CounterOperationInfo
+    : TElement extends Tree
+      ? TreeOperationInfo
+      : TElement extends BaseArray<any>
+        ? ArrayOperationInfo
+        : TElement extends BaseObject<any>
+          ? ObjectOperationInfo
+          : OperationInfo;
 
 /**
  * `OperationInfoOfInternal` represents the type of the operation info of the
@@ -473,24 +473,24 @@ type OperationInfoOfInternal<
 > = TDepth extends 0
   ? TElement
   : TKeyOrPath extends `${infer TFirst}.${infer TRest}`
-  ? TFirst extends keyof TElement
-    ? TElement[TFirst] extends BaseArray<unknown>
-      ? OperationInfoOfInternal<
-          TElement[TFirst],
-          number,
-          DecreasedDepthOf<TDepth>
-        >
-      : OperationInfoOfInternal<
-          TElement[TFirst],
-          TRest,
-          DecreasedDepthOf<TDepth>
-        >
-    : OperationInfo
-  : TKeyOrPath extends keyof TElement
-  ? TElement[TKeyOrPath] extends BaseArray<unknown>
-    ? ArrayOperationInfo
-    : OperationInfoOfElement<TElement[TKeyOrPath]>
-  : OperationInfo;
+    ? TFirst extends keyof TElement
+      ? TElement[TFirst] extends BaseArray<unknown>
+        ? OperationInfoOfInternal<
+            TElement[TFirst],
+            number,
+            DecreasedDepthOf<TDepth>
+          >
+        : OperationInfoOfInternal<
+            TElement[TFirst],
+            TRest,
+            DecreasedDepthOf<TDepth>
+          >
+      : OperationInfo
+    : TKeyOrPath extends keyof TElement
+      ? TElement[TKeyOrPath] extends BaseArray<unknown>
+        ? ArrayOperationInfo
+        : OperationInfoOfElement<TElement[TKeyOrPath]>
+      : OperationInfo;
 
 /**
  * `DecreasedDepthOf` represents the type of the decreased depth of the given depth.
@@ -498,24 +498,24 @@ type OperationInfoOfInternal<
 type DecreasedDepthOf<Depth extends number = 0> = Depth extends 10
   ? 9
   : Depth extends 9
-  ? 8
-  : Depth extends 8
-  ? 7
-  : Depth extends 7
-  ? 6
-  : Depth extends 6
-  ? 5
-  : Depth extends 5
-  ? 4
-  : Depth extends 4
-  ? 3
-  : Depth extends 3
-  ? 2
-  : Depth extends 2
-  ? 1
-  : Depth extends 1
-  ? 0
-  : -1;
+    ? 8
+    : Depth extends 8
+      ? 7
+      : Depth extends 7
+        ? 6
+        : Depth extends 6
+          ? 5
+          : Depth extends 5
+            ? 4
+            : Depth extends 4
+              ? 3
+              : Depth extends 3
+                ? 2
+                : Depth extends 2
+                  ? 1
+                  : Depth extends 1
+                    ? 0
+                    : -1;
 
 /**
  * `PathOfInternal` represents the type of the path of the given element.
@@ -527,29 +527,29 @@ type PathOfInternal<
 > = Depth extends 0
   ? Prefix
   : TElement extends Record<string, any>
-  ? {
-      [TKey in keyof TElement]: TElement[TKey] extends LeafElement
-        ? `${Prefix}${TKey & string}`
-        : TElement[TKey] extends BaseArray<infer TArrayElement>
-        ?
-            | `${Prefix}${TKey & string}`
-            | `${Prefix}${TKey & string}.${number}`
-            | PathOfInternal<
-                TArrayElement,
-                `${Prefix}${TKey & string}.${number}.`,
-                DecreasedDepthOf<Depth>
-              >
-        :
-            | `${Prefix}${TKey & string}`
-            | PathOfInternal<
-                TElement[TKey],
-                `${Prefix}${TKey & string}.`,
-                DecreasedDepthOf<Depth>
-              >;
-    }[keyof TElement]
-  : Prefix extends `${infer TRest}.`
-  ? TRest
-  : Prefix;
+    ? {
+        [TKey in keyof TElement]: TElement[TKey] extends LeafElement
+          ? `${Prefix}${TKey & string}`
+          : TElement[TKey] extends BaseArray<infer TArrayElement>
+            ?
+                | `${Prefix}${TKey & string}`
+                | `${Prefix}${TKey & string}.${number}`
+                | PathOfInternal<
+                    TArrayElement,
+                    `${Prefix}${TKey & string}.${number}.`,
+                    DecreasedDepthOf<Depth>
+                  >
+            :
+                | `${Prefix}${TKey & string}`
+                | PathOfInternal<
+                    TElement[TKey],
+                    `${Prefix}${TKey & string}.`,
+                    DecreasedDepthOf<Depth>
+                  >;
+      }[keyof TElement]
+    : Prefix extends `${infer TRest}.`
+      ? TRest
+      : Prefix;
 
 /**
  * `OperationInfoOf` represents the type of the operation info of the given

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -420,21 +420,26 @@ export type DocEventTopic = keyof DocEventCallbackMap<never>;
 export type DocEventCallback<P extends Indexable> =
   DocEventCallbackMap<P>[DocEventTopic];
 
-export type Json = JsonScalar | JsonArray | JsonObject;
+/**
+ * `Json` represents the JSON data type. It is used to represent the data
+ * structure of the document.
+ */
+export type Json = JsonPrimitive | JsonArray | JsonObject;
 
 // eslint-disable-next-line @typescript-eslint/ban-types
-type JsonScalar = string | number | boolean | null;
+type JsonPrimitive = string | number | boolean | null;
 type JsonArray = Array<Json>;
 type JsonObject = { [key: string]: Json | undefined };
 
 /**
- * Indexable key, value
+ * `Indexable` represents the type of the indexable object. It is used to
+ * represent the presence information of the client.
  * @public
  */
 export type Indexable = Record<string, Json>;
 
 /**
- * Document key type
+ * `DocumentKey` represents the key of the document.
  * @public
  */
 export type DocumentKey = string;

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -385,7 +385,7 @@ export interface PresenceChangedEvent<P extends Indexable>
 
 export interface BroadcastEvent extends BaseDocEvent {
   type: DocEventType.Broadcast;
-  value: { clientID: ActorID; topic: string; payload: any };
+  value: { clientID: ActorID; topic: string; payload: Json };
   error?: ErrorFn;
 }
 
@@ -420,7 +420,7 @@ export type DocEventTopic = keyof DocEventCallbackMap<never>;
 export type DocEventCallback<P extends Indexable> =
   DocEventCallbackMap<P>[DocEventTopic];
 
-type Json = JsonScalar | JsonArray | JsonObject;
+export type Json = JsonScalar | JsonArray | JsonObject;
 
 // eslint-disable-next-line @typescript-eslint/ban-types
 type JsonScalar = string | number | boolean | null;
@@ -2065,7 +2065,7 @@ export class Document<T, P extends Indexable = Indexable> {
   /**
    * `broadcast` the payload to the given topic.
    */
-  public broadcast(topic: string, payload: any, error?: ErrorFn) {
+  public broadcast(topic: string, payload: Json, error?: ErrorFn) {
     const broadcastEvent: LocalBroadcastEvent = {
       type: DocEventType.LocalBroadcast,
       value: { topic, payload },

--- a/packages/sdk/src/document/json/tree.ts
+++ b/packages/sdk/src/document/json/tree.ts
@@ -86,10 +86,10 @@ function buildDescendants(
     let attrs;
 
     if (typeof attributes === 'object' && !isEmpty(attributes)) {
-      attributes = stringifyObjectValues(attributes);
+      const stringifiedAttributes = stringifyObjectValues(attributes);
       attrs = new RHT();
 
-      for (const [key, value] of Object.entries(attributes)) {
+      for (const [key, value] of Object.entries(stringifiedAttributes)) {
         attrs.set(key, value, ticket);
       }
     }
@@ -125,10 +125,10 @@ function createCRDTTreeNode(context: ChangeContext, content: TreeNode) {
     let attrs;
 
     if (typeof attributes === 'object' && !isEmpty(attributes)) {
-      attributes = stringifyObjectValues(attributes);
+      const stringifiedAttributes = stringifyObjectValues(attributes);
       attrs = new RHT();
 
-      for (const [key, value] of Object.entries(attributes)) {
+      for (const [key, value] of Object.entries(stringifiedAttributes)) {
         attrs.set(key, value, ticket);
       }
     }

--- a/packages/sdk/src/document/json/tree.ts
+++ b/packages/sdk/src/document/json/tree.ts
@@ -82,7 +82,7 @@ function buildDescendants(
     parent.append(textNode);
   } else {
     const { children = [] } = treeNode as ElementNode;
-    let { attributes } = treeNode as ElementNode;
+    const { attributes } = treeNode as ElementNode;
     let attrs;
 
     if (typeof attributes === 'object' && !isEmpty(attributes)) {
@@ -121,7 +121,7 @@ function createCRDTTreeNode(context: ChangeContext, content: TreeNode) {
     root = CRDTTreeNode.create(CRDTTreeNodeID.of(ticket, 0), type, value);
   } else if (content) {
     const { children = [] } = content as ElementNode;
-    let { attributes } = content as ElementNode;
+    const { attributes } = content as ElementNode;
     let attrs;
 
     if (typeof attributes === 'object' && !isEmpty(attributes)) {

--- a/packages/sdk/src/util/object.ts
+++ b/packages/sdk/src/util/object.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import { Indexable } from '@yorkie-js-sdk/src/document/document';
+
 /**
  * `deepcopy` returns a deep copy of the given object.
  */
@@ -40,7 +42,7 @@ export const isEmpty = (object: object) => {
 /**
  * `stringifyObjectValues` makes values of attributes to JSON parsable string.
  */
-export const stringifyObjectValues = <A extends object>(
+export const stringifyObjectValues = <A extends Indexable>(
   attributes: A,
 ): Record<string, string> => {
   const attrs: Record<string, string> = {};
@@ -53,7 +55,7 @@ export const stringifyObjectValues = <A extends object>(
 /**
  `parseObjectValues` returns the JSON parsable string values to the origin states.
  */
-export const parseObjectValues = <A extends object>(
+export const parseObjectValues = <A extends Indexable>(
   attrs: Record<string, string>,
 ): A => {
   const attributes: Record<string, unknown> = {};

--- a/packages/sdk/src/util/validator.ts
+++ b/packages/sdk/src/util/validator.ts
@@ -17,7 +17,7 @@
 /**
  * `validateSerializable` returns whether the given value is serializable or not.
  */
-export const validateSerializable = (value: any): boolean => {
+export const validateSerializable = (value: unknown): boolean => {
   try {
     const serialized = JSON.stringify(value);
 

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -900,6 +900,8 @@ describe.sequential('Client', function () {
       eventCollector.add(error.message);
     };
 
+    // @ts-ignore
+    // Disable type checking for testing purposes
     doc.broadcast(broadcastTopic, payload, errorHandler);
 
     await eventCollector.waitAndVerifyNthEvent(1, broadcastErrMessage);

--- a/packages/sdk/test/integration/integration_helper.ts
+++ b/packages/sdk/test/integration/integration_helper.ts
@@ -13,12 +13,15 @@ export function toDocKey(title: string): string {
     .replace(/[^a-z0-9-]/g, '-');
 }
 
-export async function withTwoClientsAndDocuments<T>(
+export async function withTwoClientsAndDocuments<
+  T,
+  P extends Indexable = Indexable,
+>(
   callback: (
     c1: Client,
-    d1: Document<T>,
+    d1: Document<T, P>,
     c2: Client,
-    d2: Document<T>,
+    d2: Document<T, P>,
   ) => Promise<void>,
   title: string,
   syncMode: SyncMode = SyncMode.Manual,
@@ -29,8 +32,8 @@ export async function withTwoClientsAndDocuments<T>(
   await client2.activate();
 
   const docKey = `${toDocKey(title)}-${new Date().getTime()}`;
-  const doc1 = new yorkie.Document<T>(docKey);
-  const doc2 = new yorkie.Document<T>(docKey);
+  const doc1 = new yorkie.Document<T, P>(docKey);
+  const doc2 = new yorkie.Document<T, P>(docKey);
 
   await client1.attach(doc1, { syncMode });
   await client2.attach(doc2, { syncMode });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR introduces a more restrictive type for the `presence` object `P`. Previously, the type `<P extends Indexable>` allowed `any` type as a value, since `Indexable` was defined as `Record<string, any>`. This broad type allowed values that are not JSON serializable, such as byte arrays, Date, and Long, which could cause issues during serialization.

To address this, we now restrict the type of `P` to only allow JSON serializable types. This ensures that the presence object contains values that can be safely serialized to JSON.

#### Any background context you want to provide?

The `Json` type introduced in this PR is based on a similar approach used by Liveblocks. Here’s the definition of the `Json` type:

```typescript
export type Json = JsonScalar | JsonArray | JsonObject;

// eslint-disable-next-line @typescript-eslint/ban-types
type JsonScalar = string | number | boolean | null;
type JsonArray = Array<Json>;
type JsonObject = { [key: string]: Json | undefined };
```

With the introduction of the `Json` type, we now enforce that only JSON serializable payloads can be broadcast, addressing issues like #884 . For instance, the `broadcast` function has been updated as follows:

```javascript
  /**
   * `broadcast` the payload to the given topic.
   */
  public broadcast(topic: string, payload: Json, error?: ErrorFn) {
  }
```

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #591 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced type safety for payloads in broadcasting methods by changing from `any` to a specific `Json` type.
  - Introduced a centralized `Json` type definition for better consistency across the codebase.

- **Bug Fixes**
  - Improved type checks in various methods to prevent runtime errors related to type mismatches.

- **Chores**
  - Added a new entry in `.eslintignore` to exclude a specific TypeScript declaration file from linting checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->