### PR TITLE
chore: update github actions version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
       matrix:
         node-version: [18.x]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: 9
 
@@ -30,7 +30,7 @@ jobs:
 
       - name: Cache pnpm store
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -48,9 +48,9 @@ jobs:
       - run: pnpm sdk test:ci
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v5
         with:
-          file: ./coverage/lcov.info
+          files: ./coverage/lcov.info
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/create-yorkie-app-publish.yml
+++ b/.github/workflows/create-yorkie-app-publish.yml
@@ -16,14 +16,14 @@ jobs:
       id-token: write
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: 9
 
       - name: Setup Node 🔧
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'pnpm'

--- a/.github/workflows/devtools-publish.yml
+++ b/.github/workflows/devtools-publish.yml
@@ -11,14 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: 9
 
       - name: Setup Node 🔧
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'pnpm'

--- a/.github/workflows/github-page-publish.yml
+++ b/.github/workflows/github-page-publish.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2.3.1
+        uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: 9
 
       - name: Setup Node 🔧
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'pnpm'
@@ -25,7 +25,7 @@ jobs:
 
       - name: Cache pnpm store
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}
@@ -44,7 +44,7 @@ jobs:
           pnpm sdk build:ghpages
 
       - name: Deploy 🚀
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./packages/sdk/ghpages

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,14 +10,14 @@ jobs:
       id-token: write
     steps:
       - name: Checkout 🛎️
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v2
+      - uses: pnpm/action-setup@v4
         with:
           version: 9
 
       - name: Setup Node 🔧
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v4
         with:
           node-version: '18'
           cache: 'pnpm'
@@ -26,7 +26,7 @@ jobs:
 
       - name: Cache pnpm store
         id: cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.pnpm-store
           key: ${{ runner.os }}-pnpm-${{ hashFiles('**/pnpm-lock.yaml') }}


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
- update .github/workflows/*.yml's actions/checkout version 2 to 4
- update .github/workflows/*.yml's pnpm/action-setup version 2 to 4
- update .github/workflows/*.yml's actions/cache version 3 to 4
- update .github/workflows/*.yml's codecov/codecov-action version 1 to 5
  - migrate `file` fileld to `files` fielid  
- update .github/workflows/*.yml's actions/cache version 3 to 4
- update .github/workflows/*.yml's actions/setup-node version 2 to 4
- update .github/workflows/*.yml's peaceiris/actions-gh-pages version 3 to 4


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Updated GitHub Actions workflows to utilize the latest versions of various actions, enhancing performance and reliability.

- **Bug Fixes**
	- Improved caching mechanisms in multiple workflows to ensure more efficient dependency management.

- **Documentation**
	- Adjusted parameters in workflows for better clarity and functionality regarding coverage file uploads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->