### PR TITLE
Fix type errors in devtools package

### DIFF
--- a/.github/workflows/devtools-publish.yml
+++ b/.github/workflows/devtools-publish.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     paths:
-      - packages/devtools/**
+      - packages/devtools/package.json
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest

--- a/packages/devtools/src/devtools/components/Detail.tsx
+++ b/packages/devtools/src/devtools/components/Detail.tsx
@@ -110,9 +110,13 @@ function TreeGraph({ tree }: { tree: Devtools.TreeNodeInfo }) {
     [],
   );
 
-  return flattenTreeWithDepth(tree).map((node) => (
-    <TreeNode key={node.id} node={node} />
-  ));
+  return (
+    <>
+      {flattenTreeWithDepth(tree).map((node) => (
+        <TreeNode key={node.id} node={node} />
+      ))}
+    </>
+  );
 }
 
 export function TreeDetail({

--- a/packages/devtools/src/devtools/components/Tree.tsx
+++ b/packages/devtools/src/devtools/components/Tree.tsx
@@ -22,7 +22,7 @@ import useResizeObserver from 'use-resize-observer';
 
 import { useSelectedNode } from '../contexts/SelectedNode';
 import { useSelectedPresence } from '../contexts/SelectedPresence';
-import type { Devtools } from 'yorkie-js-sdk';
+import type { Devtools, Json } from 'yorkie-js-sdk';
 
 import {
   ArrayIcon,
@@ -47,7 +47,7 @@ export type UserNode = Devtools.Client & {
 export type PresenceJsonNode = {
   id: string;
   key: string;
-  value: Devtools.Json;
+  value: Json;
   isLastChild: boolean;
   type: 'JSON';
 };

--- a/packages/devtools/src/devtools/contexts/YorkieSource.tsx
+++ b/packages/devtools/src/devtools/contexts/YorkieSource.tsx
@@ -31,7 +31,7 @@ import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
 const DocKeyContext = createContext<string>(null);
 const YorkieDocContext = createContext(null);
 const ReplayDocEventsContext = createContext<{
-  events: Array<Devtools.EventsForDocReplay>;
+  events: Array<Devtools.DocEventsForReplay>;
   hidePresenceEvents: boolean;
   setHidePresenceEvents: Dispatch<SetStateAction<boolean>>;
 }>(null);
@@ -44,7 +44,7 @@ export function YorkieSourceProvider({ children }: Props) {
   const [currentDocKey, setCurrentDocKey] = useState<string>('');
   const [doc, setDoc] = useState(null);
   const [replayDocEvents, setReplayDocEvents] = useState<
-    Array<Devtools.EventsForDocReplay>
+    Array<Devtools.DocEventsForReplay>
   >([]);
 
   // filter out presence events
@@ -146,7 +146,7 @@ export enum ReplayDocEventType {
 }
 
 export const getReplayDocEventType = (
-  event: Devtools.EventsForDocReplay,
+  event: Devtools.DocEventsForReplay,
 ): ReplayDocEventType => {
   for (const docEvent of event) {
     if (

--- a/packages/devtools/src/devtools/panel/index.tsx
+++ b/packages/devtools/src/devtools/panel/index.tsx
@@ -91,7 +91,7 @@ const Panel = () => {
         filteredEventIndex++;
       }
 
-      doc.applyEventsForDocReplay(originalEvents[eventIndex].event);
+      doc.applyDocEventsForReplay(originalEvents[eventIndex].event);
       eventIndex++;
     }
 

--- a/packages/devtools/src/devtools/panel/index.tsx
+++ b/packages/devtools/src/devtools/panel/index.tsx
@@ -23,7 +23,7 @@ import { SelectedPresenceProvider } from '../contexts/SelectedPresence';
 import {
   YorkieSourceProvider,
   useCurrentDocKey,
-  useTransactionEvents,
+  useReplayDocEvents,
   useYorkieDoc,
 } from '../contexts/YorkieSource';
 import { Document } from '../tabs/Document';
@@ -34,7 +34,7 @@ import { Separator } from '../components/ResizableSeparator';
 const Panel = () => {
   const currentDocKey = useCurrentDocKey();
   const { originalEvents, presenceFilteredEvents, hidePresenceEvents } =
-    useTransactionEvents();
+    useReplayDocEvents();
   const [, setDoc] = useYorkieDoc();
   const [selectedEventIndexInfo, setSelectedEventIndexInfo] = useState({
     index: null,
@@ -91,7 +91,7 @@ const Panel = () => {
         filteredEventIndex++;
       }
 
-      doc.applyTransactionEvent(originalEvents[eventIndex].event);
+      doc.applyEventsForDocReplay(originalEvents[eventIndex].event);
       eventIndex++;
     }
 

--- a/packages/devtools/src/devtools/panel/index.tsx
+++ b/packages/devtools/src/devtools/panel/index.tsx
@@ -23,7 +23,7 @@ import { SelectedPresenceProvider } from '../contexts/SelectedPresence';
 import {
   YorkieSourceProvider,
   useCurrentDocKey,
-  useReplayDocEvents,
+  useDocEventsForReplay,
   useYorkieDoc,
 } from '../contexts/YorkieSource';
 import { Document } from '../tabs/Document';
@@ -34,7 +34,7 @@ import { Separator } from '../components/ResizableSeparator';
 const Panel = () => {
   const currentDocKey = useCurrentDocKey();
   const { originalEvents, presenceFilteredEvents, hidePresenceEvents } =
-    useReplayDocEvents();
+    useDocEventsForReplay();
   const [, setDoc] = useYorkieDoc();
   const [selectedEventIndexInfo, setSelectedEventIndexInfo] = useState({
     index: null,

--- a/packages/devtools/src/devtools/tabs/History.tsx
+++ b/packages/devtools/src/devtools/tabs/History.tsx
@@ -26,7 +26,7 @@ import {
 
 const SLIDER_MARK_WIDTH = 24;
 
-const getEventInfo = (event: Devtools.EventsForDocReplay) => {
+const getEventInfo = (event: Devtools.DocEventsForReplay) => {
   const info = [];
   for (const docEvent of event) {
     if (

--- a/packages/devtools/src/devtools/tabs/History.tsx
+++ b/packages/devtools/src/devtools/tabs/History.tsx
@@ -19,10 +19,7 @@ import { DocEventType, Change, Devtools } from 'yorkie-js-sdk';
 import Slider from 'rc-slider';
 import { JSONView } from '../components/JsonView';
 import { CursorIcon, DocumentIcon } from '../icons';
-import {
-  ReplayDocEventType,
-  useReplayDocEvents,
-} from '../contexts/YorkieSource';
+import { DocEventScope, useDocEventsForReplay } from '../contexts/YorkieSource';
 
 const SLIDER_MARK_WIDTH = 24;
 
@@ -75,7 +72,7 @@ export function History({
     presenceFilteredEvents,
     hidePresenceEvents,
     setHidePresenceEvents,
-  } = useReplayDocEvents();
+  } = useDocEventsForReplay();
 
   const events = hidePresenceEvents ? presenceFilteredEvents : originalEvents;
 
@@ -109,13 +106,10 @@ export function History({
     const marks = {};
     for (const [index, event] of events.entries()) {
       const source = event.event[0].source;
-      const replayDocEventType = event.replayDocEventType;
 
       marks[index] = (
-        <span
-          className={`mark-history mark-${source} mark-${replayDocEventType}`}
-        >
-          {replayDocEventType === ReplayDocEventType.Presence ? (
+        <span className={`mark-history mark-${source} mark-${event.scope}`}>
+          {event.scope === DocEventScope.Presence ? (
             <CursorIcon />
           ) : (
             <DocumentIcon />

--- a/packages/devtools/src/devtools/tabs/History.tsx
+++ b/packages/devtools/src/devtools/tabs/History.tsx
@@ -15,18 +15,18 @@
  */
 
 import { useEffect, useState, useRef } from 'react';
