### PR TITLE
Ensure `find` and `indexOf` perform splay

### DIFF
--- a/packages/sdk/src/util/splay_tree.ts
+++ b/packages/sdk/src/util/splay_tree.ts
@@ -211,6 +211,7 @@ export class SplayTree<V> {
         `out of index range: pos: ${pos} > node.length: ${node.getLength()}`,
       );
     }
+    this.splayNode(node)
     return [node, pos];
   }
 
@@ -225,19 +226,8 @@ export class SplayTree<V> {
       return -1;
     }
 
-    let index = 0;
-    let current: SplayNode<V> | undefined = node;
-    let prev: SplayNode<V> | undefined;
-    while (current) {
-      if (!prev || prev === current.getRight()) {
-        index +=
-          current.getLength() +
-          (current.hasLeft() ? current.getLeftWeight() : 0);
-      }
-      prev = current;
-      current = current.getParent();
-    }
-    return index - node.getLength();
+    this.splayNode(node)
+    return this.root!.getLeftWeight();
   }
 
   /**

--- a/packages/sdk/test/bench/splay_tree.bench.ts
+++ b/packages/sdk/test/bench/splay_tree.bench.ts
@@ -3,10 +3,7 @@ import { SplayNode, SplayTree } from '@yorkie-js-sdk/src/util/splay_tree';
 import editTraceData from './editing-trace.json';
 
 class StringNode extends SplayNode<string> {
-  public removed: Boolean = false;
-  constructor(value: string) {
-    super(value);
-  }
+  public removed: boolean = false;
 
   public static create(value: string): StringNode {
     return new StringNode(value);
@@ -84,12 +81,15 @@ describe('splay_tree.edit', () => {
     };
     for (const i of editTrace.edits) {
       if (i[0] == 0 && i[0] != undefined) {
-        tree.insertAfter(
-          tree.find(i[1] as number)[0]!,
-          StringNode.create(i[2] as string),
-        );
+        const node = tree.find(i[1] as number)[0];
+        if (node) {
+          tree.insertAfter(node, StringNode.create(i[2] as string));
+        }
       } else if (i[0] == 1) {
-        tree.delete(tree.find(i[1] as number)[0]!);
+        const nodeToDelete = tree.find(i[1] as number)[0];
+        if (nodeToDelete) {
+          tree.delete(nodeToDelete);
+        }
       }
     }
   });

--- a/packages/sdk/test/bench/splay_tree.bench.ts
+++ b/packages/sdk/test/bench/splay_tree.bench.ts
@@ -1,0 +1,96 @@
+import { describe, bench } from 'vitest';
+import { SplayNode, SplayTree } from '@yorkie-js-sdk/src/util/splay_tree';
+import editTraceData from './editing-trace.json';
+
+class StringNode extends SplayNode<string> {
+  public removed: Boolean = false;
+  constructor(value: string) {
+    super(value);
+  }
+
+  public static create(value: string): StringNode {
+    return new StringNode(value);
+  }
+
+  public getLength(): number {
+    if (this.removed) {
+      return 0;
+    }
+    return this.value.length;
+  }
+}
+
+const benchmarkRandomAccess = (size: number) => {
+  const tree = new SplayTree<string>();
+  for (let i = 0; i < size; i++) {
+    tree.insert(StringNode.create('A'));
+  }
+  for (let i = 0; i < 1000; i++) {
+    tree.find(Math.floor(Math.random() * i));
+  }
+};
+
+const stressTest = (size: number) => {
+  const tree = new SplayTree<string>();
+  let treeSize = 1;
+  for (let i = 0; i < size; i++) {
+    const op = Math.floor(Math.random() * 3);
+    if (op == 0) {
+      const node = tree.find(Math.floor(Math.random() * treeSize))[0];
+      if (node != undefined) {
+        tree.insertAfter(node, StringNode.create('A'));
+      } else {
+        tree.insert(StringNode.create('A'));
+      }
+      treeSize++;
+    } else if (op == 1) {
+      tree.find(Math.floor(Math.random() * treeSize));
+    } else {
+      const node = tree.find(Math.floor(Math.random() * treeSize))[0];
+      if (node != undefined) {
+        tree.delete(node);
+        treeSize--;
+      }
+    }
+  }
+};
+
+interface edit_operation {
+  cursor: number;
+  opeator: number;
+  operand?: string;
+}
+
+describe('splay_tree.edit', () => {
+  bench('splay_tree.stress 10000', () => {
+    stressTest(10000);
+  });
+  bench('splay_tree.stress 20000', () => {
+    stressTest(20000);
+  });
+  bench('splay_tree.stress 30000', () => {
+    stressTest(30000);
+  });
+
+  bench('splay_tree.random_access 10000', () => {
+    benchmarkRandomAccess(10000);
+  });
+  bench('splay_tree.random_access 20000', () => {
+    benchmarkRandomAccess(20000);
+  });
+  bench('splay_tree.random_access 30000', () => {
+    benchmarkRandomAccess(30000);
+  });
+
+  bench('editing-trace', () => {
+    const tree = new SplayTree<string>();
+    const editTrace = editTraceData as { edits: Array<edit_operation> };
+    for (const i of editTrace.edits) {
+      if (i.opeator == 0 && i.operand != undefined) {
+        tree.insertAfter(tree.find(i.cursor)[0]!, StringNode.create(i.operand));
+      } else if (i.opeator == 1) {
+        tree.delete(tree.find(i.cursor)[0]!);
+      }
+    }
+  });
+});

--- a/packages/sdk/test/bench/splay_tree.bench.ts
+++ b/packages/sdk/test/bench/splay_tree.bench.ts
@@ -55,12 +55,6 @@ const stressTest = (size: number) => {
   }
 };
 
-interface edit_operation {
-  cursor: number;
-  opeator: number;
-  operand?: string;
-}
-
 describe('splay_tree.edit', () => {
   bench('splay_tree.stress 10000', () => {
     stressTest(10000);
@@ -84,12 +78,18 @@ describe('splay_tree.edit', () => {
 
   bench('editing-trace', () => {
     const tree = new SplayTree<string>();
-    const editTrace = editTraceData as { edits: Array<edit_operation> };
+    const editTrace = editTraceData as {
+      edits: Array<Array<string | number>>;
+      finalText: string;
+    };
     for (const i of editTrace.edits) {
-      if (i.opeator == 0 && i.operand != undefined) {
-        tree.insertAfter(tree.find(i.cursor)[0]!, StringNode.create(i.operand));
-      } else if (i.opeator == 1) {
-        tree.delete(tree.find(i.cursor)[0]!);
+      if (i[0] == 0 && i[0] != undefined) {
+        tree.insertAfter(
+          tree.find(i[1] as number)[0]!,
+          StringNode.create(i[2] as string),
+        );
+      } else if (i[0] == 1) {
+        tree.delete(tree.find(i[1] as number)[0]!);
       }
     }
   });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR addresses a critical issue in the splay tree implementation where the Find and IndexOf functions do not perform the necessary splay operation after locating a node. By ensuring that these functions splay the accessed node to the root, we maintain the amortized O(log n) time complexity for subsequent operations. This enhancement optimizes the overall efficiency and performance of the splay tree, ensuring that frequently accessed nodes remain close to the root and improving access times for future queries.

#### Any background context you want to provide?
Same PR as the Go repository
https://github.com/yorkie-team/yorkie/pull/1017
![image](https://github.com/user-attachments/assets/58c9d9af-7347-4a1c-a897-48d7e5690159)


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #903 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **New Features**
	- Enhanced the `SplayTree` functionality for improved node access and manipulation.
	- Introduced a new benchmarking suite to evaluate the performance of the `SplayTree` under various conditions, including random access and stress tests.

- **Bug Fixes**
	- Improved control flow in the `getNodeAt` and `getIndexOfNode` methods for more reliable node retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->