### PR TITLE
Replace maxCreatedAtMap with version vector for causal-concurrent operations

### DIFF
--- a/packages/sdk/src/document/change/change.ts
+++ b/packages/sdk/src/document/change/change.ts
@@ -162,7 +162,11 @@ export class Change<P extends Indexable> {
     const reverseOps: Array<HistoryOperation<P>> = [];
 
     for (const operation of this.operations) {
-      const executionResult = operation.execute(root, source);
+      const executionResult = operation.execute(
+        root,
+        source,
+        this.id.getVersionVector(),
+      );
       // NOTE(hackerwins): If the element was removed while executing undo/redo,
       // the operation is not executed and executionResult is undefined.
       if (!executionResult) continue;

--- a/packages/sdk/src/document/operation/edit_operation.ts
+++ b/packages/sdk/src/document/operation/edit_operation.ts
@@ -15,6 +15,7 @@
  */
 
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
+import { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import { RGATreeSplitPos } from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';
 import { CRDTText } from '@yorkie-js-sdk/src/document/crdt/text';
@@ -22,6 +23,7 @@ import {
   Operation,
   OperationInfo,
   ExecutionResult,
+  OpSource,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { Indexable } from '../document';
 import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
@@ -80,7 +82,11 @@ export class EditOperation extends Operation {
   /**
    * `execute` executes this operation on the given `CRDTRoot`.
    */
-  public execute<A extends Indexable>(root: CRDTRoot): ExecutionResult {
+  public execute<A extends Indexable>(
+    root: CRDTRoot,
+    _: OpSource,
+    versionVector?: VersionVector,
+  ): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       throw new YorkieError(
@@ -102,6 +108,7 @@ export class EditOperation extends Operation {
       this.getExecutedAt(),
       Object.fromEntries(this.attributes),
       this.maxCreatedAtMapByActor,
+      versionVector,
     );
 
     for (const pair of pairs) {

--- a/packages/sdk/src/document/operation/operation.ts
+++ b/packages/sdk/src/document/operation/operation.ts
@@ -16,6 +16,7 @@
 
 import { ActorID } from '@yorkie-js-sdk/src/document/time/actor_id';
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
+import { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
 import { TreeNode } from '@yorkie-js-sdk/src/document/crdt/tree';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import { Indexable } from '@yorkie-js-sdk/src/document/document';
@@ -248,5 +249,6 @@ export abstract class Operation {
   public abstract execute(
     root: CRDTRoot,
     source: OpSource,
+    versionVector?: VersionVector,
   ): ExecutionResult | undefined;
 }

--- a/packages/sdk/src/document/operation/style_operation.ts
+++ b/packages/sdk/src/document/operation/style_operation.ts
@@ -15,6 +15,7 @@
  */
 
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
+import { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import { RGATreeSplitPos } from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';
 import { CRDTText } from '@yorkie-js-sdk/src/document/crdt/text';
@@ -22,6 +23,7 @@ import {
   Operation,
   OperationInfo,
   ExecutionResult,
+  OpSource,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { Indexable } from '../document';
 import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
@@ -74,7 +76,11 @@ export class StyleOperation extends Operation {
   /**
    * `execute` executes this operation on the given `CRDTRoot`.
    */
-  public execute<A extends Indexable>(root: CRDTRoot): ExecutionResult {
+  public execute<A extends Indexable>(
+    root: CRDTRoot,
+    _: OpSource,
+    versionVector?: VersionVector,
+  ): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       throw new YorkieError(
@@ -94,6 +100,7 @@ export class StyleOperation extends Operation {
       this.attributes ? Object.fromEntries(this.attributes) : {},
       this.getExecutedAt(),
       this.maxCreatedAtMapByActor,
+      versionVector,
     );
 
     for (const pair of pairs) {

--- a/packages/sdk/src/document/operation/tree_edit_operation.ts
+++ b/packages/sdk/src/document/operation/tree_edit_operation.ts
@@ -15,6 +15,7 @@
  */
 
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
+import { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import {
   CRDTTree,
@@ -26,6 +27,7 @@ import {
   Operation,
   OperationInfo,
   ExecutionResult,
+  OpSource,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 
@@ -82,7 +84,11 @@ export class TreeEditOperation extends Operation {
   /**
    * `execute` executes this operation on the given `CRDTRoot`.
    */
-  public execute(root: CRDTRoot): ExecutionResult {
+  public execute(
+    root: CRDTRoot,
+    _: OpSource,
+    versionVector?: VersionVector,
+  ): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       throw new YorkieError(
@@ -124,6 +130,7 @@ export class TreeEditOperation extends Operation {
         return issueTimeTicket;
       })(),
       this.maxCreatedAtMapByActor,
+      versionVector,
     );
 
     for (const pair of pairs) {

--- a/packages/sdk/src/document/operation/tree_style_operation.ts
+++ b/packages/sdk/src/document/operation/tree_style_operation.ts
@@ -15,6 +15,7 @@
  */
 
 import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
+import { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
 import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
 import {
   CRDTTree,
@@ -25,6 +26,7 @@ import {
   Operation,
   OperationInfo,
   ExecutionResult,
+  OpSource,
 } from '@yorkie-js-sdk/src/document/operation/operation';
 import { GCPair } from '@yorkie-js-sdk/src/document/crdt/gc';
 import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
@@ -74,7 +76,7 @@ export class TreeStyleOperation extends Operation {
       toPos,
       maxCreatedAtMapByActor,
       attributes,
-      new Array<string>(),
+      [],
       executedAt,
     );
   }
@@ -104,7 +106,11 @@ export class TreeStyleOperation extends Operation {
   /**
    * `execute` executes this operation on the given `CRDTRoot`.
    */
-  public execute(root: CRDTRoot): ExecutionResult {
+  public execute(
+    root: CRDTRoot,
+    _: OpSource,
+    versionVector: VersionVector,
+  ): ExecutionResult {
     const parentObject = root.findByCreatedAt(this.getParentCreatedAt());
     if (!parentObject) {
       throw new YorkieError(
@@ -130,6 +136,7 @@ export class TreeStyleOperation extends Operation {
         attributes,
         this.getExecutedAt(),
         this.maxCreatedAtMapByActor,
+        versionVector,
       );
     } else {
       const attributesToRemove = this.attributesToRemove;
@@ -139,6 +146,7 @@ export class TreeStyleOperation extends Operation {
         attributesToRemove,
         this.getExecutedAt(),
         this.maxCreatedAtMapByActor,
+        versionVector,
       );
     }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR replaces the usage of `MaxCreatedAtMapByActor` with `version vector` for operations that handle causal and concurrent relationships. (`Text.Edit`, `Text.Style`, `Tree.Edit`, and `Tree.Style`)

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related https://github.com/yorkie-team/yorkie/pull/1088

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced operation execution with version vector support across various document operations.
	- Improved node management in CRDT structures, allowing for more precise control over edits and styles.

- **Bug Fixes**
	- Adjusted logic for node existence checks and style applications to incorporate new parameters.

- **Documentation**
	- Updated method signatures to reflect new parameters related to versioning.

- **Chores**
	- Refactored imports and constants for consistency in versioning across the SDK.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->