### PR TITLE
Fix version vector handling in applyChange and applySnapshot

### DIFF
--- a/packages/sdk/src/document/change/change_id.ts
+++ b/packages/sdk/src/document/change/change_id.ts
@@ -94,6 +94,9 @@ export class ChangeID {
       maxVersionVector,
     );
     newID.versionVector.set(this.actor, lamport);
+    if (other.versionVector.size() === 0) {
+      newID.versionVector.set(other.actor, other.lamport);
+    }
     return newID;
   }
 
@@ -103,9 +106,10 @@ export class ChangeID {
    */
   public setClocks(otherLamport: bigint, vector: VersionVector): ChangeID {
     const lamport =
-      otherLamport > this.lamport ? otherLamport : this.lamport + 1n;
+      otherLamport > this.lamport ? otherLamport + 1n : this.lamport + 1n;
     const maxVersionVector = this.versionVector.max(vector);
     maxVersionVector.set(this.actor, lamport);
+    maxVersionVector.unset(InitialActorID);
 
     return ChangeID.of(this.clientSeq, lamport, this.actor, maxVersionVector);
   }

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -1450,7 +1450,10 @@ export class Document<T, P extends Indexable = Indexable> {
     const { root, presences } = converter.bytesToSnapshot<P>(snapshot);
     this.root = new CRDTRoot(root);
     this.presences = presences;
-    this.changeID = this.changeID.setClocks(serverSeq, snapshotVector);
+    this.changeID = this.changeID.setClocks(
+      snapshotVector.maxLamport(),
+      snapshotVector,
+    );
 
     // drop clone because it is contaminated.
     this.clone = undefined;

--- a/packages/sdk/src/document/time/version_vector.ts
+++ b/packages/sdk/src/document/time/version_vector.ts
@@ -37,6 +37,13 @@ export class VersionVector {
   }
 
   /**
+   * `unset` removes the version for the given actor from the VersionVector.
+   */
+  public unset(actorID: string): void {
+    this.vector.delete(actorID);
+  }
+
+  /**
    * `get` gets the lamport timestamp of the given actor.
    */
   public get(actorID: string): bigint | undefined {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

1. Add `{actorID:lamport}` to accumulate VV when VV is empty in applyChange
   - Changes with VV length of 0 were created from legacy SDK (v0.5.2 or below)
   - In legacy SDK, we added lamport to VV to ensure information could be updated properly

2. Use maxLamport() instead of serverSeq in applySnapshot
   - Fixed an issue where characters were not being deleted because some lamport values were larger than serverSeq when setting clocks in applySnapshot


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related https://github.com/yorkie-team/yorkie/pull/1096

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything
