### PR TITLE
Preserve Detached Client's Lamport in Version Vector

### DIFF
--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -1233,12 +1233,7 @@ export class Document<T, P extends Indexable = Indexable> {
       this.garbageCollect(pack.getVersionVector()!);
     }
 
-    // 04. Filter detached client's lamport from version vector
-    if (!hasSnapshot) {
-      this.filterVersionVector(pack.getVersionVector()!);
-    }
-
-    // 05. Update the status.
+    // 04. Update the status.
     if (pack.getIsRemoved()) {
       this.applyStatus(DocStatus.Removed);
     }

--- a/packages/sdk/src/document/time/version_vector.ts
+++ b/packages/sdk/src/document/time/version_vector.ts
@@ -59,26 +59,6 @@ export class VersionVector {
   }
 
   /**
-   * `minLamport` returns min lamport value from vector
-   */
-  public minLamport(): bigint {
-    // TODO(hackerwins): If the version vector is empty, minLamport could be the
-    // max value of int64. This is because if the last client leaves the
-    // document, the min version vector becomes empty.
-    // This is a temporary solution and needs to be fixed later.
-
-    // 2^63-1 (int64 max)
-    let min = 9223372036854775807n;
-
-    for (const [, lamport] of this) {
-      if (lamport < min) {
-        min = lamport;
-      }
-    }
-    return min;
-  }
-
-  /**
    * `max` returns new version vector which consists of max value of each vector
    */
   public max(other: VersionVector): VersionVector {
@@ -116,7 +96,7 @@ export class VersionVector {
     const lamport = this.vector.get(other.getActorID());
 
     if (lamport === undefined) {
-      return this.minLamport() > other.getLamport();
+      return false;
     }
 
     return lamport >= other.getLamport();


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Since we found GC error in https://github.com/yorkie-team/yorkie/issues/1089.
We decided to leave detached client's lamport in version vector for now and look for a solution later.

I modified following items
- Local document version vector filtering
- Using minLamport when run GC

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/yorkie/issues/1089

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Simplified document status update logic after applying change packs.
	- Enhanced garbage collection handling for detached documents in multi-client scenarios.

- **Bug Fixes**
	- Improved accuracy of version vector handling during garbage collection.

- **Tests**
	- Added new test cases for garbage collection with detached documents and multiple clients.
	- Updated existing tests to ensure comprehensive coverage of version vector states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->