### PR TITLE
Add metadata to Client for MAU tracking

### DIFF
--- a/examples/vanilla-quill/src/main.ts
+++ b/examples/vanilla-quill/src/main.ts
@@ -42,7 +42,6 @@ async function main() {
   // 01-1. create client with RPCAddr then activate it.
   const client = new yorkie.Client(import.meta.env.VITE_YORKIE_API_ADDR, {
     apiKey: import.meta.env.VITE_YORKIE_API_KEY,
-    metadata: { userId: 'dummy_user_id' },
   });
   await client.activate();
 

--- a/examples/vanilla-quill/src/main.ts
+++ b/examples/vanilla-quill/src/main.ts
@@ -42,6 +42,7 @@ async function main() {
   // 01-1. create client with RPCAddr then activate it.
   const client = new yorkie.Client(import.meta.env.VITE_YORKIE_API_ADDR, {
     apiKey: import.meta.env.VITE_YORKIE_API_KEY,
+    metadata: { userId: 'dummy_user_id' },
   });
   await client.activate();
 

--- a/packages/sdk/src/api/yorkie/v1/yorkie.proto
+++ b/packages/sdk/src/api/yorkie/v1/yorkie.proto
@@ -41,6 +41,8 @@ service YorkieService {
 
 message ActivateClientRequest {
   string client_key = 1;
+  string user_id = 2;
+  map<string, string> metadata = 3;
 }
 
 message ActivateClientResponse {

--- a/packages/sdk/src/api/yorkie/v1/yorkie.proto
+++ b/packages/sdk/src/api/yorkie/v1/yorkie.proto
@@ -41,8 +41,7 @@ service YorkieService {
 
 message ActivateClientRequest {
   string client_key = 1;
-  string user_id = 2;
-  map<string, string> metadata = 3;
+  map<string, string> metadata = 2;
 }
 
 message ActivateClientResponse {

--- a/packages/sdk/src/api/yorkie/v1/yorkie_pb.ts
+++ b/packages/sdk/src/api/yorkie/v1/yorkie_pb.ts
@@ -31,6 +31,16 @@ export class ActivateClientRequest extends Message<ActivateClientRequest> {
    */
   clientKey = "";
 
+  /**
+   * @generated from field: string user_id = 2;
+   */
+  userId = "";
+
+  /**
+   * @generated from field: map<string, string> metadata = 3;
+   */
+  metadata: { [key: string]: string } = {};
+
   constructor(data?: PartialMessage<ActivateClientRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -40,6 +50,8 @@ export class ActivateClientRequest extends Message<ActivateClientRequest> {
   static readonly typeName = "yorkie.v1.ActivateClientRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "metadata", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "scalar", T: 9 /* ScalarType.STRING */} },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ActivateClientRequest {

--- a/packages/sdk/src/api/yorkie/v1/yorkie_pb.ts
+++ b/packages/sdk/src/api/yorkie/v1/yorkie_pb.ts
@@ -32,12 +32,7 @@ export class ActivateClientRequest extends Message<ActivateClientRequest> {
   clientKey = "";
 
   /**
-   * @generated from field: string user_id = 2;
-   */
-  userId = "";
-
-  /**
-   * @generated from field: map<string, string> metadata = 3;
+   * @generated from field: map<string, string> metadata = 2;
    */
   metadata: { [key: string]: string } = {};
 
@@ -50,8 +45,7 @@ export class ActivateClientRequest extends Message<ActivateClientRequest> {
   static readonly typeName = "yorkie.v1.ActivateClientRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "user_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "metadata", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "scalar", T: 9 /* ScalarType.STRING */} },
+    { no: 2, name: "metadata", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "scalar", T: 9 /* ScalarType.STRING */} },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): ActivateClientRequest {

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -129,12 +129,6 @@ export interface ClientOptions {
   apiKey?: string;
 
   /**
-   * `userId` is the user key. It is used to identify the user.
-   * If not set, a random key is generated.
-   */
-  userId?: string;
-
-  /**
    * `metadata` is the metadata of the client. It is used to store additional
    * information about the client.
    */
@@ -197,7 +191,6 @@ const DefaultBroadcastOptions = {
 export class Client {
   private id?: ActorID;
   private key: string;
-  private userId: string;
   private metadata: Record<string, string>;
   private status: ClientStatus;
   private attachmentMap: Map<DocKey, Attachment<unknown, any>>;
@@ -223,7 +216,6 @@ export class Client {
     opts = opts || DefaultClientOptions;
 
     this.key = opts.key ? opts.key : uuid();
-    this.userId = opts.userId ? opts.userId : uuid();
     this.metadata = opts.metadata || {};
     this.status = ClientStatus.Deactivated;
     this.attachmentMap = new Map();
@@ -285,7 +277,6 @@ export class Client {
         .activateClient(
           {
             clientKey: this.key,
-            userId: this.userId,
             metadata: this.metadata,
           },
           { headers: { 'x-shard-key': this.apiKey } },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Add `metadata` and `user_id` in client info for MAU measurement. 
- `metadata`: Additional data from users. Stored in yorkie analytic storage
- `user_id`: Identifier of client's user. MAU is measured by the number of users.
```js
const client = new yorkie.Client(import.meta.env.VITE_YORKIE_API_ADDR, {
    apiKey: import.meta.env.VITE_YORKIE_API_KEY,
    metadata: { userID: 'dummy_user_id' },
  });
```



#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->

Address https://github.com/yorkie-team/yorkie/pull/1130

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Client activation now supports including custom metadata, allowing additional details to be sent during the activation process.
	- Enhanced the activation process without affecting existing functionalities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->