### PR TITLE
Add `doc.getStats` for debugging purpose

### DIFF
--- a/packages/sdk/public/index.html
+++ b/packages/sdk/public/index.html
@@ -328,6 +328,8 @@
           const doc = new yorkie.Document('codemirror', {
             enableDevtools: true,
           });
+          window.doc = doc;
+
           doc.subscribe('connection', new Network(statusHolder).statusListener);
           doc.subscribe('presence', (event) => {
             if (event.type === 'presence-changed') return;

--- a/packages/sdk/src/document/crdt/root.ts
+++ b/packages/sdk/src/document/crdt/root.ts
@@ -40,6 +40,26 @@ interface CRDTElementPair {
 }
 
 /**
+ * `RootStats` is a structure that represents the statistics of the root object.
+ */
+export interface RootStats {
+  /**
+   * `elements` is the number of elements in the root object.
+   */
+  elements?: number;
+
+  /**
+   * `gcElements` is the number of elements that can be garbage collected.
+   */
+  gcElements?: number;
+
+  /**
+   * `gcPairs` is the number of garbage collection pairs.
+   */
+  gcPairs?: number;
+}
+
+/**
  * `CRDTRoot` is a structure that represents the root. It has a hash table of
  * all elements to find a specific element when applying remote changes
  * received from server.
@@ -307,5 +327,17 @@ export class CRDTRoot {
    */
   public toSortedJSON(): string {
     return this.rootObject.toSortedJSON();
+  }
+
+  /**
+   * `getStats` returns the current statistics of the root object.
+   * This includes counts of various types of elements and structural information.
+   */
+  public getStats(): RootStats {
+    return {
+      elements: this.getElementMapSize(),
+      gcPairs: this.gcPairMap.size,
+      gcElements: this.getGarbageElementSetSize(),
+    };
   }
 }

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -42,7 +42,7 @@ import {
 import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
 import { converter } from '@yorkie-js-sdk/src/api/converter';
 import { ChangePack } from '@yorkie-js-sdk/src/document/change/change_pack';
-import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
+import { CRDTRoot, RootStats } from '@yorkie-js-sdk/src/document/crdt/root';
 import { CRDTObject } from '@yorkie-js-sdk/src/document/crdt/object';
 import {
   createJSON,
@@ -1386,6 +1386,13 @@ export class Document<T, P extends Indexable = Indexable> {
    */
   public toSortedJSON(): string {
     return this.root.toSortedJSON();
+  }
+
+  /**
+   * `getStats` returns the statistics of this document.
+   */
+  public getStats(): RootStats {
+    return this.root.getStats();
   }
 
   /**

--- a/packages/sdk/src/util/splay_tree.ts
+++ b/packages/sdk/src/util/splay_tree.ts
@@ -211,7 +211,7 @@ export class SplayTree<V> {
         `out of index range: pos: ${pos} > node.length: ${node.getLength()}`,
       );
     }
-    this.splayNode(node)
+    this.splayNode(node);
     return [node, pos];
   }
 
@@ -226,7 +226,7 @@ export class SplayTree<V> {
       return -1;
     }
 
-    this.splayNode(node)
+    this.splayNode(node);
     return this.root!.getLeftWeight();
   }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Add `root.getStats` for debugging purpose

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a global `doc` variable for easier access and debugging.
	- Added a `getStats()` method in both `CRDTRoot` and `Document` classes to retrieve statistics about the root object and document.

- **Bug Fixes**
	- Minor formatting adjustments to ensure consistent statement termination in `SplayTree` class methods.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->