### PR TITLE
Add configurable retry mechanism to broadcast interface

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -165,7 +165,7 @@ const DefaultClientOptions = {
  * `DefaultBroadcastOptions` is the default options for broadcast.
  */
 const DefaultBroadcastOptions = {
-  maxRetries: 20,
+  maxRetries: Infinity,
   initialRetryInterval: 1000,
   maxBackoff: 20000,
 };

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -165,7 +165,7 @@ const DefaultClientOptions = {
  * `DefaultBroadcastOptions` is the default options for broadcast.
  */
 const DefaultBroadcastOptions = {
-  maxRetries: 10,
+  maxRetries: 0,
   retryInterval: 1000,
 };
 
@@ -315,13 +315,13 @@ export class Client {
     doc.update((_, p) => p.set(options.initialPresence || {}));
     const unsubscribeBroacastEvent = doc.subscribe(
       'local-broadcast',
-      (event) => {
+      async (event) => {
         const { topic, payload } = event.value;
         const errorFn = event.options?.error;
         const options = event.options;
 
         try {
-          this.broadcast(doc.getKey(), topic, payload, options);
+          await this.broadcast(doc.getKey(), topic, payload, options);
         } catch (error: unknown) {
           if (error instanceof Error) {
             errorFn?.(error);
@@ -648,7 +648,7 @@ export class Client {
 
     let retryCount = 0;
 
-    const doLoop = (): Promise<void> => {
+    const doLoop = async (): Promise<any> => {
       return this.enqueueTask(async () => {
         return this.rpcClient
           .broadcast(

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -408,21 +408,13 @@ export interface PresenceChangedEvent<P extends Indexable>
 export interface BroadcastEvent extends BaseDocEvent {
   type: DocEventType.Broadcast;
   value: { clientID: ActorID; topic: string; payload: Json };
-  options?: {
-    error?: ErrorFn;
-    maxRetries?: number;
-    retryInterval?: number;
-  };
+  options?: BroadcastOptions;
 }
 
 export interface LocalBroadcastEvent extends BaseDocEvent {
   type: DocEventType.LocalBroadcast;
   value: { topic: string; payload: any };
-  options?: {
-    error?: ErrorFn;
-    maxRetries?: number;
-    retryInterval?: number;
-  };
+  options?: BroadcastOptions;
 }
 
 type DocEventCallbackMap<P extends Indexable> = {

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -94,11 +94,6 @@ export interface BroadcastOptions {
    * `maxRetries` is the maximum number of retries.
    */
   maxRetries?: number;
-
-  /**
-   * `retryInterval` is the interval of retries.
-   */
-  retryInterval?: number;
 }
 
 /**

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -80,6 +80,28 @@ import { setupDevtools } from '@yorkie-js-sdk/src/devtools';
 import * as Devtools from '@yorkie-js-sdk/src/devtools/types';
 
 /**
+ * `BroadcastOptions` are the options to create a new document.
+ *
+ * @public
+ */
+export interface BroadcastOptions {
+  /**
+   * `error` is called when an error occurs.
+   */
+  error?: ErrorFn;
+
+  /**
+   * `maxRetries` is the maximum number of retries.
+   */
+  maxRetries?: number;
+
+  /**
+   * `retryInterval` is the interval of retries.
+   */
+  retryInterval?: number;
+}
+
+/**
  * `DocumentOptions` are the options to create a new document.
  *
  * @public
@@ -386,13 +408,21 @@ export interface PresenceChangedEvent<P extends Indexable>
 export interface BroadcastEvent extends BaseDocEvent {
   type: DocEventType.Broadcast;
   value: { clientID: ActorID; topic: string; payload: Json };
-  error?: ErrorFn;
+  options?: {
+    error?: ErrorFn;
+    maxRetries?: number;
+    retryInterval?: number;
+  };
 }
 
 export interface LocalBroadcastEvent extends BaseDocEvent {
   type: DocEventType.LocalBroadcast;
   value: { topic: string; payload: any };
-  error?: ErrorFn;
+  options?: {
+    error?: ErrorFn;
+    maxRetries?: number;
+    retryInterval?: number;
+  };
 }
 
 type DocEventCallbackMap<P extends Indexable> = {
@@ -450,14 +480,14 @@ export type DocumentKey = string;
 type OperationInfoOfElement<TElement> = TElement extends Text
   ? TextOperationInfo
   : TElement extends Counter
-    ? CounterOperationInfo
-    : TElement extends Tree
-      ? TreeOperationInfo
-      : TElement extends BaseArray<any>
-        ? ArrayOperationInfo
-        : TElement extends BaseObject<any>
-          ? ObjectOperationInfo
-          : OperationInfo;
+  ? CounterOperationInfo
+  : TElement extends Tree
+  ? TreeOperationInfo
+  : TElement extends BaseArray<any>
+  ? ArrayOperationInfo
+  : TElement extends BaseObject<any>
+  ? ObjectOperationInfo
+  : OperationInfo;
 
 /**
  * `OperationInfoOfInternal` represents the type of the operation info of the
@@ -478,24 +508,24 @@ type OperationInfoOfInternal<
 > = TDepth extends 0
   ? TElement
   : TKeyOrPath extends `${infer TFirst}.${infer TRest}`
-    ? TFirst extends keyof TElement
-      ? TElement[TFirst] extends BaseArray<unknown>
-        ? OperationInfoOfInternal<
-            TElement[TFirst],
-            number,
-            DecreasedDepthOf<TDepth>
-          >
-        : OperationInfoOfInternal<
-            TElement[TFirst],
-            TRest,
-            DecreasedDepthOf<TDepth>
-          >
-      : OperationInfo
-    : TKeyOrPath extends keyof TElement
-      ? TElement[TKeyOrPath] extends BaseArray<unknown>
-        ? ArrayOperationInfo
-        : OperationInfoOfElement<TElement[TKeyOrPath]>
-      : OperationInfo;
+  ? TFirst extends keyof TElement
+    ? TElement[TFirst] extends BaseArray<unknown>
+      ? OperationInfoOfInternal<
+          TElement[TFirst],
+          number,
+          DecreasedDepthOf<TDepth>
+        >
+      : OperationInfoOfInternal<
+          TElement[TFirst],
+          TRest,
+          DecreasedDepthOf<TDepth>
+        >
+    : OperationInfo
+  : TKeyOrPath extends keyof TElement
+  ? TElement[TKeyOrPath] extends BaseArray<unknown>
+    ? ArrayOperationInfo
+    : OperationInfoOfElement<TElement[TKeyOrPath]>
+  : OperationInfo;
 
 /**
  * `DecreasedDepthOf` represents the type of the decreased depth of the given depth.
@@ -503,24 +533,24 @@ type OperationInfoOfInternal<
 type DecreasedDepthOf<Depth extends number = 0> = Depth extends 10
   ? 9
   : Depth extends 9
-    ? 8
-    : Depth extends 8
-      ? 7
-      : Depth extends 7
-        ? 6
-        : Depth extends 6
-          ? 5
-          : Depth extends 5
-            ? 4
-            : Depth extends 4
-              ? 3
-              : Depth extends 3
-                ? 2
-                : Depth extends 2
-                  ? 1
-                  : Depth extends 1
-                    ? 0
-                    : -1;
+  ? 8
+  : Depth extends 8
+  ? 7
+  : Depth extends 7
+  ? 6
+  : Depth extends 6
+  ? 5
+  : Depth extends 5
+  ? 4
+  : Depth extends 4
+  ? 3
+  : Depth extends 3
+  ? 2
+  : Depth extends 2
+  ? 1
+  : Depth extends 1
+  ? 0
+  : -1;
 
 /**
  * `PathOfInternal` represents the type of the path of the given element.
@@ -532,29 +562,29 @@ type PathOfInternal<
 > = Depth extends 0
   ? Prefix
   : TElement extends Record<string, any>
-    ? {
-        [TKey in keyof TElement]: TElement[TKey] extends LeafElement
-          ? `${Prefix}${TKey & string}`
-          : TElement[TKey] extends BaseArray<infer TArrayElement>
-            ?
-                | `${Prefix}${TKey & string}`
-                | `${Prefix}${TKey & string}.${number}`
-                | PathOfInternal<
-                    TArrayElement,
-                    `${Prefix}${TKey & string}.${number}.`,
-                    DecreasedDepthOf<Depth>
-                  >
-            :
-                | `${Prefix}${TKey & string}`
-                | PathOfInternal<
-                    TElement[TKey],
-                    `${Prefix}${TKey & string}.`,
-                    DecreasedDepthOf<Depth>
-                  >;
-      }[keyof TElement]
-    : Prefix extends `${infer TRest}.`
-      ? TRest
-      : Prefix;
+  ? {
+      [TKey in keyof TElement]: TElement[TKey] extends LeafElement
+        ? `${Prefix}${TKey & string}`
+        : TElement[TKey] extends BaseArray<infer TArrayElement>
+        ?
+            | `${Prefix}${TKey & string}`
+            | `${Prefix}${TKey & string}.${number}`
+            | PathOfInternal<
+                TArrayElement,
+                `${Prefix}${TKey & string}.${number}.`,
+                DecreasedDepthOf<Depth>
+              >
+        :
+            | `${Prefix}${TKey & string}`
+            | PathOfInternal<
+                TElement[TKey],
+                `${Prefix}${TKey & string}.`,
+                DecreasedDepthOf<Depth>
+              >;
+    }[keyof TElement]
+  : Prefix extends `${infer TRest}.`
+  ? TRest
+  : Prefix;
 
 /**
  * `OperationInfoOf` represents the type of the operation info of the given
@@ -2070,11 +2100,11 @@ export class Document<T, P extends Indexable = Indexable> {
   /**
    * `broadcast` the payload to the given topic.
    */
-  public broadcast(topic: string, payload: Json, error?: ErrorFn) {
+  public broadcast(topic: string, payload: Json, options?: BroadcastOptions) {
     const broadcastEvent: LocalBroadcastEvent = {
       type: DocEventType.LocalBroadcast,
       value: { topic, payload },
-      error,
+      options,
     };
 
     this.publish([broadcastEvent]);

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -1142,10 +1142,6 @@ describe.sequential('Client', function () {
           maxRetries: 0,
         });
 
-        // Failed to broadcast due to network failure
-        await new Promise((res) => setTimeout(res, 3000));
-        assert.equal(eventCollector.getLength(), 0);
-
         // 02. Back to normal condition
         vi.unstubAllGlobals();
 

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -1085,10 +1085,7 @@ describe.sequential('Client', function () {
 
         const payload = { a: 1, b: '2' };
 
-        // Broadcasting with retry option
-        d1.broadcast(broadcastTopic, payload, {
-          maxRetries: 10,
-        });
+        d1.broadcast(broadcastTopic, payload);
 
         // Failed to broadcast due to network failure
         await new Promise((res) => setTimeout(res, 3000));

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -1091,7 +1091,7 @@ describe.sequential('Client', function () {
         });
 
         // Failed to broadcast due to network failure
-        await new Promise((res) => setTimeout(res, 1000));
+        await new Promise((res) => setTimeout(res, 3000));
         assert.equal(eventCollector.getLength(), 0);
 
         // 02. Back to normal condition
@@ -1109,7 +1109,7 @@ describe.sequential('Client', function () {
     );
   });
 
-  it('Should not retry broadcasting on network failure witout retry option', async ({
+  it('Should not retry broadcasting on network failure when maxRetries is set to zero', async ({
     task,
   }) => {
     await withTwoClientsAndDocuments<{ t: Text }>(
@@ -1140,13 +1140,13 @@ describe.sequential('Client', function () {
           }
         };
 
-        // Broadcasting without retry option
         d1.broadcast(broadcastTopic, payload, {
           error: errorHandler,
+          maxRetries: 0,
         });
 
         // Failed to broadcast due to network failure
-        await new Promise((res) => setTimeout(res, 1000));
+        await new Promise((res) => setTimeout(res, 3000));
         assert.equal(eventCollector.getLength(), 0);
 
         // 02. Back to normal condition


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR introduces a broadcast interface with configurable retry mechanisms. In the event of a network failure, the broadcast will automatically retry based on the provided settings.

#### Any background context you want to provide?

Here is the updated broadcast interface. The `BroadcastOptions` interface includes optional settings for `error` callbacks, `maxRetries`. Retry options apply only to network errors. (retries will not occur for non-network errors such as broadcasting unserializable payloads.)


```javascript
  // document.ts

  public broadcast(topic: string, payload: Json, options?: BroadcastOptions) {
      // skipped
  }
```

```javascript
export interface BroadcastOptions {
  /**
   * `error` is called when an error occurs.
   */
  error?: ErrorFn;

  /**
   * `maxRetries` is the maximum number of retries.
   */
  maxRetries?: number;  // Default is 0 meaning it won't retry on error.
}
```

```javascript
  // usage
  doc.broadcast("YOUR_TOPIC",  "SERIALIZABLE_PAYLOAD", {
      maxRetries: 10,
      error: (error) => {
         console.log(error) 
     } 
  })
```

I'm concerned that the `maxRetries`  option is not as intuitive as the `shouldQueueEventIfNotReady` option provided by Liveblocks.

We could also provide the same option by two possible solutions:

1. The simplest approach would be to set `maxRetries` to `Infinity`, though this may lead to performance issues.

2. Another approach is to implement a loop similar to `runSyncLoop` for broadcasts, continuously checking if the network is restored. However, adding a separate loop for broadcasting feels redundant at this point. Therefore, I've opted to keep the solution as simple as possible for now.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #891 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Introduced `DefaultBroadcastOptions` for enhanced broadcasting settings, including retry logic.
	- Added flexibility in the broadcasting method to handle options for error handling and retries.

- **Bug Fixes**
	- Improved error handling during network failures with refined retry capabilities.

- **Tests**
	- Added new test cases to validate broadcasting behavior under network failure scenarios, ensuring correct retry logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->