### PR TITLE
Update removedAt for already deleted nodes during range deletions

### DIFF
--- a/packages/sdk/test/helper/helper.ts
+++ b/packages/sdk/test/helper/helper.ts
@@ -187,7 +187,7 @@ export async function assertThrowsAsync(
   message?: string,
 ) {
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  let errFn = () => {};
+  let errFn = () => { };
   try {
     await fn();
   } catch (e) {
@@ -284,4 +284,11 @@ export function posT(offset = 0): CRDTTreeNodeID {
  */
 export function timeT(): TimeTicket {
   return dummyContext.issueTimeTicket();
+}
+
+/**
+ * `getLTT` is a helpher function that returns the last time ticket.
+ */
+export function getLTT(): TimeTicket {
+  return dummyContext.getLastTimeTicket();
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->
#### What this PR does / why we need it:

This PR addresses the issue where `removedAt` timestamps were not being updated for nodes that had already been deleted during range deletion operations. The changes ensure that the `removedAt` field reflects the most recent deletion time, which is crucial for maintaining operational consistency across remote clients, particularly in scenarios that may involve future undo/redo functionalities.

#### Any background context you want to provide?

Previously, nodes that were already marked as removed did not have their removedAt timestamp updated during subsequent deletion operations.
This led to inconsistencies when undoing or redoing changes, especially in cases where multiple clients performed overlapping deletion operations.
This PR ensures that the removedAt field is always reflective of the most recent deletion, thereby maintaining the integrity of the document's operational history and facilitating accurate undo/redo operations.

#### What are the relevant tickets?

Fixes #821 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced methods for managing tree positions in the CRDT structure.
	- Added a new method for creating a CRDT tree with a root and time ticket.
	- Introduced a comparator for comparing node IDs based on creation time.
	- New function to retrieve the last time ticket for testing purposes.

- **Improvements**
	- Streamlined import statements for better organization.
	- Refined methods for handling node edits, styling, and removals, improving concurrent edit management.

- **Bug Fixes**
	- Adjusted comparison methods to ensure accurate evaluations of tree positions and IDs.
	- Added test case to verify correct updates of removed nodes during deletions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->