-import { DocEventType, Change, type TransactionEvent } from 'yorkie-js-sdk';
+import { DocEventType, Change, Devtools } from 'yorkie-js-sdk';
 import Slider from 'rc-slider';
 import { JSONView } from '../components/JsonView';
 import { CursorIcon, DocumentIcon } from '../icons';
 import {
-  TransactionEventType,
-  useTransactionEvents,
+  ReplayDocEventType,
+  useReplayDocEvents,
 } from '../contexts/YorkieSource';
 
 const SLIDER_MARK_WIDTH = 24;
 
-const getEventInfo = (event: TransactionEvent) => {
+const getEventInfo = (event: Devtools.EventsForDocReplay) => {
   const info = [];
   for (const docEvent of event) {
     if (
@@ -75,7 +75,7 @@ export function History({
     presenceFilteredEvents,
     hidePresenceEvents,
     setHidePresenceEvents,
-  } = useTransactionEvents();
+  } = useReplayDocEvents();
 
   const events = hidePresenceEvents ? presenceFilteredEvents : originalEvents;
 
@@ -109,13 +109,13 @@ export function History({
     const marks = {};
     for (const [index, event] of events.entries()) {
       const source = event.event[0].source;
-      const transactionEventType = event.transactionEventType;
+      const replayDocEventType = event.replayDocEventType;
 
       marks[index] = (
         <span
-          className={`mark-history mark-${source} mark-${transactionEventType}`}
+          className={`mark-history mark-${source} mark-${replayDocEventType}`}
         >
-          {transactionEventType === TransactionEventType.Presence ? (
+          {replayDocEventType === ReplayDocEventType.Presence ? (
             <CursorIcon />
           ) : (
             <DocumentIcon />

--- a/packages/sdk/src/devtools/index.ts
+++ b/packages/sdk/src/devtools/index.ts
@@ -18,7 +18,7 @@ import { Document, Indexable } from '@yorkie-js-sdk/src/yorkie';
 import { logger } from '@yorkie-js-sdk/src/util/logger';
 import type * as DevTools from './protocol';
 import { EventSourceDevPanel, EventSourceSDK } from './protocol';
-import { EventsForDocReplay, isEventsForDocReplay } from './types';
+import { DocEventsForReplay, isDocEventsForReplay } from './types';
 
 type DevtoolsStatus = 'connected' | 'disconnected' | 'synced';
 let devtoolsStatus: DevtoolsStatus = 'disconnected';
@@ -29,10 +29,10 @@ const unsubsByDocKey = new Map<string, Array<() => void>>();
  * (time-traveling feature) in Devtools. Later, external storage such as
  * IndexedDB will be used.
  */
-const replayEventsByDocKey = new Map<string, Array<EventsForDocReplay>>();
+const replayEventsByDocKey = new Map<string, Array<DocEventsForReplay>>();
 declare global {
   interface Window {
-    replayEventsByDocKey: Map<string, Array<EventsForDocReplay>>;
+    replayEventsByDocKey: Map<string, Array<DocEventsForReplay>>;
   }
 }
 if (typeof window !== 'undefined') {
@@ -77,7 +77,7 @@ export function setupDevtools<T, P extends Indexable>(
 
   replayEventsByDocKey.set(doc.getKey(), []);
   const unsub = doc.subscribe('all', (event) => {
-    if (!isEventsForDocReplay(event)) {
+    if (!isDocEventsForReplay(event)) {
       return;
     }
 

--- a/packages/sdk/src/devtools/index.ts
+++ b/packages/sdk/src/devtools/index.ts
@@ -14,33 +14,29 @@
  * limitations under the License.
  */
 
-import {
-  Document,
-  Indexable,
-  TransactionEvent,
-} from '@yorkie-js-sdk/src/yorkie';
-import { DocEventType } from '@yorkie-js-sdk/src/document/document';
+import { Document, Indexable } from '@yorkie-js-sdk/src/yorkie';
 import { logger } from '@yorkie-js-sdk/src/util/logger';
 import type * as DevTools from './protocol';
 import { EventSourceDevPanel, EventSourceSDK } from './protocol';
+import { EventsForDocReplay, isEventsForDocReplay } from './types';
 
 type DevtoolsStatus = 'connected' | 'disconnected' | 'synced';
 let devtoolsStatus: DevtoolsStatus = 'disconnected';
 const unsubsByDocKey = new Map<string, Array<() => void>>();
 
 /**
- * `transactionEventsByDocKey` stores all events in the document for replaying
+ * `replayEventsByDocKey` stores all events in the document for replaying
  * (time-traveling feature) in Devtools. Later, external storage such as
  * IndexedDB will be used.
  */
-const transactionEventsByDocKey = new Map<string, Array<TransactionEvent>>();
+const replayEventsByDocKey = new Map<string, Array<EventsForDocReplay>>();
 declare global {
   interface Window {
-    transactionEventsByDocKey: Map<string, Array<TransactionEvent>>;
+    replayEventsByDocKey: Map<string, Array<EventsForDocReplay>>;
   }
 }
 if (typeof window !== 'undefined') {
-  window.transactionEventsByDocKey = transactionEventsByDocKey;
+  window.replayEventsByDocKey = replayEventsByDocKey;
 }
 
 /**
@@ -79,25 +75,13 @@ export function setupDevtools<T, P extends Indexable>(
     return;
   }
 
-  transactionEventsByDocKey.set(doc.getKey(), []);
+  replayEventsByDocKey.set(doc.getKey(), []);
   const unsub = doc.subscribe('all', (event) => {
-    if (
-      event.some(
-        (docEvent) =>
-          docEvent.type !== DocEventType.StatusChanged &&
-          docEvent.type !== DocEventType.Snapshot &&
-          docEvent.type !== DocEventType.LocalChange &&
-          docEvent.type !== DocEventType.RemoteChange &&
-          docEvent.type !== DocEventType.Initialized &&
-          docEvent.type !== DocEventType.Watched &&
-          docEvent.type !== DocEventType.Unwatched &&
-          docEvent.type !== DocEventType.PresenceChanged,
-      )
-    ) {
+    if (!isEventsForDocReplay(event)) {
       return;
     }
 
-    transactionEventsByDocKey.get(doc.getKey())!.push(event);
+    replayEventsByDocKey.get(doc.getKey())!.push(event);
     if (devtoolsStatus === 'synced') {
       sendToPanel({
         msg: 'doc::sync::partial',
@@ -148,7 +132,7 @@ export function setupDevtools<T, P extends Indexable>(
           sendToPanel({
             msg: 'doc::sync::full',
             docKey: doc.getKey(),
-            events: transactionEventsByDocKey.get(doc.getKey())!,
+            events: replayEventsByDocKey.get(doc.getKey())!,
           });
           logger.info(`[YD] Devtools subscribed. Doc: ${doc.getKey()}`);
           break;

--- a/packages/sdk/src/devtools/protocol.ts
+++ b/packages/sdk/src/devtools/protocol.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { EventsForDocReplay } from './types';
+import { DocEventsForReplay } from './types';
 
 /**
  * `EventSourceDevPanel` is the name of the source representing messages
@@ -76,7 +76,7 @@ export type SDKToPanelMessage =
   | {
       msg: 'doc::sync::full';
       docKey: string;
-      events: Array<EventsForDocReplay>;
+      events: Array<DocEventsForReplay>;
     }
   /**
    * Sent whenever the document is changed.
@@ -84,7 +84,7 @@ export type SDKToPanelMessage =
   | {
       msg: 'doc::sync::partial';
       docKey: string;
-      event: EventsForDocReplay;
+      event: DocEventsForReplay;
     };
 
 export type FullPanelToSDKMessage = PanelToSDKMessage & {

--- a/packages/sdk/src/devtools/protocol.ts
+++ b/packages/sdk/src/devtools/protocol.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { TransactionEvent } from '@yorkie-js-sdk/src/document/document';
+import { EventsForDocReplay } from './types';
 
 /**
  * `EventSourceDevPanel` is the name of the source representing messages
@@ -76,7 +76,7 @@ export type SDKToPanelMessage =
   | {
       msg: 'doc::sync::full';
       docKey: string;
-      events: Array<TransactionEvent>;
+      events: Array<EventsForDocReplay>;
     }
   /**
    * Sent whenever the document is changed.
@@ -84,7 +84,7 @@ export type SDKToPanelMessage =
   | {
       msg: 'doc::sync::partial';
       docKey: string;
-      event: TransactionEvent;
+      event: EventsForDocReplay;
     };
 
 export type FullPanelToSDKMessage = PanelToSDKMessage & {

--- a/packages/sdk/src/devtools/types.ts
+++ b/packages/sdk/src/devtools/types.ts
@@ -127,7 +127,7 @@ export type DocEventsForReplay = Array<DocEventForReplay>;
 export function isDocEventForReplay(
   event: DocEvent,
 ): event is DocEventForReplay {
-  const typesForDocReplay = [
+  const types = [
     DocEventType.StatusChanged,
     DocEventType.Snapshot,
     DocEventType.LocalChange,
@@ -138,7 +138,7 @@ export function isDocEventForReplay(
     DocEventType.PresenceChanged,
   ];
 
-  return typesForDocReplay.includes(event.type);
+  return types.includes(event.type);
 }
 
 /**

--- a/packages/sdk/src/devtools/types.ts
+++ b/packages/sdk/src/devtools/types.ts
@@ -17,7 +17,21 @@
 import type { PrimitiveValue } from '@yorkie-js-sdk/src/document/crdt/primitive';
 import type { CRDTTreePosStruct } from '@yorkie-js-sdk/src/document/crdt/tree';
 import { CounterValue } from '@yorkie-js-sdk/src/document/crdt/counter';
-import { Json } from '@yorkie-js-sdk/src/document/document';
+import {
+  Json,
+  DocEvent,
+  DocEventType,
+  type Indexable,
+  type StatusChangedEvent,
+  type SnapshotEvent,
+  type LocalChangeEvent,
+  type RemoteChangeEvent,
+  type InitializedEvent,
+  type WatchedEvent,
+  type UnwatchedEvent,
+  type PresenceChangedEvent,
+} from '@yorkie-js-sdk/src/document/document';
+import type { OperationInfo } from '@yorkie-js-sdk/src/document/operation/operation';
 
 /**
  * `Client` represents a client value in devtools.
@@ -85,3 +99,53 @@ export type TreeNodeInfo = {
   path?: Array<number>;
   pos?: CRDTTreePosStruct;
 };
+
+/**
+ * `EventForDocReplay` is an event used to replay a document.
+ */
+export type EventForDocReplay<
+  P extends Indexable = Indexable,
+  T = OperationInfo,
+> =
+  | StatusChangedEvent
+  | SnapshotEvent
+  | LocalChangeEvent<T, P>
+  | RemoteChangeEvent<T, P>
+  | InitializedEvent<P>
+  | WatchedEvent<P>
+  | UnwatchedEvent<P>
+  | PresenceChangedEvent<P>;
+
+/**
+ * `EventsForDocReplay` is a list of events used to replay a document.
+ */
+export type EventsForDocReplay = Array<EventForDocReplay>;
+
+/**
+ * `isEventForDocReplay` checks if an event can be used to replay a document.
+ */
+export function isEventForDocReplay(
+  event: DocEvent,
+): event is EventForDocReplay {
+  const typesForDocReplay = [
+    DocEventType.StatusChanged,
+    DocEventType.Snapshot,
+    DocEventType.LocalChange,
+    DocEventType.RemoteChange,
+    DocEventType.Initialized,
+    DocEventType.Watched,
+    DocEventType.Unwatched,
+    DocEventType.PresenceChanged,
+  ];
+
+  return typesForDocReplay.includes(event.type);
+}
+
+/**
+ * `isEventsForDocReplay` checks if a list of events can be used to replay a document.
+ */
+export function isEventsForDocReplay(
+  events: Array<DocEvent>,
+): events is EventsForDocReplay {
+  return events.every(isEventForDocReplay);
+}

--- a/packages/sdk/src/devtools/types.ts
+++ b/packages/sdk/src/devtools/types.ts
@@ -101,9 +101,9 @@ export type TreeNodeInfo = {
 };
 
 /**
- * `EventForDocReplay` is an event used to replay a document.
+ * `DocEventForReplay` is an event used to replay a document.
  */
-export type EventForDocReplay<
+export type DocEventForReplay<
   P extends Indexable = Indexable,
   T = OperationInfo,
 > =
@@ -117,16 +117,16 @@ export type EventForDocReplay<
   | PresenceChangedEvent<P>;
 
 /**
- * `EventsForDocReplay` is a list of events used to replay a document.
+ * `DocEventsForReplay` is a list of events used to replay a document.
  */
-export type EventsForDocReplay = Array<EventForDocReplay>;
+export type DocEventsForReplay = Array<DocEventForReplay>;
 
 /**
- * `isEventForDocReplay` checks if an event can be used to replay a document.
+ * `isDocEventForReplay` checks if an event can be used to replay a document.
  */
-export function isEventForDocReplay(
+export function isDocEventForReplay(
   event: DocEvent,
-): event is EventForDocReplay {
+): event is DocEventForReplay {
   const typesForDocReplay = [
     DocEventType.StatusChanged,
     DocEventType.Snapshot,
@@ -142,10 +142,10 @@ export function isEventForDocReplay(
 }
 
 /**
- * `isEventsForDocReplay` checks if a list of events can be used to replay a document.
+ * `isDocEventsForReplay` checks if a list of events can be used to replay a document.
  */
-export function isEventsForDocReplay(
+export function isDocEventsForReplay(
   events: Array<DocEvent>,
-): events is EventsForDocReplay {
-  return events.every(isEventForDocReplay);
+): events is DocEventsForReplay {
+  return events.every(isDocEventForReplay);
 }

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -1718,9 +1718,9 @@ export class Document<T, P extends Indexable = Indexable> {
   }
 
   /**
-   * `applyDocEvent` applies the docEvent into this document.
+   * `applyEventForDocReplay` applies the given event into this document.
    */
-  public applyDocEvent(event: DocEvent<P>) {
+  public applyEventForDocReplay(event: Devtools.EventForDocReplay<P>) {
     if (event.type === DocEventType.StatusChanged) {
       this.applyStatus(event.value.status);
       if (event.value.status === DocStatus.Attached) {
@@ -1782,11 +1782,11 @@ export class Document<T, P extends Indexable = Indexable> {
   }
 
   /**
-   * `applyTransactionEvent` applies the given TransactionEvent into this document.
+   * `applyEventsForDocReplay` applies the given events into this document.
    */
-  public applyTransactionEvent(event: TransactionEvent<P>) {
+  public applyEventsForDocReplay(event: Array<Devtools.EventForDocReplay<P>>) {
     for (const docEvent of event) {
-      this.applyDocEvent(docEvent);
+      this.applyEventForDocReplay(docEvent);
     }
   }
 

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -1780,7 +1780,7 @@ export class Document<T, P extends Indexable = Indexable> {
   }
 
   /**
-   * `applyEventsForDocReplay` applies the given events into this document.
+   * `applyDocEventsForReplay` applies the given events into this document.
    */
   public applyDocEventsForReplay(event: Array<Devtools.DocEventForReplay<P>>) {
     for (const docEvent of event) {

--- a/packages/sdk/src/yorkie.ts
+++ b/packages/sdk/src/yorkie.ts
@@ -44,6 +44,7 @@ export {
   DocSyncStatus,
   DocStatus,
   type Indexable,
+  type Json,
   type DocEvent,
   type TransactionEvent,
   Document,

--- a/packages/sdk/src/yorkie.ts
+++ b/packages/sdk/src/yorkie.ts
@@ -46,7 +46,7 @@ export {
   type Indexable,
   type Json,
   type DocEvent,
-  type TransactionEvent,
+  type DocEvents,
   Document,
   type ChangeInfo,
 } from '@yorkie-js-sdk/src/document/document';


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

- Resolved TransactionEvent type issue
  - Previously, `TransactionEvent` represented a collection of `DocEvent`s occurring within a single transaction (e.g. doc.update())
  - With the addition of `BroadcastEvent`, `AuthErrorEvent`, etc., we needed a more robust type definition
  - Introduced `EventsForDocReplay` type to differentiate from `TransactionEvent`, specifically designed for document replay functionality in devtools
- Fixed other type errors
- Modified devtools-publish workflow to trigger only when package.json is updated

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #873 

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Workflow Changes**
	- Updated GitHub Actions workflow to trigger only on `packages/devtools/package.json` modifications.

- **DevTools Improvements**
	- Refactored event handling mechanism to focus on document replay.
	- Updated type definitions and event processing logic for improved clarity.
	- Renamed context, hook, and method names to align with new event replay functionality.

- **SDK Enhancements**
	- Introduced new types for document event replay.
	- Added `Json` type export for enhanced type definitions.
	- Modified methods for applying document events to support new event structure.

These changes enhance the functionality and usability of the Yorkie DevTools and SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->