### PR TITLE
Add keepalive option in client.deactivate

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -199,6 +199,7 @@ export class Client {
   private setAuthToken: (token: string) => void;
   private taskQueue: Array<() => Promise<any>>;
   private processing = false;
+  private unloading = false;
 
   /**
    * @param rpcAddr - the address of the RPC server.
@@ -238,7 +239,7 @@ export class Client {
         fetch: (input, init) => {
           const newInit = {
             ...init,
-            keepalive: true,
+            keepalive: this.unloading,
           };
 
           return fetch(input, newInit);
@@ -293,6 +294,7 @@ export class Client {
     }
 
     if (options.fireImmediately) {
+      this.unloading = true;
       this.rpcClient.deactivateClient(
         { clientId: this.id! },
         { headers: { 'x-shard-key': this.apiKey } },

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -287,12 +287,12 @@ export class Client {
   /**
    * `deactivate` deactivates this client.
    */
-  public deactivate(fireImmediately = false): Promise<void> {
+  public deactivate(options = { fireImmediately: false }): Promise<void> {
     if (this.status === ClientStatus.Deactivated) {
       return Promise.resolve();
     }
 
-    if (fireImmediately) {
+    if (options.fireImmediately) {
       this.rpcClient.deactivateClient(
         { clientId: this.id! },
         { headers: { 'x-shard-key': this.apiKey } },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Since introducing version vectors, we have been using them for GC.
However, if the client deactivate process is not properly completed when a browser in the middle of editing is closed, the version vector table in the database retains version vectors for users whose deactivate process was incomplete.
As a result, unnecessary values remain in the minimum version vector, causing GC to fail to operate.

Therefore, we needed to enable functionality that allows the client to request the user's deactivate process when the browser is refreshed or closed. To address this, we made `rpcClient.DeactivateClient` callable.

Since the execution of the browser's `beforeunload` event handler is not guaranteed, I conducted a hit rate test with three comparison methods:

- `navigator.sendBeacon`
- `fetch`
- `rpcClient.DeactivateClient`

Below are the hit rate comparison results. In summary, `rpcClient.DeactivateClient` demonstrated the highest hit rate.  
As a result, without adding extra code, we configured the RPC creation process to use the `keepalive` option in `fetch`.

#### Test Results

- **navigator.sendBeacon**
  - **No throttle**
    - Single refresh: 50/50 = 100%
    - Single browser close: 50/50 = 100%
    - Single refresh + single browser close: 98/100 = 98%
  - **Fast 3G**
    - Single refresh: 44/50 = 88%
    - Single browser close: 45/50 = 90%
    - Single refresh + single browser close: 79/100 = 79%

- **fetch + keepalive**
  - **No throttle**
    - Single refresh: 50/50 = 100%
    - Single browser close: 50/50 = 100%
    - Single refresh + single browser close: 100/100 = 100%
  - **Fast 3G**
    - Single refresh: 50/50 = 100%
    - Single browser close: 49/50 = 98%
    - Single refresh + single browser close: 100/100 = 100%

- **rpc.DeactivateClient (client.deactivate({fireImmediately: true}))**
  - **No throttle**
    - Single refresh: 50/50 = 100%
    - Single browser close: 50/50 = 100%
    - Single refresh + single browser close: 100/100 = 100%
  - **Fast 3G**
    - Single refresh: 50/50 = 100%
    - Single browser close: 50/50 = 100%
    - Single refresh + single browser close: 100/100 = 100%



#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced `deactivate` functionality to allow immediate execution based on optional parameters.
	- Improved connection persistence with new transport options.

- **Bug Fixes**
	- Adjusted control flow in the `deactivate` method to ensure correct execution with new parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->