### PR TITLE
Add Proactive WatchDocument Connection Retry Mechanism with Exponential Backoff and Jitter

### DIFF
--- a/packages/sdk/public/index.html
+++ b/packages/sdk/public/index.html
@@ -320,7 +320,7 @@
           devtool.setCodeMirror(codemirror);
 
           // 02-1. create client with RPCAddr.
-          const client = new yorkie.Client('http://localhost:80');
+          const client = new yorkie.Client('http://localhost:8080');
           // 02-2. activate client
           await client.activate();
 

--- a/packages/sdk/public/index.html
+++ b/packages/sdk/public/index.html
@@ -320,7 +320,7 @@
           devtool.setCodeMirror(codemirror);
 
           // 02-1. create client with RPCAddr.
-          const client = new yorkie.Client('http://localhost:8080');
+          const client = new yorkie.Client('http://localhost:80');
           // 02-2. activate client
           await client.activate();
 

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -1011,6 +1011,7 @@ export class Client {
                   },
                 ]);
                 reject(err); // Don't retry on auth errors
+                onDisconnect();
                 return;
               }
 

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -911,7 +911,7 @@ export class Client {
         logger.info(`[WD] c:"${this.getKey()}" watches d:"${docKey}"`);
 
         return new Promise((resolve, reject) => {
-          let idleTimer: any;
+          let idleTimer: ReturnType<typeof setTimeout>;
 
           const scheduleIdleTimer = () => {
             if (idleTimer) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR introduces a proactive retry mechanism for the WatchDocument connection, implementing [exponential backoff and jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/)). This optimization addresses several issues:

1. It significantly reduces the frequency of connection retries when only one client is present at the document and the server's idle timeout causes disconnection due to lack of events. The previous approach resulted in 60 reconnections per hour, while the new mechanism will reduce this to approximately 7-8 reconnections, achieving an optimization of around 88%.
2. It provides clients with greater flexibility in reconnecting. For instance, clients seeking a more sensitive collaborative editing experience can configure shorter backoff timeout values to reconnect more quickly in case of a split-brain scenario with the server.
3. By adding jitter to the reconnection process, it prevents all clients from attempting to reconnect simultaneously when the server disconnects multiple connections. This reduces server overload by staggering reconnection attempts.

Additionally, the implementation respects server-side idle timeouts, ensuring that unused connections are cleaned up efficiently on both the server and client sides.

#### Any background context you want to provide?

This issue was originally derived from the [Split-brain of Long-lived Connection (WatchDocument)](https://github.com/yorkie-team/yorkie/blob/main/design/sharded-cluster-mode.md#risks-and-mitigation).

1. The split-brain issue in WatchDocument occurred due to the Sharded Cluster Mode of the Yorkie Server.
2. It was initially mitigated using an idle timeout (retry). This worked well in scenarios where clients were actively exchanging events, as the idle timeout would not trigger for active connections. However, a new problem arose—clients editing alone experienced frequent reconnections, with the system reconnecting every minute just to prevent the rare possibility of a split-brain issue.
3. To address this, we are introducing proactive WatchDocument reconnection from the client, incorporating exponential backoff and jitter. This prevents excessive reconnections for clients editing alone, provides more configuration options for sensitive editing experiences, and helps prevent connection storms.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #940

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced configurable reconnection timeout settings that let users adjust the recovery behavior after periods of inactivity.
	- The client now automatically adapts and increases the delay between reconnection attempts—up to a maximum threshold—to improve error handling and connection stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->