### PR TITLE
Refactor import paths to use '@yorkie-js/sdk'

### DIFF
--- a/examples/nextjs-scheduler/tsconfig.json
+++ b/examples/nextjs-scheduler/tsconfig.json
@@ -22,7 +22,7 @@
     "paths": {
       "@/*": ["./*"],
       "react": ["./node_modules/@types/react"],
-      "@yorkie-js-sdk/src/*": ["../../packages/sdk/src/*"]
+      "@yorkie-js/sdk/src/*": ["../../packages/sdk/src/*"]
     }
   },
   "include": [

--- a/examples/profile-stack/vite.config.js
+++ b/examples/profile-stack/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: '@yorkie-js-sdk/src',
+        find: '@yorkie-js/sdk/src',
         replacement: path.resolve(__dirname, '../../packages/sdk/src'),
       },
     ],

--- a/examples/react-tldraw/src/tldraw.d.ts
+++ b/examples/react-tldraw/src/tldraw.d.ts
@@ -1,4 +1,4 @@
-import { Indexable, Json } from '@yorkie-js-sdk/src/document/document';
+import { Indexable, Json } from '@yorkie-js/sdk/src/document/document';
 import { TDUser } from '@tldraw/tldraw';
 
 declare module '@tldraw/tldraw' {

--- a/examples/react-tldraw/tsconfig.json
+++ b/examples/react-tldraw/tsconfig.json
@@ -16,7 +16,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "paths": {
-      "@yorkie-js-sdk/src/*": ["../../packages/sdk/src/*"]
+      "@yorkie-js/sdk/src/*": ["../../packages/sdk/src/*"]
     }
   },
   "include": ["src"],

--- a/examples/react-tldraw/vite.config.ts
+++ b/examples/react-tldraw/vite.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: '@yorkie-js-sdk/src',
+        find: '@yorkie-js/sdk/src',
         replacement: path.resolve(__dirname, '../../packages/sdk/src'),
       },
     ],

--- a/examples/react-todomvc/tsconfig.json
+++ b/examples/react-todomvc/tsconfig.json
@@ -16,7 +16,7 @@
     "noEmit": true,
     "jsx": "react-jsx",
     "paths": {
-      "@yorkie-js-sdk/src/*": ["../../packages/sdk/src/*"]
+      "@yorkie-js/sdk/src/*": ["../../packages/sdk/src/*"]
     }
   },
   "include": ["src"],

--- a/examples/react-todomvc/vite.config.ts
+++ b/examples/react-todomvc/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
         replacement: path.resolve(__dirname, '../../packages/react/src'),
       },
       {
-        find: '@yorkie-js-sdk/src',
+        find: '@yorkie-js/sdk/src',
         replacement: path.resolve(__dirname, '../../packages/sdk/src'),
       },
     ],

--- a/examples/simultaneous-cursors/vite.config.js
+++ b/examples/simultaneous-cursors/vite.config.js
@@ -9,7 +9,7 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: '@yorkie-js-sdk/src',
+        find: '@yorkie-js/sdk/src',
         replacement: path.resolve(__dirname, '../../packages/sdk/src'),
       },
     ],

--- a/examples/vanilla-codemirror6/tsconfig.json
+++ b/examples/vanilla-codemirror6/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmit": true,
     "skipLibCheck": true,
     "paths": {
-      "@yorkie-js-sdk/src/*": ["../../packages/sdk/src/*"]
+      "@yorkie-js/sdk/src/*": ["../../packages/sdk/src/*"]
     }
   },
   "include": ["src"]

--- a/examples/vanilla-codemirror6/vite.config.js
+++ b/examples/vanilla-codemirror6/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: '@yorkie-js-sdk/src',
+        find: '@yorkie-js/sdk/src',
         replacement: path.resolve(__dirname, '../../packages/sdk/src'),
       },
     ],

--- a/examples/vanilla-quill/tsconfig.json
+++ b/examples/vanilla-quill/tsconfig.json
@@ -13,7 +13,7 @@
     "noEmit": true,
     "skipLibCheck": true,
     "paths": {
-      "@yorkie-js-sdk/src/*": ["../../packages/sdk/src/*"]
+      "@yorkie-js/sdk/src/*": ["../../packages/sdk/src/*"]
     }
   },
   "include": ["src"]

--- a/examples/vanilla-quill/vite.config.js
+++ b/examples/vanilla-quill/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: '@yorkie-js-sdk/src',
+        find: '@yorkie-js/sdk/src',
         replacement: path.resolve(__dirname, '../../packages/sdk/src'),
       },
     ],

--- a/examples/vuejs-kanban/vite.config.js
+++ b/examples/vuejs-kanban/vite.config.js
@@ -11,7 +11,7 @@ export default defineConfig({
   resolve: {
     alias: [
       {
-        find: '@yorkie-js-sdk/src',
+        find: '@yorkie-js/sdk/src',
         replacement: path.resolve(__dirname, '../../packages/sdk/src'),
       },
       {

--- a/packages/devtools/src/devtools/contexts/SelectedNode.tsx
+++ b/packages/devtools/src/devtools/contexts/SelectedNode.tsx
@@ -17,7 +17,7 @@
 import type { ReactNode, Dispatch, SetStateAction } from 'react';
 import { createContext, useContext, useState } from 'react';
 import type { RootTreeNode } from '../components/Tree';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 type SelectedNodeContext = [
   RootTreeNode,

--- a/packages/devtools/src/devtools/contexts/SelectedPresence.tsx
+++ b/packages/devtools/src/devtools/contexts/SelectedPresence.tsx
@@ -17,7 +17,7 @@
 import type { ReactNode, Dispatch, SetStateAction } from 'react';
 import { createContext, useContext, useState } from 'react';
 import type { PresenceJsonNode } from '../components/Tree';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 type SelectedPresenceContext = [
   PresenceJsonNode,

--- a/packages/devtools/src/devtools/contexts/YorkieSource.tsx
+++ b/packages/devtools/src/devtools/contexts/YorkieSource.tsx
@@ -26,7 +26,7 @@ import {
 
 import { DocEventType, Devtools, type SDKToPanelMessage } from '@yorkie-js/sdk';
 import { connectPort, sendToSDK } from '../../port';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 const DocKeyContext = createContext<string>(null);
 const YorkieDocContext = createContext(null);

--- a/packages/devtools/tsconfig.json
+++ b/packages/devtools/tsconfig.json
@@ -5,7 +5,7 @@
   "compilerOptions": {
     "paths": {
       "~*": ["./*"],
-      "@yorkie-js-sdk/src/*": ["../sdk/src/*"]
+      "@yorkie-js/sdk/src/*": ["../sdk/src/*"]
     },
     "baseUrl": ".",
     "typeRoots": ["./node_modules/@types"]

--- a/packages/react/tsconfig.json
+++ b/packages/react/tsconfig.json
@@ -20,7 +20,7 @@
     /* Paths */
     "baseUrl": ".",
     "paths": {
-      "@yorkie-js-sdk/src/*": ["../../packages/sdk/src/*"]
+      "@yorkie-js/sdk/src/*": ["../../packages/sdk/src/*"]
     }
   },
   "include": ["src"]

--- a/packages/react/vite.config.js
+++ b/packages/react/vite.config.js
@@ -21,7 +21,7 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      '@yorkie-js-sdk/src': path.resolve(__dirname, '../sdk/src'),
+      '@yorkie-js/sdk/src': path.resolve(__dirname, '../sdk/src'),
     },
   },
   plugins: [

--- a/packages/sdk/src/api/converter.ts
+++ b/packages/sdk/src/api/converter.ts
@@ -16,47 +16,47 @@
 
 import { ConnectError } from '@connectrpc/connect';
 import { ErrorInfo } from '@buf/googleapis_googleapis.bufbuild_es/google/rpc/error_details_pb';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
-import { Indexable } from '@yorkie-js-sdk/src/document/document';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
+import { Indexable } from '@yorkie-js/sdk/src/document/document';
 import {
   PresenceChange,
   PresenceChangeType,
-} from '@yorkie-js-sdk/src/document/presence/presence';
+} from '@yorkie-js/sdk/src/document/presence/presence';
 import {
   InitialTimeTicket,
   TimeTicket,
-} from '@yorkie-js-sdk/src/document/time/ticket';
-import { ActorID } from '@yorkie-js-sdk/src/document/time/actor_id';
-import { Operation } from '@yorkie-js-sdk/src/document/operation/operation';
-import { SetOperation } from '@yorkie-js-sdk/src/document/operation/set_operation';
-import { AddOperation } from '@yorkie-js-sdk/src/document/operation/add_operation';
-import { MoveOperation } from '@yorkie-js-sdk/src/document/operation/move_operation';
-import { RemoveOperation } from '@yorkie-js-sdk/src/document/operation/remove_operation';
-import { EditOperation } from '@yorkie-js-sdk/src/document/operation/edit_operation';
-import { StyleOperation } from '@yorkie-js-sdk/src/document/operation/style_operation';
-import { TreeEditOperation } from '@yorkie-js-sdk/src/document/operation/tree_edit_operation';
-import { ChangeID } from '@yorkie-js-sdk/src/document/change/change_id';
-import { Change } from '@yorkie-js-sdk/src/document/change/change';
-import { ChangePack } from '@yorkie-js-sdk/src/document/change/change_pack';
-import { Checkpoint } from '@yorkie-js-sdk/src/document/change/checkpoint';
-import { ElementRHT } from '@yorkie-js-sdk/src/document/crdt/element_rht';
-import { RGATreeList } from '@yorkie-js-sdk/src/document/crdt/rga_tree_list';
-import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
-import { CRDTObject } from '@yorkie-js-sdk/src/document/crdt/object';
-import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';
-import { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
+} from '@yorkie-js/sdk/src/document/time/ticket';
+import { ActorID } from '@yorkie-js/sdk/src/document/time/actor_id';
+import { Operation } from '@yorkie-js/sdk/src/document/operation/operation';
+import { SetOperation } from '@yorkie-js/sdk/src/document/operation/set_operation';
+import { AddOperation } from '@yorkie-js/sdk/src/document/operation/add_operation';
+import { MoveOperation } from '@yorkie-js/sdk/src/document/operation/move_operation';
+import { RemoveOperation } from '@yorkie-js/sdk/src/document/operation/remove_operation';
+import { EditOperation } from '@yorkie-js/sdk/src/document/operation/edit_operation';
+import { StyleOperation } from '@yorkie-js/sdk/src/document/operation/style_operation';
+import { TreeEditOperation } from '@yorkie-js/sdk/src/document/operation/tree_edit_operation';
+import { ChangeID } from '@yorkie-js/sdk/src/document/change/change_id';
+import { Change } from '@yorkie-js/sdk/src/document/change/change';
+import { ChangePack } from '@yorkie-js/sdk/src/document/change/change_pack';
+import { Checkpoint } from '@yorkie-js/sdk/src/document/change/checkpoint';
+import { ElementRHT } from '@yorkie-js/sdk/src/document/crdt/element_rht';
+import { RGATreeList } from '@yorkie-js/sdk/src/document/crdt/rga_tree_list';
+import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
+import { CRDTObject } from '@yorkie-js/sdk/src/document/crdt/object';
+import { CRDTArray } from '@yorkie-js/sdk/src/document/crdt/array';
+import { VersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
 import { CRDTTreePos } from './../document/crdt/tree';
 import {
   RGATreeSplit,
   RGATreeSplitNode,
   RGATreeSplitNodeID,
   RGATreeSplitPos,
-} from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';
-import { CRDTText, CRDTTextValue } from '@yorkie-js-sdk/src/document/crdt/text';
+} from '@yorkie-js/sdk/src/document/crdt/rga_tree_split';
+import { CRDTText, CRDTTextValue } from '@yorkie-js/sdk/src/document/crdt/text';
 import {
   Primitive,
   PrimitiveType,
-} from '@yorkie-js-sdk/src/document/crdt/primitive';
+} from '@yorkie-js/sdk/src/document/crdt/primitive';
 import {
   Change as PbChange,
   ChangeID as PbChangeID,
@@ -97,17 +97,17 @@ import {
   Operation_Increase as PbOperation_Increase,
   Operation_TreeEdit as PbOperation_TreeEdit,
   Operation_TreeStyle as PbOperation_TreeStyle,
-} from '@yorkie-js-sdk/src/api/yorkie/v1/resources_pb';
-import { IncreaseOperation } from '@yorkie-js-sdk/src/document/operation/increase_operation';
+} from '@yorkie-js/sdk/src/api/yorkie/v1/resources_pb';
+import { IncreaseOperation } from '@yorkie-js/sdk/src/document/operation/increase_operation';
 import {
   CounterType,
   CRDTCounter,
-} from '@yorkie-js-sdk/src/document/crdt/counter';
+} from '@yorkie-js/sdk/src/document/crdt/counter';
 import {
   CRDTTree,
   CRDTTreeNode,
   CRDTTreeNodeID,
-} from '@yorkie-js-sdk/src/document/crdt/tree';
+} from '@yorkie-js/sdk/src/document/crdt/tree';
 import { traverseAll } from '../util/index_tree';
 import { TreeStyleOperation } from '../document/operation/tree_style_operation';
 import { RHT } from '../document/crdt/rht';

--- a/packages/sdk/src/client/attachment.ts
+++ b/packages/sdk/src/client/attachment.ts
@@ -1,5 +1,5 @@
-import { Document, Indexable } from '@yorkie-js-sdk/src/document/document';
-import { SyncMode } from '@yorkie-js-sdk/src/client/client';
+import { Document, Indexable } from '@yorkie-js/sdk/src/document/document';
+import { SyncMode } from '@yorkie-js/sdk/src/client/client';
 import { Unsubscribe } from '../yorkie';
 
 /**

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ActorID } from '@yorkie-js-sdk/src/document/time/actor_id';
+import { ActorID } from '@yorkie-js/sdk/src/document/time/actor_id';
 import {
   createPromiseClient,
   PromiseClient,
@@ -22,18 +22,18 @@ import {
   Code as ConnectErrorCode,
 } from '@connectrpc/connect';
 import { createGrpcWebTransport } from '@connectrpc/connect-web';
-import { YorkieService } from '@yorkie-js-sdk/src/api/yorkie/v1/yorkie_connect';
-import { WatchDocumentResponse } from '@yorkie-js-sdk/src/api/yorkie/v1/yorkie_pb';
-import { DocEventType as PbDocEventType } from '@yorkie-js-sdk/src/api/yorkie/v1/resources_pb';
+import { YorkieService } from '@yorkie-js/sdk/src/api/yorkie/v1/yorkie_connect';
+import { WatchDocumentResponse } from '@yorkie-js/sdk/src/api/yorkie/v1/yorkie_pb';
+import { DocEventType as PbDocEventType } from '@yorkie-js/sdk/src/api/yorkie/v1/resources_pb';
 import {
   converter,
   errorCodeOf,
   errorMetadataOf,
-} from '@yorkie-js-sdk/src/api/converter';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
-import { logger } from '@yorkie-js-sdk/src/util/logger';
-import { uuid } from '@yorkie-js-sdk/src/util/uuid';
-import { Attachment, WatchStream } from '@yorkie-js-sdk/src/client/attachment';
+} from '@yorkie-js/sdk/src/api/converter';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
+import { logger } from '@yorkie-js/sdk/src/util/logger';
+import { uuid } from '@yorkie-js/sdk/src/util/uuid';
+import { Attachment, WatchStream } from '@yorkie-js/sdk/src/client/attachment';
 import {
   Document,
   DocKey,
@@ -42,12 +42,12 @@ import {
   DocEventType,
   StreamConnectionStatus,
   DocSyncStatus,
-} from '@yorkie-js-sdk/src/document/document';
-import { OpSource } from '@yorkie-js-sdk/src/document/operation/operation';
-import { createAuthInterceptor } from '@yorkie-js-sdk/src/client/auth_interceptor';
-import { createMetricInterceptor } from '@yorkie-js-sdk/src/client/metric_interceptor';
+} from '@yorkie-js/sdk/src/document/document';
+import { OpSource } from '@yorkie-js/sdk/src/document/operation/operation';
+import { createAuthInterceptor } from '@yorkie-js/sdk/src/client/auth_interceptor';
+import { createMetricInterceptor } from '@yorkie-js/sdk/src/client/metric_interceptor';
 import { validateSerializable } from '../util/validator';
-import { Json, BroadcastOptions } from '@yorkie-js-sdk/src/document/document';
+import { Json, BroadcastOptions } from '@yorkie-js/sdk/src/document/document';
 
 /**
  * `SyncMode` defines synchronization modes for the PushPullChanges API.

--- a/packages/sdk/src/devtools/index.ts
+++ b/packages/sdk/src/devtools/index.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { Document, Indexable } from '@yorkie-js-sdk/src/yorkie';
-import { logger } from '@yorkie-js-sdk/src/util/logger';
+import { Document, Indexable } from '@yorkie-js/sdk/src/yorkie';
+import { logger } from '@yorkie-js/sdk/src/util/logger';
 import type * as DevTools from './protocol';
 import { EventSourceDevPanel, EventSourceSDK } from './protocol';
 import { DocEventsForReplay, isDocEventsForReplay } from './types';

--- a/packages/sdk/src/devtools/types.ts
+++ b/packages/sdk/src/devtools/types.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import type { PrimitiveValue } from '@yorkie-js-sdk/src/document/crdt/primitive';
-import type { CRDTTreePosStruct } from '@yorkie-js-sdk/src/document/crdt/tree';
-import { CounterValue } from '@yorkie-js-sdk/src/document/crdt/counter';
+import type { PrimitiveValue } from '@yorkie-js/sdk/src/document/crdt/primitive';
+import type { CRDTTreePosStruct } from '@yorkie-js/sdk/src/document/crdt/tree';
+import { CounterValue } from '@yorkie-js/sdk/src/document/crdt/counter';
 import {
   Json,
   DocEvent,
@@ -30,8 +30,8 @@ import {
   type WatchedEvent,
   type UnwatchedEvent,
   type PresenceChangedEvent,
-} from '@yorkie-js-sdk/src/document/document';
-import type { OperationInfo } from '@yorkie-js-sdk/src/document/operation/operation';
+} from '@yorkie-js/sdk/src/document/document';
+import type { OperationInfo } from '@yorkie-js/sdk/src/document/operation/operation';
 
 /**
  * `Client` represents a client value in devtools.

--- a/packages/sdk/src/document/change/change.ts
+++ b/packages/sdk/src/document/change/change.ts
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-import { ActorID } from '@yorkie-js-sdk/src/document/time/actor_id';
+import { ActorID } from '@yorkie-js/sdk/src/document/time/actor_id';
 import {
   OpSource,
   Operation,
   OperationInfo,
-} from '@yorkie-js-sdk/src/document/operation/operation';
-import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
-import { ChangeID } from '@yorkie-js-sdk/src/document/change/change_id';
-import { Indexable } from '@yorkie-js-sdk/src/document/document';
-import { converter } from '@yorkie-js-sdk/src/api/converter';
-import { HistoryOperation } from '@yorkie-js-sdk/src/document/history';
+} from '@yorkie-js/sdk/src/document/operation/operation';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
+import { ChangeID } from '@yorkie-js/sdk/src/document/change/change_id';
+import { Indexable } from '@yorkie-js/sdk/src/document/document';
+import { converter } from '@yorkie-js/sdk/src/api/converter';
+import { HistoryOperation } from '@yorkie-js/sdk/src/document/history';
 import {
   PresenceChange,
   PresenceChangeType,
-} from '@yorkie-js-sdk/src/document/presence/presence';
-import { deepcopy } from '@yorkie-js-sdk/src/util/object';
+} from '@yorkie-js/sdk/src/document/presence/presence';
+import { deepcopy } from '@yorkie-js/sdk/src/util/object';
 
 /**
  * `ChangeStruct` represents the structure of Change.

--- a/packages/sdk/src/document/change/change_id.ts
+++ b/packages/sdk/src/document/change/change_id.ts
@@ -17,8 +17,8 @@
 import {
   ActorID,
   InitialActorID,
-} from '@yorkie-js-sdk/src/document/time/actor_id';
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
+} from '@yorkie-js/sdk/src/document/time/actor_id';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
 import { InitialVersionVector, VersionVector } from '../time/version_vector';
 
 /**

--- a/packages/sdk/src/document/change/change_pack.ts
+++ b/packages/sdk/src/document/change/change_pack.ts
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-import { Indexable } from '@yorkie-js-sdk/src/document/document';
-import { Checkpoint } from '@yorkie-js-sdk/src/document/change/checkpoint';
-import { Change } from '@yorkie-js-sdk/src/document/change/change';
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
+import { Indexable } from '@yorkie-js/sdk/src/document/document';
+import { Checkpoint } from '@yorkie-js/sdk/src/document/change/checkpoint';
+import { Change } from '@yorkie-js/sdk/src/document/change/change';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
 import { VersionVector } from '../time/version_vector';
 
 /**

--- a/packages/sdk/src/document/change/context.ts
+++ b/packages/sdk/src/document/change/context.ts
@@ -17,19 +17,19 @@
 import {
   TimeTicket,
   InitialDelimiter,
-} from '@yorkie-js-sdk/src/document/time/ticket';
-import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
+} from '@yorkie-js/sdk/src/document/time/ticket';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
 import {
   CRDTContainer,
   CRDTElement,
-} from '@yorkie-js-sdk/src/document/crdt/element';
-import { Operation } from '@yorkie-js-sdk/src/document/operation/operation';
-import { ChangeID } from '@yorkie-js-sdk/src/document/change/change_id';
-import { Change } from '@yorkie-js-sdk/src/document/change/change';
-import { PresenceChange } from '@yorkie-js-sdk/src/document/presence/presence';
-import { Indexable } from '@yorkie-js-sdk/src/document/document';
-import { deepcopy } from '@yorkie-js-sdk/src/util/object';
-import { GCPair } from '@yorkie-js-sdk/src/document/crdt/gc';
+} from '@yorkie-js/sdk/src/document/crdt/element';
+import { Operation } from '@yorkie-js/sdk/src/document/operation/operation';
+import { ChangeID } from '@yorkie-js/sdk/src/document/change/change_id';
+import { Change } from '@yorkie-js/sdk/src/document/change/change';
+import { PresenceChange } from '@yorkie-js/sdk/src/document/presence/presence';
+import { Indexable } from '@yorkie-js/sdk/src/document/document';
+import { deepcopy } from '@yorkie-js/sdk/src/util/object';
+import { GCPair } from '@yorkie-js/sdk/src/document/crdt/gc';
 
 /**
  * `ChangeContext` is used to record the context of modification when editing

--- a/packages/sdk/src/document/crdt/array.ts
+++ b/packages/sdk/src/document/crdt/array.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
 import {
   CRDTContainer,
   CRDTElement,
-} from '@yorkie-js-sdk/src/document/crdt/element';
-import { RGATreeList } from '@yorkie-js-sdk/src/document/crdt/rga_tree_list';
-import * as Devtools from '@yorkie-js-sdk/src/devtools/types';
+} from '@yorkie-js/sdk/src/document/crdt/element';
+import { RGATreeList } from '@yorkie-js/sdk/src/document/crdt/rga_tree_list';
+import * as Devtools from '@yorkie-js/sdk/src/devtools/types';
 
 /**
  * `CRDTArray` represents an array data type containing `CRDTElement`s.

--- a/packages/sdk/src/document/crdt/counter.ts
+++ b/packages/sdk/src/document/crdt/counter.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
+import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
 import Long from 'long';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 import {
   Primitive,
   PrimitiveType,
-} from '@yorkie-js-sdk/src/document/crdt/primitive';
-import { removeDecimal } from '@yorkie-js-sdk/src/util/number';
-import type * as Devtools from '@yorkie-js-sdk/src/devtools/types';
+} from '@yorkie-js/sdk/src/document/crdt/primitive';
+import { removeDecimal } from '@yorkie-js/sdk/src/util/number';
+import type * as Devtools from '@yorkie-js/sdk/src/devtools/types';
 
 export enum CounterType {
   IntegerCnt,

--- a/packages/sdk/src/document/crdt/element.ts
+++ b/packages/sdk/src/document/crdt/element.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import type * as Devtools from '@yorkie-js-sdk/src/devtools/types';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import type * as Devtools from '@yorkie-js/sdk/src/devtools/types';
 
 /**
  * `CRDTElement` represents an element that has `TimeTicket`s.

--- a/packages/sdk/src/document/crdt/element_rht.ts
+++ b/packages/sdk/src/document/crdt/element_rht.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
-import { YorkieError, Code } from '@yorkie-js-sdk/src/util/error';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
+import { YorkieError, Code } from '@yorkie-js/sdk/src/util/error';
 
 /**
  * `ElementRHTNode` is a node of ElementRHT.

--- a/packages/sdk/src/document/crdt/gc.ts
+++ b/packages/sdk/src/document/crdt/gc.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
 
 /**
  * `GCPair` is a structure that represents a pair of parent and child for garbage

--- a/packages/sdk/src/document/crdt/object.ts
+++ b/packages/sdk/src/document/crdt/object.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { escapeString } from '@yorkie-js-sdk/src/document/json/strings';
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
+import { escapeString } from '@yorkie-js/sdk/src/document/json/strings';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
 import {
   CRDTContainer,
   CRDTElement,
-} from '@yorkie-js-sdk/src/document/crdt/element';
-import { ElementRHT } from '@yorkie-js-sdk/src/document/crdt/element_rht';
-import type * as Devtools from '@yorkie-js-sdk/src/devtools/types';
+} from '@yorkie-js/sdk/src/document/crdt/element';
+import { ElementRHT } from '@yorkie-js/sdk/src/document/crdt/element_rht';
+import type * as Devtools from '@yorkie-js/sdk/src/devtools/types';
 
 /**
  * `CRDTObject` represents an object data type, but unlike regular JSON,

--- a/packages/sdk/src/document/crdt/primitive.ts
+++ b/packages/sdk/src/document/crdt/primitive.ts
@@ -15,11 +15,11 @@
  */
 
 import Long from 'long';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
-import { escapeString } from '@yorkie-js-sdk/src/document/json/strings';
-import type * as Devtools from '@yorkie-js-sdk/src/devtools/types';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
+import { escapeString } from '@yorkie-js/sdk/src/document/json/strings';
+import type * as Devtools from '@yorkie-js/sdk/src/devtools/types';
 
 export enum PrimitiveType {
   Null,

--- a/packages/sdk/src/document/crdt/rga_tree_list.ts
+++ b/packages/sdk/src/document/crdt/rga_tree_list.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { SplayNode, SplayTree } from '@yorkie-js-sdk/src/util/splay_tree';
+import { SplayNode, SplayTree } from '@yorkie-js/sdk/src/util/splay_tree';
 import {
   InitialTimeTicket,
   TimeTicket,
-} from '@yorkie-js-sdk/src/document/time/ticket';
-import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
-import { Primitive } from '@yorkie-js-sdk/src/document/crdt/primitive';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+} from '@yorkie-js/sdk/src/document/time/ticket';
+import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
+import { Primitive } from '@yorkie-js/sdk/src/document/crdt/primitive';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
  * `RGATreeListNode` is a node of RGATreeList.

--- a/packages/sdk/src/document/crdt/rga_tree_split.ts
+++ b/packages/sdk/src/document/crdt/rga_tree_split.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import { ActorID } from '@yorkie-js-sdk/src/document/time/actor_id';
-import { Comparator } from '@yorkie-js-sdk/src/util/comparator';
-import { SplayNode, SplayTree } from '@yorkie-js-sdk/src/util/splay_tree';
-import { LLRBTree } from '@yorkie-js-sdk/src/util/llrb_tree';
+import { ActorID } from '@yorkie-js/sdk/src/document/time/actor_id';
+import { Comparator } from '@yorkie-js/sdk/src/util/comparator';
+import { SplayNode, SplayTree } from '@yorkie-js/sdk/src/util/splay_tree';
+import { LLRBTree } from '@yorkie-js/sdk/src/util/llrb_tree';
 import {
   InitialTimeTicket,
   MaxLamport,
   TimeTicket,
   TimeTicketStruct,
-} from '@yorkie-js-sdk/src/document/time/ticket';
-import { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
-import { GCChild, GCPair, GCParent } from '@yorkie-js-sdk/src/document/crdt/gc';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+} from '@yorkie-js/sdk/src/document/time/ticket';
+import { VersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
+import { GCChild, GCPair, GCParent } from '@yorkie-js/sdk/src/document/crdt/gc';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 export interface ValueChange<T> {
   actor: ActorID;

--- a/packages/sdk/src/document/crdt/rht.ts
+++ b/packages/sdk/src/document/crdt/rht.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { escapeString } from '@yorkie-js-sdk/src/document/json/strings';
-import { GCChild } from '@yorkie-js-sdk/src/document/crdt/gc';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { escapeString } from '@yorkie-js/sdk/src/document/json/strings';
+import { GCChild } from '@yorkie-js/sdk/src/document/crdt/gc';
 
 /**
  * `RHTNode` is a node of RHT(Replicated Hashtable).

--- a/packages/sdk/src/document/crdt/root.ts
+++ b/packages/sdk/src/document/crdt/root.ts
@@ -17,16 +17,16 @@
 import {
   InitialTimeTicket,
   TimeTicket,
-} from '@yorkie-js-sdk/src/document/time/ticket';
+} from '@yorkie-js/sdk/src/document/time/ticket';
 import {
   CRDTContainer,
   CRDTElement,
-} from '@yorkie-js-sdk/src/document/crdt/element';
-import { CRDTObject } from '@yorkie-js-sdk/src/document/crdt/object';
-import { GCPair } from '@yorkie-js-sdk/src/document/crdt/gc';
-import { CRDTText } from '@yorkie-js-sdk/src/document/crdt/text';
-import { CRDTTree } from '@yorkie-js-sdk/src/document/crdt/tree';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+} from '@yorkie-js/sdk/src/document/crdt/element';
+import { CRDTObject } from '@yorkie-js/sdk/src/document/crdt/object';
+import { GCPair } from '@yorkie-js/sdk/src/document/crdt/gc';
+import { CRDTText } from '@yorkie-js/sdk/src/document/crdt/text';
+import { CRDTTree } from '@yorkie-js/sdk/src/document/crdt/tree';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 import { VersionVector } from '../time/version_vector';
 
 /**

--- a/packages/sdk/src/document/crdt/text.ts
+++ b/packages/sdk/src/document/crdt/text.ts
@@ -18,24 +18,24 @@ import {
   MaxLamport,
   InitialTimeTicket,
   TimeTicket,
-} from '@yorkie-js-sdk/src/document/time/ticket';
-import { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
-import { Indexable } from '@yorkie-js-sdk/src/document/document';
-import { RHT, RHTNode } from '@yorkie-js-sdk/src/document/crdt/rht';
-import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
+} from '@yorkie-js/sdk/src/document/time/ticket';
+import { VersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
+import { Indexable } from '@yorkie-js/sdk/src/document/document';
+import { RHT, RHTNode } from '@yorkie-js/sdk/src/document/crdt/rht';
+import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
 import {
   RGATreeSplit,
   RGATreeSplitNode,
   RGATreeSplitNodeID,
   RGATreeSplitPosRange,
   ValueChange,
-} from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';
-import { escapeString } from '@yorkie-js-sdk/src/document/json/strings';
-import { parseObjectValues } from '@yorkie-js-sdk/src/util/object';
-import type * as Devtools from '@yorkie-js-sdk/src/devtools/types';
-import { GCChild, GCPair } from '@yorkie-js-sdk/src/document/crdt/gc';
-import { SplayTree } from '@yorkie-js-sdk/src/util/splay_tree';
-import { LLRBTree } from '@yorkie-js-sdk/src/util/llrb_tree';
+} from '@yorkie-js/sdk/src/document/crdt/rga_tree_split';
+import { escapeString } from '@yorkie-js/sdk/src/document/json/strings';
+import { parseObjectValues } from '@yorkie-js/sdk/src/util/object';
+import type * as Devtools from '@yorkie-js/sdk/src/devtools/types';
+import { GCChild, GCPair } from '@yorkie-js/sdk/src/document/crdt/gc';
+import { SplayTree } from '@yorkie-js/sdk/src/util/splay_tree';
+import { LLRBTree } from '@yorkie-js/sdk/src/util/llrb_tree';
 
 /**
  * `TextChangeType` is the type of TextChange.

--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -19,9 +19,9 @@ import {
   InitialTimeTicket,
   TimeTicketStruct,
   MaxLamport,
-} from '@yorkie-js-sdk/src/document/time/ticket';
-import { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
-import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
+} from '@yorkie-js/sdk/src/document/time/ticket';
+import { VersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
+import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
 
 import {
   IndexTree,
@@ -29,22 +29,22 @@ import {
   IndexTreeNode,
   traverseAll,
   TokenType,
-} from '@yorkie-js-sdk/src/util/index_tree';
+} from '@yorkie-js/sdk/src/util/index_tree';
 import { RHT, RHTNode } from './rht';
 import { ActorID } from './../time/actor_id';
-import { LLRBTree } from '@yorkie-js-sdk/src/util/llrb_tree';
-import { Comparator } from '@yorkie-js-sdk/src/util/comparator';
-import { parseObjectValues } from '@yorkie-js-sdk/src/util/object';
+import { LLRBTree } from '@yorkie-js/sdk/src/util/llrb_tree';
+import { Comparator } from '@yorkie-js/sdk/src/util/comparator';
+import { parseObjectValues } from '@yorkie-js/sdk/src/util/object';
 import type {
   DefaultTextType,
   TreeNodeType,
   TreeToken,
-} from '@yorkie-js-sdk/src/util/index_tree';
-import { Indexable } from '@yorkie-js-sdk/src/document/document';
-import type * as Devtools from '@yorkie-js-sdk/src/devtools/types';
-import { escapeString } from '@yorkie-js-sdk/src/document/json/strings';
-import { GCChild, GCPair, GCParent } from '@yorkie-js-sdk/src/document/crdt/gc';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+} from '@yorkie-js/sdk/src/util/index_tree';
+import { Indexable } from '@yorkie-js/sdk/src/document/document';
+import type * as Devtools from '@yorkie-js/sdk/src/devtools/types';
+import { escapeString } from '@yorkie-js/sdk/src/document/json/strings';
+import { GCChild, GCPair, GCParent } from '@yorkie-js/sdk/src/document/crdt/gc';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
  * `TreeNode` represents a node in the tree.
@@ -1426,8 +1426,8 @@ export class CRDTTree extends CRDTElement implements GCParent {
       const treePos = node.isText
         ? { node, offset: 0 }
         : parentNode && leftChildNode
-          ? this.toTreePos(parentNode, leftChildNode)
-          : null;
+        ? this.toTreePos(parentNode, leftChildNode)
+        : null;
 
       if (treePos) {
         index = this.indexTree.indexOf(treePos);

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -13,11 +13,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-import type { WatchDocumentResponse } from '@yorkie-js-sdk/src/api/yorkie/v1/yorkie_pb';
-import { DocEventType as PbDocEventType } from '@yorkie-js-sdk/src/api/yorkie/v1/resources_pb';
-import { logger, LogLevel } from '@yorkie-js-sdk/src/util/logger';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
-import { deepcopy } from '@yorkie-js-sdk/src/util/object';
+import type { WatchDocumentResponse } from '@yorkie-js/sdk/src/api/yorkie/v1/yorkie_pb';
+import { DocEventType as PbDocEventType } from '@yorkie-js/sdk/src/api/yorkie/v1/resources_pb';
+import { logger, LogLevel } from '@yorkie-js/sdk/src/util/logger';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
+import { deepcopy } from '@yorkie-js/sdk/src/util/object';
 import {
   Observer,
   Observable,
@@ -26,35 +26,35 @@ import {
   ErrorFn,
   CompleteFn,
   NextFn,
-} from '@yorkie-js-sdk/src/util/observable';
+} from '@yorkie-js/sdk/src/util/observable';
 import {
   ActorID,
   InitialActorID,
-} from '@yorkie-js-sdk/src/document/time/actor_id';
+} from '@yorkie-js/sdk/src/document/time/actor_id';
 import {
   Change,
   ChangeStruct,
-} from '@yorkie-js-sdk/src/document/change/change';
+} from '@yorkie-js/sdk/src/document/change/change';
 import {
   ChangeID,
   InitialChangeID,
-} from '@yorkie-js-sdk/src/document/change/change_id';
-import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
-import { converter } from '@yorkie-js-sdk/src/api/converter';
-import { ChangePack } from '@yorkie-js-sdk/src/document/change/change_pack';
-import { CRDTRoot, RootStats } from '@yorkie-js-sdk/src/document/crdt/root';
-import { CRDTObject } from '@yorkie-js-sdk/src/document/crdt/object';
+} from '@yorkie-js/sdk/src/document/change/change_id';
+import { ChangeContext } from '@yorkie-js/sdk/src/document/change/context';
+import { converter } from '@yorkie-js/sdk/src/api/converter';
+import { ChangePack } from '@yorkie-js/sdk/src/document/change/change_pack';
+import { CRDTRoot, RootStats } from '@yorkie-js/sdk/src/document/crdt/root';
+import { CRDTObject } from '@yorkie-js/sdk/src/document/crdt/object';
 import {
   createJSON,
   JSONElement,
   LeafElement,
   BaseArray,
   BaseObject,
-} from '@yorkie-js-sdk/src/document/json/element';
+} from '@yorkie-js/sdk/src/document/json/element';
 import {
   Checkpoint,
   InitialCheckpoint,
-} from '@yorkie-js-sdk/src/document/change/checkpoint';
+} from '@yorkie-js/sdk/src/document/change/checkpoint';
 import {
   OpSource,
   OperationInfo,
@@ -64,18 +64,18 @@ import {
   ArrayOperationInfo,
   TreeOperationInfo,
   Operation,
-} from '@yorkie-js-sdk/src/document/operation/operation';
-import { JSONObject } from '@yorkie-js-sdk/src/document/json/object';
-import { Counter } from '@yorkie-js-sdk/src/document/json/counter';
-import { Text } from '@yorkie-js-sdk/src/document/json/text';
-import { Tree } from '@yorkie-js-sdk/src/document/json/tree';
+} from '@yorkie-js/sdk/src/document/operation/operation';
+import { JSONObject } from '@yorkie-js/sdk/src/document/json/object';
+import { Counter } from '@yorkie-js/sdk/src/document/json/counter';
+import { Text } from '@yorkie-js/sdk/src/document/json/text';
+import { Tree } from '@yorkie-js/sdk/src/document/json/tree';
 import {
   Presence,
   PresenceChangeType,
-} from '@yorkie-js-sdk/src/document/presence/presence';
-import { History, HistoryOperation } from '@yorkie-js-sdk/src/document/history';
-import { setupDevtools } from '@yorkie-js-sdk/src/devtools';
-import * as Devtools from '@yorkie-js-sdk/src/devtools/types';
+} from '@yorkie-js/sdk/src/document/presence/presence';
+import { History, HistoryOperation } from '@yorkie-js/sdk/src/document/history';
+import { setupDevtools } from '@yorkie-js/sdk/src/devtools';
+import * as Devtools from '@yorkie-js/sdk/src/devtools/types';
 import { VersionVector } from './time/version_vector';
 
 /**
@@ -483,14 +483,14 @@ export type DocKey = string;
 type OperationInfoOfElement<TElement> = TElement extends Text
   ? TextOperationInfo
   : TElement extends Counter
-    ? CounterOperationInfo
-    : TElement extends Tree
-      ? TreeOperationInfo
-      : TElement extends BaseArray<any>
-        ? ArrayOperationInfo
-        : TElement extends BaseObject<any>
-          ? ObjectOperationInfo
-          : OperationInfo;
+  ? CounterOperationInfo
+  : TElement extends Tree
+  ? TreeOperationInfo
+  : TElement extends BaseArray<any>
+  ? ArrayOperationInfo
+  : TElement extends BaseObject<any>
+  ? ObjectOperationInfo
+  : OperationInfo;
 
 /**
  * `OperationInfoOfInternal` represents the type of the operation info of the
@@ -511,24 +511,24 @@ type OperationInfoOfInternal<
 > = TDepth extends 0
   ? TElement
   : TKeyOrPath extends `${infer TFirst}.${infer TRest}`
-    ? TFirst extends keyof TElement
-      ? TElement[TFirst] extends BaseArray<unknown>
-        ? OperationInfoOfInternal<
-            TElement[TFirst],
-            number,
-            DecreasedDepthOf<TDepth>
-          >
-        : OperationInfoOfInternal<
-            TElement[TFirst],
-            TRest,
-            DecreasedDepthOf<TDepth>
-          >
-      : OperationInfo
-    : TKeyOrPath extends keyof TElement
-      ? TElement[TKeyOrPath] extends BaseArray<unknown>
-        ? ArrayOperationInfo
-        : OperationInfoOfElement<TElement[TKeyOrPath]>
-      : OperationInfo;
+  ? TFirst extends keyof TElement
+    ? TElement[TFirst] extends BaseArray<unknown>
+      ? OperationInfoOfInternal<
+          TElement[TFirst],
+          number,
+          DecreasedDepthOf<TDepth>
+        >
+      : OperationInfoOfInternal<
+          TElement[TFirst],
+          TRest,
+          DecreasedDepthOf<TDepth>
+        >
+    : OperationInfo
+  : TKeyOrPath extends keyof TElement
+  ? TElement[TKeyOrPath] extends BaseArray<unknown>
+    ? ArrayOperationInfo
+    : OperationInfoOfElement<TElement[TKeyOrPath]>
+  : OperationInfo;
 
 /**
  * `DecreasedDepthOf` represents the type of the decreased depth of the given depth.
@@ -536,24 +536,24 @@ type OperationInfoOfInternal<
 type DecreasedDepthOf<Depth extends number = 0> = Depth extends 10
   ? 9
   : Depth extends 9
-    ? 8
-    : Depth extends 8
-      ? 7
-      : Depth extends 7
-        ? 6
-        : Depth extends 6
-          ? 5
-          : Depth extends 5
-            ? 4
-            : Depth extends 4
-              ? 3
-              : Depth extends 3
-                ? 2
-                : Depth extends 2
-                  ? 1
-                  : Depth extends 1
-                    ? 0
-                    : -1;
+  ? 8
+  : Depth extends 8
+  ? 7
+  : Depth extends 7
+  ? 6
+  : Depth extends 6
+  ? 5
+  : Depth extends 5
+  ? 4
+  : Depth extends 4
+  ? 3
+  : Depth extends 3
+  ? 2
+  : Depth extends 2
+  ? 1
+  : Depth extends 1
+  ? 0
+  : -1;
 
 /**
  * `PathOfInternal` represents the type of the path of the given element.
@@ -565,29 +565,29 @@ type PathOfInternal<
 > = Depth extends 0
   ? Prefix
   : TElement extends Record<string, any>
-    ? {
-        [TKey in keyof TElement]: TElement[TKey] extends LeafElement
-          ? `${Prefix}${TKey & string}`
-          : TElement[TKey] extends BaseArray<infer TArrayElement>
-            ?
-                | `${Prefix}${TKey & string}`
-                | `${Prefix}${TKey & string}.${number}`
-                | PathOfInternal<
-                    TArrayElement,
-                    `${Prefix}${TKey & string}.${number}.`,
-                    DecreasedDepthOf<Depth>
-                  >
-            :
-                | `${Prefix}${TKey & string}`
-                | PathOfInternal<
-                    TElement[TKey],
-                    `${Prefix}${TKey & string}.`,
-                    DecreasedDepthOf<Depth>
-                  >;
-      }[keyof TElement]
-    : Prefix extends `${infer TRest}.`
-      ? TRest
-      : Prefix;
+  ? {
+      [TKey in keyof TElement]: TElement[TKey] extends LeafElement
+        ? `${Prefix}${TKey & string}`
+        : TElement[TKey] extends BaseArray<infer TArrayElement>
+        ?
+            | `${Prefix}${TKey & string}`
+            | `${Prefix}${TKey & string}.${number}`
+            | PathOfInternal<
+                TArrayElement,
+                `${Prefix}${TKey & string}.${number}.`,
+                DecreasedDepthOf<Depth>
+              >
+        :
+            | `${Prefix}${TKey & string}`
+            | PathOfInternal<
+                TElement[TKey],
+                `${Prefix}${TKey & string}.`,
+                DecreasedDepthOf<Depth>
+              >;
+    }[keyof TElement]
+  : Prefix extends `${infer TRest}.`
+  ? TRest
+  : Prefix;
 
 /**
  * `OperationInfoOf` represents the type of the operation info of the given

--- a/packages/sdk/src/document/json/array.ts
+++ b/packages/sdk/src/document/json/array.ts
@@ -14,23 +14,23 @@
  * limitations under the License.
  */
 
-import { logger, LogLevel } from '@yorkie-js-sdk/src/util/logger';
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { AddOperation } from '@yorkie-js-sdk/src/document/operation/add_operation';
-import { MoveOperation } from '@yorkie-js-sdk/src/document/operation/move_operation';
-import { RemoveOperation } from '@yorkie-js-sdk/src/document/operation/remove_operation';
-import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
-import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
-import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';
-import { Primitive } from '@yorkie-js-sdk/src/document/crdt/primitive';
+import { logger, LogLevel } from '@yorkie-js/sdk/src/util/logger';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { AddOperation } from '@yorkie-js/sdk/src/document/operation/add_operation';
+import { MoveOperation } from '@yorkie-js/sdk/src/document/operation/move_operation';
+import { RemoveOperation } from '@yorkie-js/sdk/src/document/operation/remove_operation';
+import { ChangeContext } from '@yorkie-js/sdk/src/document/change/context';
+import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
+import { CRDTArray } from '@yorkie-js/sdk/src/document/crdt/array';
+import { Primitive } from '@yorkie-js/sdk/src/document/crdt/primitive';
 import {
   JSONElement,
   WrappedElement,
   toWrappedElement,
   toJSONElement,
   buildCRDTElement,
-} from '@yorkie-js-sdk/src/document/json/element';
-import * as Devtools from '@yorkie-js-sdk/src/devtools/types';
+} from '@yorkie-js/sdk/src/document/json/element';
+import * as Devtools from '@yorkie-js/sdk/src/devtools/types';
 
 /**
  * `JSONArray` represents JSON array, but unlike regular JSON, it has time
@@ -557,8 +557,8 @@ export class ArrayProxy {
       deleteCount === undefined
         ? length
         : deleteCount < 0
-          ? from
-          : Math.min(from + deleteCount, length);
+        ? from
+        : Math.min(from + deleteCount, length);
     const removeds: JSONArray<JSONElement> = [];
     for (let i = from; i < to; i++) {
       const removed = ArrayProxy.deleteInternalByIndex(context, target, from);
@@ -598,8 +598,8 @@ export class ArrayProxy {
       fromIndex === undefined
         ? 0
         : fromIndex < 0
-          ? Math.max(fromIndex + length, 0)
-          : fromIndex;
+        ? Math.max(fromIndex + length, 0)
+        : fromIndex;
 
     if (from >= length) return false;
 
@@ -634,8 +634,8 @@ export class ArrayProxy {
       fromIndex === undefined
         ? 0
         : fromIndex < 0
-          ? Math.max(fromIndex + length, 0)
-          : fromIndex;
+        ? Math.max(fromIndex + length, 0)
+        : fromIndex;
 
     if (from >= length) return -1;
 
@@ -670,8 +670,8 @@ export class ArrayProxy {
       fromIndex === undefined || fromIndex >= length
         ? length - 1
         : fromIndex < 0
-          ? fromIndex + length
-          : fromIndex;
+        ? fromIndex + length
+        : fromIndex;
 
     if (from < 0) return -1;
 

--- a/packages/sdk/src/document/json/counter.ts
+++ b/packages/sdk/src/document/json/counter.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
-import { Primitive } from '@yorkie-js-sdk/src/document/crdt/primitive';
-import { IncreaseOperation } from '@yorkie-js-sdk/src/document/operation/increase_operation';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { ChangeContext } from '@yorkie-js/sdk/src/document/change/context';
+import { Primitive } from '@yorkie-js/sdk/src/document/crdt/primitive';
+import { IncreaseOperation } from '@yorkie-js/sdk/src/document/operation/increase_operation';
 import Long from 'long';
 import {
   CounterType,
   CRDTCounter,
-} from '@yorkie-js-sdk/src/document/crdt/counter';
-import type * as Devtools from '@yorkie-js-sdk/src/devtools/types';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+} from '@yorkie-js/sdk/src/document/crdt/counter';
+import type * as Devtools from '@yorkie-js/sdk/src/devtools/types';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
  * `Counter` is a custom data type that is used to counter.

--- a/packages/sdk/src/document/json/element.ts
+++ b/packages/sdk/src/document/json/element.ts
@@ -14,36 +14,36 @@
  * limitations under the License.
  */
 
-import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
-import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
-import { CRDTObject } from '@yorkie-js-sdk/src/document/crdt/object';
-import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';
+import { ChangeContext } from '@yorkie-js/sdk/src/document/change/context';
+import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
+import { CRDTObject } from '@yorkie-js/sdk/src/document/crdt/object';
+import { CRDTArray } from '@yorkie-js/sdk/src/document/crdt/array';
 import {
   Primitive,
   PrimitiveValue,
-} from '@yorkie-js-sdk/src/document/crdt/primitive';
-import { CRDTText } from '@yorkie-js-sdk/src/document/crdt/text';
+} from '@yorkie-js/sdk/src/document/crdt/primitive';
+import { CRDTText } from '@yorkie-js/sdk/src/document/crdt/text';
 import {
   CounterType,
   CRDTCounter,
-} from '@yorkie-js-sdk/src/document/crdt/counter';
-import { CRDTTree } from '@yorkie-js-sdk/src/document/crdt/tree';
-import { RGATreeSplit } from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
+} from '@yorkie-js/sdk/src/document/crdt/counter';
+import { CRDTTree } from '@yorkie-js/sdk/src/document/crdt/tree';
+import { RGATreeSplit } from '@yorkie-js/sdk/src/document/crdt/rga_tree_split';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
 
 import {
   JSONObject,
   createJSONObject,
   ObjectProxy,
-} from '@yorkie-js-sdk/src/document/json/object';
+} from '@yorkie-js/sdk/src/document/json/object';
 import {
   JSONArray,
   createJSONArray,
   ArrayProxy,
-} from '@yorkie-js-sdk/src/document/json/array';
-import { Text } from '@yorkie-js-sdk/src/document/json/text';
-import { Counter } from '@yorkie-js-sdk/src/document/json/counter';
-import { Tree } from '@yorkie-js-sdk/src/document/json/tree';
+} from '@yorkie-js/sdk/src/document/json/array';
+import { Text } from '@yorkie-js/sdk/src/document/json/text';
+import { Counter } from '@yorkie-js/sdk/src/document/json/counter';
+import { Tree } from '@yorkie-js/sdk/src/document/json/tree';
 import { Indexable } from '../document';
 
 /**

--- a/packages/sdk/src/document/json/object.ts
+++ b/packages/sdk/src/document/json/object.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import { logger, LogLevel } from '@yorkie-js-sdk/src/util/logger';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { SetOperation } from '@yorkie-js-sdk/src/document/operation/set_operation';
-import { RemoveOperation } from '@yorkie-js-sdk/src/document/operation/remove_operation';
-import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
-import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
-import { CRDTObject } from '@yorkie-js-sdk/src/document/crdt/object';
+import { logger, LogLevel } from '@yorkie-js/sdk/src/util/logger';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { SetOperation } from '@yorkie-js/sdk/src/document/operation/set_operation';
+import { RemoveOperation } from '@yorkie-js/sdk/src/document/operation/remove_operation';
+import { ChangeContext } from '@yorkie-js/sdk/src/document/change/context';
+import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
+import { CRDTObject } from '@yorkie-js/sdk/src/document/crdt/object';
 import {
   toJSONElement,
   buildCRDTElement,
-} from '@yorkie-js-sdk/src/document/json/element';
-import * as Devtools from '@yorkie-js-sdk/src/devtools/types';
+} from '@yorkie-js/sdk/src/document/json/element';
+import * as Devtools from '@yorkie-js/sdk/src/devtools/types';
 
 /**
  * `JSONObject` represents a JSON object, but unlike regular JSON, it has time

--- a/packages/sdk/src/document/json/text.ts
+++ b/packages/sdk/src/document/json/text.ts
@@ -14,31 +14,31 @@
  * limitations under the License.
  */
 
-import { logger, LogLevel } from '@yorkie-js-sdk/src/util/logger';
-import { Indexable } from '@yorkie-js-sdk/src/document/document';
+import { logger, LogLevel } from '@yorkie-js/sdk/src/util/logger';
+import { Indexable } from '@yorkie-js/sdk/src/document/document';
 import {
   TimeTicket,
   TimeTicketStruct,
-} from '@yorkie-js-sdk/src/document/time/ticket';
-import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
+} from '@yorkie-js/sdk/src/document/time/ticket';
+import { ChangeContext } from '@yorkie-js/sdk/src/document/change/context';
 import {
   RGATreeSplitNode,
   RGATreeSplitNodeID,
   RGATreeSplitPos,
   RGATreeSplitPosRange,
-} from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';
+} from '@yorkie-js/sdk/src/document/crdt/rga_tree_split';
 import {
   CRDTText,
   CRDTTextValue,
   TextValueType,
-} from '@yorkie-js-sdk/src/document/crdt/text';
-import { EditOperation } from '@yorkie-js-sdk/src/document/operation/edit_operation';
-import { StyleOperation } from '@yorkie-js-sdk/src/document/operation/style_operation';
-import { stringifyObjectValues } from '@yorkie-js-sdk/src/util/object';
-import type * as Devtools from '@yorkie-js-sdk/src/devtools/types';
-import { SplayTree } from '@yorkie-js-sdk/src/util/splay_tree';
-import { LLRBTree } from '@yorkie-js-sdk/src/util/llrb_tree';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+} from '@yorkie-js/sdk/src/document/crdt/text';
+import { EditOperation } from '@yorkie-js/sdk/src/document/operation/edit_operation';
+import { StyleOperation } from '@yorkie-js/sdk/src/document/operation/style_operation';
+import { stringifyObjectValues } from '@yorkie-js/sdk/src/util/object';
+import type * as Devtools from '@yorkie-js/sdk/src/devtools/types';
+import { SplayTree } from '@yorkie-js/sdk/src/util/splay_tree';
+import { LLRBTree } from '@yorkie-js/sdk/src/util/llrb_tree';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
  * `TextPosStruct` represents the structure of RGATreeSplitPos.

--- a/packages/sdk/src/document/json/tree.ts
+++ b/packages/sdk/src/document/json/tree.ts
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { ChangeContext } from '@yorkie-js/sdk/src/document/change/context';
 import {
   CRDTTree,
   CRDTTreeNodeID,
   CRDTTreeNode,
   CRDTTreePos,
-} from '@yorkie-js-sdk/src/document/crdt/tree';
+} from '@yorkie-js/sdk/src/document/crdt/tree';
 
 import {
   IndexTree,
   DefaultRootType,
   DefaultTextType,
-} from '@yorkie-js-sdk/src/util/index_tree';
-import { TreeEditOperation } from '@yorkie-js-sdk/src/document/operation/tree_edit_operation';
-import { isEmpty, stringifyObjectValues } from '@yorkie-js-sdk/src/util/object';
+} from '@yorkie-js/sdk/src/util/index_tree';
+import { TreeEditOperation } from '@yorkie-js/sdk/src/document/operation/tree_edit_operation';
+import { isEmpty, stringifyObjectValues } from '@yorkie-js/sdk/src/util/object';
 import { RHT } from '../crdt/rht';
 import { TreeStyleOperation } from '../operation/tree_style_operation';
 import type {
@@ -40,9 +40,9 @@ import type {
   TreeChangeType,
   TreePosStructRange,
   CRDTTreeNodeIDStruct,
-} from '@yorkie-js-sdk/src/document/crdt/tree';
-import type * as Devtools from '@yorkie-js-sdk/src/devtools/types';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+} from '@yorkie-js/sdk/src/document/crdt/tree';
+import type * as Devtools from '@yorkie-js/sdk/src/devtools/types';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
  * NOTE(hackerwins): In normal case, we should define the following types in

--- a/packages/sdk/src/document/operation/add_operation.ts
+++ b/packages/sdk/src/document/operation/add_operation.ts
@@ -14,15 +14,15 @@
  * limitations under the License.
  */
 
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
-import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
-import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
+import { CRDTArray } from '@yorkie-js/sdk/src/document/crdt/array';
 import {
   Operation,
   ExecutionResult,
-} from '@yorkie-js-sdk/src/document/operation/operation';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+} from '@yorkie-js/sdk/src/document/operation/operation';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
  * `AddOperation` is an operation representing adding an element to an Array.

--- a/packages/sdk/src/document/operation/edit_operation.ts
+++ b/packages/sdk/src/document/operation/edit_operation.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
-import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
-import { RGATreeSplitPos } from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';
-import { CRDTText } from '@yorkie-js-sdk/src/document/crdt/text';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { VersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
+import { RGATreeSplitPos } from '@yorkie-js/sdk/src/document/crdt/rga_tree_split';
+import { CRDTText } from '@yorkie-js/sdk/src/document/crdt/text';
 import {
   Operation,
   OperationInfo,
   ExecutionResult,
   OpSource,
-} from '@yorkie-js-sdk/src/document/operation/operation';
+} from '@yorkie-js/sdk/src/document/operation/operation';
 import { Indexable } from '../document';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
  * `EditOperation` is an operation representing editing Text. Most of the same as

--- a/packages/sdk/src/document/operation/increase_operation.ts
+++ b/packages/sdk/src/document/operation/increase_operation.ts
@@ -18,16 +18,16 @@ import Long from 'long';
 import {
   ExecutionResult,
   Operation,
-} from '@yorkie-js-sdk/src/document/operation/operation';
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
-import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
+} from '@yorkie-js/sdk/src/document/operation/operation';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
 import {
   Primitive,
   PrimitiveType,
-} from '@yorkie-js-sdk/src/document/crdt/primitive';
-import { CRDTCounter } from '@yorkie-js-sdk/src/document/crdt/counter';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+} from '@yorkie-js/sdk/src/document/crdt/primitive';
+import { CRDTCounter } from '@yorkie-js/sdk/src/document/crdt/counter';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
  * `IncreaseOperation` represents an operation that increments a numeric value to Counter.

--- a/packages/sdk/src/document/operation/move_operation.ts
+++ b/packages/sdk/src/document/operation/move_operation.ts
@@ -14,14 +14,14 @@
  * limitations under the License.
  */
 
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
-import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
+import { CRDTArray } from '@yorkie-js/sdk/src/document/crdt/array';
 import {
   Operation,
   ExecutionResult,
-} from '@yorkie-js-sdk/src/document/operation/operation';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+} from '@yorkie-js/sdk/src/document/operation/operation';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
  * `MoveOperation` is an operation representing moving an element to an Array.

--- a/packages/sdk/src/document/operation/operation.ts
+++ b/packages/sdk/src/document/operation/operation.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { ActorID } from '@yorkie-js-sdk/src/document/time/actor_id';
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
-import { TreeNode } from '@yorkie-js-sdk/src/document/crdt/tree';
-import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
-import { Indexable } from '@yorkie-js-sdk/src/document/document';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+import { ActorID } from '@yorkie-js/sdk/src/document/time/actor_id';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { VersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
+import { TreeNode } from '@yorkie-js/sdk/src/document/crdt/tree';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
+import { Indexable } from '@yorkie-js/sdk/src/document/document';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
  * `OpSource` represents the source of the operation. It is used to handle

--- a/packages/sdk/src/document/operation/remove_operation.ts
+++ b/packages/sdk/src/document/operation/remove_operation.ts
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
 import {
   OpSource,
   Operation,
   OperationInfo,
   ExecutionResult,
-} from '@yorkie-js-sdk/src/document/operation/operation';
+} from '@yorkie-js/sdk/src/document/operation/operation';
 import {
   CRDTContainer,
   CRDTElement,
-} from '@yorkie-js-sdk/src/document/crdt/element';
-import { CRDTObject } from '@yorkie-js-sdk/src/document/crdt/object';
-import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';
-import { SetOperation } from '@yorkie-js-sdk/src/document/operation/set_operation';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+} from '@yorkie-js/sdk/src/document/crdt/element';
+import { CRDTObject } from '@yorkie-js/sdk/src/document/crdt/object';
+import { CRDTArray } from '@yorkie-js/sdk/src/document/crdt/array';
+import { SetOperation } from '@yorkie-js/sdk/src/document/operation/set_operation';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
  * `RemoveOperation` is an operation that removes an element from `CRDTContainer`.

--- a/packages/sdk/src/document/operation/set_operation.ts
+++ b/packages/sdk/src/document/operation/set_operation.ts
@@ -14,17 +14,17 @@
  * limitations under the License.
  */
 
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
-import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
-import { CRDTObject } from '@yorkie-js-sdk/src/document/crdt/object';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
+import { CRDTObject } from '@yorkie-js/sdk/src/document/crdt/object';
 import {
   OpSource,
   Operation,
   ExecutionResult,
-} from '@yorkie-js-sdk/src/document/operation/operation';
-import { RemoveOperation } from '@yorkie-js-sdk/src/document/operation/remove_operation';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+} from '@yorkie-js/sdk/src/document/operation/operation';
+import { RemoveOperation } from '@yorkie-js/sdk/src/document/operation/remove_operation';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
  * `SetOperation` represents an operation that stores the value corresponding to the

--- a/packages/sdk/src/document/operation/style_operation.ts
+++ b/packages/sdk/src/document/operation/style_operation.ts
@@ -14,19 +14,19 @@
  * limitations under the License.
  */
 
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
-import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
-import { RGATreeSplitPos } from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';
-import { CRDTText } from '@yorkie-js-sdk/src/document/crdt/text';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { VersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
+import { RGATreeSplitPos } from '@yorkie-js/sdk/src/document/crdt/rga_tree_split';
+import { CRDTText } from '@yorkie-js/sdk/src/document/crdt/text';
 import {
   Operation,
   OperationInfo,
   ExecutionResult,
   OpSource,
-} from '@yorkie-js-sdk/src/document/operation/operation';
+} from '@yorkie-js/sdk/src/document/operation/operation';
 import { Indexable } from '../document';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
  *  `StyleOperation` is an operation applies the style of the given range to Text.

--- a/packages/sdk/src/document/operation/tree_edit_operation.ts
+++ b/packages/sdk/src/document/operation/tree_edit_operation.ts
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
-import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { VersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
 import {
   CRDTTree,
   CRDTTreeNode,
   CRDTTreePos,
   toXML,
-} from '@yorkie-js-sdk/src/document/crdt/tree';
+} from '@yorkie-js/sdk/src/document/crdt/tree';
 import {
   Operation,
   OperationInfo,
   ExecutionResult,
   OpSource,
-} from '@yorkie-js-sdk/src/document/operation/operation';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+} from '@yorkie-js/sdk/src/document/operation/operation';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
  * `TreeEditOperation` is an operation representing Tree editing.

--- a/packages/sdk/src/document/operation/tree_style_operation.ts
+++ b/packages/sdk/src/document/operation/tree_style_operation.ts
@@ -14,22 +14,22 @@
  * limitations under the License.
  */
 
-import { TimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
-import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { VersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
 import {
   CRDTTree,
   CRDTTreePos,
   TreeChange,
-} from '@yorkie-js-sdk/src/document/crdt/tree';
+} from '@yorkie-js/sdk/src/document/crdt/tree';
 import {
   Operation,
   OperationInfo,
   ExecutionResult,
   OpSource,
-} from '@yorkie-js-sdk/src/document/operation/operation';
-import { GCPair } from '@yorkie-js-sdk/src/document/crdt/gc';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+} from '@yorkie-js/sdk/src/document/operation/operation';
+import { GCPair } from '@yorkie-js/sdk/src/document/crdt/gc';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
  * `TreeStyleOperation` represents an operation that modifies the style of the

--- a/packages/sdk/src/document/presence/presence.ts
+++ b/packages/sdk/src/document/presence/presence.ts
@@ -14,9 +14,9 @@
  * limitations under the License.
  */
 
-import { deepcopy } from '@yorkie-js-sdk/src/util/object';
-import { Indexable } from '@yorkie-js-sdk/src/document/document';
-import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
+import { deepcopy } from '@yorkie-js/sdk/src/util/object';
+import { Indexable } from '@yorkie-js/sdk/src/document/document';
+import { ChangeContext } from '@yorkie-js/sdk/src/document/change/context';
 
 /**
  * `PresenceChangeType` represents the type of presence change.

--- a/packages/sdk/src/document/time/ticket.ts
+++ b/packages/sdk/src/document/time/ticket.ts
@@ -14,12 +14,12 @@
  * limitations under the License.
  */
 
-import { Comparator } from '@yorkie-js-sdk/src/util/comparator';
+import { Comparator } from '@yorkie-js/sdk/src/util/comparator';
 import {
   ActorID,
   InitialActorID,
   MaxActorID,
-} from '@yorkie-js-sdk/src/document/time/actor_id';
+} from '@yorkie-js/sdk/src/document/time/actor_id';
 
 export const TicketComparator: Comparator<TimeTicket> = (
   p1: TimeTicket,

--- a/packages/sdk/src/util/llrb_tree.ts
+++ b/packages/sdk/src/util/llrb_tree.ts
@@ -17,7 +17,7 @@
 import {
   Comparator,
   DefaultComparator,
-} from '@yorkie-js-sdk/src/util/comparator';
+} from '@yorkie-js/sdk/src/util/comparator';
 
 interface Entry<K, V> {
   key: K;

--- a/packages/sdk/src/util/object.ts
+++ b/packages/sdk/src/util/object.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Indexable } from '@yorkie-js-sdk/src/document/document';
+import { Indexable } from '@yorkie-js/sdk/src/document/document';
 
 /**
  * `deepcopy` returns a deep copy of the given object.

--- a/packages/sdk/src/util/observable.ts
+++ b/packages/sdk/src/util/observable.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { logger } from '@yorkie-js-sdk/src/util/logger';
-import { uuid } from '@yorkie-js-sdk/src/util/uuid';
+import { logger } from '@yorkie-js/sdk/src/util/logger';
+import { uuid } from '@yorkie-js/sdk/src/util/uuid';
 import { Code, YorkieError } from './error';
 
 export type NextFn<T> = (value: T) => void;

--- a/packages/sdk/src/yorkie.ts
+++ b/packages/sdk/src/yorkie.ts
@@ -14,13 +14,13 @@
  * limitations under the License.
  */
 
-import { Client } from '@yorkie-js-sdk/src/client/client';
-import { Document } from '@yorkie-js-sdk/src/document/document';
-import { Text } from '@yorkie-js-sdk/src/document/json/text';
-import { Tree } from '@yorkie-js-sdk/src/document/json/tree';
-import { Counter } from '@yorkie-js-sdk/src/document/json/counter';
-import { CounterType } from '@yorkie-js-sdk/src/document/crdt/counter';
-import * as Devtools from '@yorkie-js-sdk/src/devtools/types';
+import { Client } from '@yorkie-js/sdk/src/client/client';
+import { Document } from '@yorkie-js/sdk/src/document/document';
+import { Text } from '@yorkie-js/sdk/src/document/json/text';
+import { Tree } from '@yorkie-js/sdk/src/document/json/tree';
+import { Counter } from '@yorkie-js/sdk/src/document/json/counter';
+import { CounterType } from '@yorkie-js/sdk/src/document/crdt/counter';
+import * as Devtools from '@yorkie-js/sdk/src/devtools/types';
 
 export {
   Client,
@@ -28,7 +28,7 @@ export {
   ClientCondition,
   SyncMode,
   type ClientOptions,
-} from '@yorkie-js-sdk/src/client/client';
+} from '@yorkie-js/sdk/src/client/client';
 export {
   DocEventType,
   type SnapshotEvent,
@@ -49,8 +49,8 @@ export {
   type DocEvents,
   Document,
   type ChangeInfo,
-} from '@yorkie-js-sdk/src/document/document';
-export { Presence } from '@yorkie-js-sdk/src/document/presence/presence';
+} from '@yorkie-js/sdk/src/document/document';
+export { Presence } from '@yorkie-js/sdk/src/document/presence/presence';
 export {
   type Observer,
   type Observable,
@@ -58,13 +58,13 @@ export {
   type ErrorFn,
   type CompleteFn,
   type Unsubscribe,
-} from '@yorkie-js-sdk/src/util/observable';
+} from '@yorkie-js/sdk/src/util/observable';
 export {
   TimeTicket,
   type TimeTicketStruct,
-} from '@yorkie-js-sdk/src/document/time/ticket';
-export { type ActorID } from '@yorkie-js-sdk/src/document/time/actor_id';
-export { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
+} from '@yorkie-js/sdk/src/document/time/ticket';
+export { type ActorID } from '@yorkie-js/sdk/src/document/time/actor_id';
+export { VersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
 export type {
   OperationInfo,
   TextOperationInfo,
@@ -81,28 +81,28 @@ export type {
   StyleOpInfo,
   TreeEditOpInfo,
   TreeStyleOpInfo,
-} from '@yorkie-js-sdk/src/document/operation/operation';
-export { OpSource } from '@yorkie-js-sdk/src/document/operation/operation';
+} from '@yorkie-js/sdk/src/document/operation/operation';
+export { OpSource } from '@yorkie-js/sdk/src/document/operation/operation';
 
 export {
   Primitive,
   type PrimitiveValue,
-} from '@yorkie-js-sdk/src/document/crdt/primitive';
-import { Primitive } from '@yorkie-js-sdk/src/document/crdt/primitive';
+} from '@yorkie-js/sdk/src/document/crdt/primitive';
+import { Primitive } from '@yorkie-js/sdk/src/document/crdt/primitive';
 
 export {
   type WrappedElement,
   type JSONElement,
-} from '@yorkie-js-sdk/src/document/json/element';
-export { type JSONObject } from '@yorkie-js-sdk/src/document/json/object';
-export { type JSONArray } from '@yorkie-js-sdk/src/document/json/array';
-export { Counter } from '@yorkie-js-sdk/src/document/json/counter';
-export { type CounterValue } from '@yorkie-js-sdk/src/document/crdt/counter';
+} from '@yorkie-js/sdk/src/document/json/element';
+export { type JSONObject } from '@yorkie-js/sdk/src/document/json/object';
+export { type JSONArray } from '@yorkie-js/sdk/src/document/json/array';
+export { Counter } from '@yorkie-js/sdk/src/document/json/counter';
+export { type CounterValue } from '@yorkie-js/sdk/src/document/crdt/counter';
 export {
   Text,
   type TextPosStruct,
   type TextPosStructRange,
-} from '@yorkie-js-sdk/src/document/json/text';
+} from '@yorkie-js/sdk/src/document/json/text';
 export {
   Tree,
   type TreeNode,
@@ -112,12 +112,12 @@ export {
   type TreeChangeType,
   type CRDTTreeNodeIDStruct,
   type TreePosStructRange,
-} from '@yorkie-js-sdk/src/document/json/tree';
-export { Change } from '@yorkie-js-sdk/src/document/change/change';
-export { converter } from '@yorkie-js-sdk/src/api/converter';
+} from '@yorkie-js/sdk/src/document/json/tree';
+export { Change } from '@yorkie-js/sdk/src/document/change/change';
+export { converter } from '@yorkie-js/sdk/src/api/converter';
 
-import { LogLevel, setLogLevel } from '@yorkie-js-sdk/src/util/logger';
-export { LogLevel, setLogLevel } from '@yorkie-js-sdk/src/util/logger';
+import { LogLevel, setLogLevel } from '@yorkie-js/sdk/src/util/logger';
+export { LogLevel, setLogLevel } from '@yorkie-js/sdk/src/util/logger';
 
 export {
   EventSourceDevPanel,
@@ -126,7 +126,7 @@ export {
   type SDKToPanelMessage,
   type FullPanelToSDKMessage,
   type FullSDKToPanelMessage,
-} from '@yorkie-js-sdk/src/devtools/protocol';
+} from '@yorkie-js/sdk/src/devtools/protocol';
 export { Devtools };
 
 /**

--- a/packages/sdk/test/bench/counter.bench.ts
+++ b/packages/sdk/test/bench/counter.bench.ts
@@ -1,5 +1,5 @@
-import { Document, Counter } from '@yorkie-js-sdk/src/yorkie';
-import { CounterType } from '@yorkie-js-sdk/src/document/crdt/counter';
+import { Document, Counter } from '@yorkie-js/sdk/src/yorkie';
+import { CounterType } from '@yorkie-js/sdk/src/document/crdt/counter';
 import { describe, bench, assert } from 'vitest';
 
 const benchmarkCounter = (size: number) => {

--- a/packages/sdk/test/bench/document.bench.ts
+++ b/packages/sdk/test/bench/document.bench.ts
@@ -1,6 +1,6 @@
-import { Document, JSONArray } from '@yorkie-js-sdk/src/yorkie';
-import { InitialCheckpoint } from '@yorkie-js-sdk/src/document/change/checkpoint';
-import { DocStatus } from '@yorkie-js-sdk/src/document/document';
+import { Document, JSONArray } from '@yorkie-js/sdk/src/yorkie';
+import { InitialCheckpoint } from '@yorkie-js/sdk/src/document/change/checkpoint';
+import { DocStatus } from '@yorkie-js/sdk/src/document/document';
 import { describe, bench, assert } from 'vitest';
 import { MaxVersionVector } from '../helper/helper';
 

--- a/packages/sdk/test/bench/splay_tree.bench.ts
+++ b/packages/sdk/test/bench/splay_tree.bench.ts
@@ -1,5 +1,5 @@
 import { describe, bench } from 'vitest';
-import { SplayNode, SplayTree } from '@yorkie-js-sdk/src/util/splay_tree';
+import { SplayNode, SplayTree } from '@yorkie-js/sdk/src/util/splay_tree';
 import editTraceData from './editing-trace.json';
 
 class StringNode extends SplayNode<string> {

--- a/packages/sdk/test/bench/text.bench.ts
+++ b/packages/sdk/test/bench/text.bench.ts
@@ -1,4 +1,4 @@
-import { Document, Text } from '@yorkie-js-sdk/src/yorkie';
+import { Document, Text } from '@yorkie-js/sdk/src/yorkie';
 import { assert, bench, describe } from 'vitest';
 import { MaxVersionVector } from '../helper/helper';
 

--- a/packages/sdk/test/bench/tree.bench.ts
+++ b/packages/sdk/test/bench/tree.bench.ts
@@ -1,4 +1,4 @@
-import { converter, Document, Tree, TreeNode } from '@yorkie-js-sdk/src/yorkie';
+import { converter, Document, Tree, TreeNode } from '@yorkie-js/sdk/src/yorkie';
 import { describe, bench, assert } from 'vitest';
 import { MaxVersionVector } from '../helper/helper';
 

--- a/packages/sdk/test/helper/helper.ts
+++ b/packages/sdk/test/helper/helper.ts
@@ -16,30 +16,30 @@
 
 import { assert } from 'vitest';
 
-import yorkie, { Tree, ElementNode } from '@yorkie-js-sdk/src/yorkie';
-import { IndexTree } from '@yorkie-js-sdk/src/util/index_tree';
+import yorkie, { Tree, ElementNode } from '@yorkie-js/sdk/src/yorkie';
+import { IndexTree } from '@yorkie-js/sdk/src/util/index_tree';
 import {
   CRDTTreeNode,
   CRDTTreeNodeID,
-} from '@yorkie-js-sdk/src/document/crdt/tree';
+} from '@yorkie-js/sdk/src/document/crdt/tree';
 import {
   OperationInfo,
   Operation,
-} from '@yorkie-js-sdk/src/document/operation/operation';
+} from '@yorkie-js/sdk/src/document/operation/operation';
 import {
   InitialTimeTicket as ITT,
   MaxLamport,
   TimeTicket,
-} from '@yorkie-js-sdk/src/document/time/ticket';
-import { HistoryOperation } from '@yorkie-js-sdk/src/document/history';
-import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
-import { InitialChangeID } from '@yorkie-js-sdk/src/document/change/change_id';
-import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
-import { CRDTObject } from '@yorkie-js-sdk/src/document/crdt/object';
-import { ElementRHT } from '@yorkie-js-sdk/src/document/crdt/element_rht';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
-import { InitialActorID } from '@yorkie-js-sdk/src/document/time/actor_id';
-import { VersionVector } from '@yorkie-js-sdk/src/document/time/version_vector';
+} from '@yorkie-js/sdk/src/document/time/ticket';
+import { HistoryOperation } from '@yorkie-js/sdk/src/document/history';
+import { ChangeContext } from '@yorkie-js/sdk/src/document/change/context';
+import { InitialChangeID } from '@yorkie-js/sdk/src/document/change/change_id';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
+import { CRDTObject } from '@yorkie-js/sdk/src/document/crdt/object';
+import { ElementRHT } from '@yorkie-js/sdk/src/document/crdt/element_rht';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
+import { InitialActorID } from '@yorkie-js/sdk/src/document/time/actor_id';
+import { VersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
 
 export type Indexable = Record<string, any>;
 export const DefaultSnapshotThreshold = 1000;
@@ -122,13 +122,10 @@ export function deepSort(target: any): any {
   if (typeof target === 'object') {
     return Object.keys(target)
       .sort()
-      .reduce(
-        (result, key) => {
-          result[key] = deepSort(target[key]);
-          return result;
-        },
-        {} as Record<string, any>,
-      );
+      .reduce((result, key) => {
+        result[key] = deepSort(target[key]);
+        return result;
+      }, {} as Record<string, any>);
   }
   return target;
 }

--- a/packages/sdk/test/integration/array_test.ts
+++ b/packages/sdk/test/integration/array_test.ts
@@ -1,12 +1,12 @@
 import { describe, it, assert } from 'vitest';
-import { Document } from '@yorkie-js-sdk/src/document/document';
-import { withTwoClientsAndDocuments } from '@yorkie-js-sdk/test/integration/integration_helper';
+import { Document } from '@yorkie-js/sdk/src/document/document';
+import { withTwoClientsAndDocuments } from '@yorkie-js/sdk/test/integration/integration_helper';
 import {
   JSONArray,
   WrappedElement,
   Primitive,
   TimeTicket,
-} from '@yorkie-js-sdk/src/yorkie';
+} from '@yorkie-js/sdk/src/yorkie';
 import { MaxVersionVector } from '../helper/helper';
 
 describe('Array', function () {

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -24,19 +24,19 @@ import yorkie, {
   DocSyncStatus,
   Tree,
   Text,
-} from '@yorkie-js-sdk/src/yorkie';
+} from '@yorkie-js/sdk/src/yorkie';
 import {
   EventCollector,
   DefaultSnapshotThreshold,
-} from '@yorkie-js-sdk/test/helper/helper';
+} from '@yorkie-js/sdk/test/helper/helper';
 import {
   toDocKey,
   testRPCAddr,
   withTwoClientsAndDocuments,
-} from '@yorkie-js-sdk/test/integration/integration_helper';
+} from '@yorkie-js/sdk/test/integration/integration_helper';
 import { ConnectError, Code as ConnectCode } from '@connectrpc/connect';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
-import { Json } from '@yorkie-js-sdk/src/document/document';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
+import { Json } from '@yorkie-js/sdk/src/document/document';
 
 describe.sequential('Client', function () {
   afterEach(() => {

--- a/packages/sdk/test/integration/counter_test.ts
+++ b/packages/sdk/test/integration/counter_test.ts
@@ -1,14 +1,14 @@
 import { describe, it, assert } from 'vitest';
-import { Document } from '@yorkie-js-sdk/src/document/document';
-import { toStringHistoryOp } from '@yorkie-js-sdk/test/helper/helper';
+import { Document } from '@yorkie-js/sdk/src/document/document';
+import { toStringHistoryOp } from '@yorkie-js/sdk/test/helper/helper';
 import {
   withTwoClientsAndDocuments,
   assertUndoRedo,
   toDocKey,
   testRPCAddr,
-} from '@yorkie-js-sdk/test/integration/integration_helper';
-import yorkie, { Counter, SyncMode } from '@yorkie-js-sdk/src/yorkie';
-import { CounterType } from '@yorkie-js-sdk/src/document/crdt/counter';
+} from '@yorkie-js/sdk/test/integration/integration_helper';
+import yorkie, { Counter, SyncMode } from '@yorkie-js/sdk/src/yorkie';
+import { CounterType } from '@yorkie-js/sdk/src/document/crdt/counter';
 import Long from 'long';
 
 describe('Counter', function () {

--- a/packages/sdk/test/integration/document_test.ts
+++ b/packages/sdk/test/integration/document_test.ts
@@ -6,25 +6,25 @@ import yorkie, {
   SyncMode,
   Tree,
   JSONElement,
-} from '@yorkie-js-sdk/src/yorkie';
+} from '@yorkie-js/sdk/src/yorkie';
 import {
   testRPCAddr,
   toDocKey,
-} from '@yorkie-js-sdk/test/integration/integration_helper';
+} from '@yorkie-js/sdk/test/integration/integration_helper';
 import {
   EventCollector,
   assertThrowsAsync,
   Indexable,
-} from '@yorkie-js-sdk/test/helper/helper';
-import type { CRDTElement } from '@yorkie-js-sdk/src/document/crdt/element';
+} from '@yorkie-js/sdk/test/helper/helper';
+import type { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
 import {
   DocStatus,
   DocEventType,
   StatusChangedEvent,
-} from '@yorkie-js-sdk/src/document/document';
-import { OperationInfo } from '@yorkie-js-sdk/src/document/operation/operation';
-import { YorkieError } from '@yorkie-js-sdk/src/util/error';
-import { CounterType } from '@yorkie-js-sdk/src/document/crdt/counter';
+} from '@yorkie-js/sdk/src/document/document';
+import { OperationInfo } from '@yorkie-js/sdk/src/document/operation/operation';
+import { YorkieError } from '@yorkie-js/sdk/src/util/error';
+import { CounterType } from '@yorkie-js/sdk/src/document/crdt/counter';
 import Long from 'long';
 
 describe('Document', function () {

--- a/packages/sdk/test/integration/gc_test.ts
+++ b/packages/sdk/test/integration/gc_test.ts
@@ -1,9 +1,9 @@
 import { describe, it, assert } from 'vitest';
-import yorkie, { Text, Tree, SyncMode } from '@yorkie-js-sdk/src/yorkie';
+import yorkie, { Text, Tree, SyncMode } from '@yorkie-js/sdk/src/yorkie';
 import {
   testRPCAddr,
   toDocKey,
-} from '@yorkie-js-sdk/test/integration/integration_helper';
+} from '@yorkie-js/sdk/test/integration/integration_helper';
 import {
   MaxVersionVector,
   versionVectorHelper,

--- a/packages/sdk/test/integration/integration_helper.ts
+++ b/packages/sdk/test/integration/integration_helper.ts
@@ -1,8 +1,8 @@
 import { assert } from 'vitest';
-import yorkie, { SyncMode } from '@yorkie-js-sdk/src/yorkie';
-import { Client } from '@yorkie-js-sdk/src/client/client';
-import { Document } from '@yorkie-js-sdk/src/document/document';
-import { Indexable } from '@yorkie-js-sdk/test/helper/helper';
+import yorkie, { SyncMode } from '@yorkie-js/sdk/src/yorkie';
+import { Client } from '@yorkie-js/sdk/src/client/client';
+import { Document } from '@yorkie-js/sdk/src/document/document';
+import { Indexable } from '@yorkie-js/sdk/test/helper/helper';
 import { execSync } from 'child_process';
 
 export const testRPCAddr = process.env.TEST_RPC_ADDR || 'http://127.0.0.1:8080';

--- a/packages/sdk/test/integration/object_test.ts
+++ b/packages/sdk/test/integration/object_test.ts
@@ -1,14 +1,14 @@
 import { describe, it, assert } from 'vitest';
-import { JSONObject, Client, SyncMode } from '@yorkie-js-sdk/src/yorkie';
-import { Document } from '@yorkie-js-sdk/src/document/document';
+import { JSONObject, Client, SyncMode } from '@yorkie-js/sdk/src/yorkie';
+import { Document } from '@yorkie-js/sdk/src/document/document';
 import {
   withTwoClientsAndDocuments,
   assertUndoRedo,
   toDocKey,
   testRPCAddr,
-} from '@yorkie-js-sdk/test/integration/integration_helper';
-import { toStringHistoryOp } from '@yorkie-js-sdk/test/helper/helper';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+} from '@yorkie-js/sdk/test/integration/integration_helper';
+import { toStringHistoryOp } from '@yorkie-js/sdk/test/helper/helper';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 describe('Object', function () {
   it('valid key test', function () {

--- a/packages/sdk/test/integration/presence_test.ts
+++ b/packages/sdk/test/integration/presence_test.ts
@@ -5,17 +5,17 @@ import yorkie, {
   Counter,
   SyncMode,
   StreamConnectionStatus,
-} from '@yorkie-js-sdk/src/yorkie';
-import { InitialActorID } from '@yorkie-js-sdk/src/document/time/actor_id';
+} from '@yorkie-js/sdk/src/yorkie';
+import { InitialActorID } from '@yorkie-js/sdk/src/document/time/actor_id';
 import {
   testRPCAddr,
   toDocKey,
-} from '@yorkie-js-sdk/test/integration/integration_helper';
+} from '@yorkie-js/sdk/test/integration/integration_helper';
 import {
   EventCollector,
   deepSort,
   DefaultSnapshotThreshold,
-} from '@yorkie-js-sdk/test/helper/helper';
+} from '@yorkie-js/sdk/test/helper/helper';
 
 describe('Presence', function () {
   afterEach(() => {

--- a/packages/sdk/test/integration/primitive_test.ts
+++ b/packages/sdk/test/integration/primitive_test.ts
@@ -1,9 +1,9 @@
 import { describe, it, assert } from 'vitest';
 import Long from 'long';
-import { Document } from '@yorkie-js-sdk/src/document/document';
-import { InitialCheckpoint } from '@yorkie-js-sdk/src/document/change/checkpoint';
-import { withTwoClientsAndDocuments } from '@yorkie-js-sdk/test/integration/integration_helper';
-import { Code, YorkieError } from '@yorkie-js-sdk/src/util/error';
+import { Document } from '@yorkie-js/sdk/src/document/document';
+import { InitialCheckpoint } from '@yorkie-js/sdk/src/document/change/checkpoint';
+import { withTwoClientsAndDocuments } from '@yorkie-js/sdk/test/integration/integration_helper';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 describe('Primitive', function () {
   it('should apply updates of string', function () {

--- a/packages/sdk/test/integration/snapshot_test.ts
+++ b/packages/sdk/test/integration/snapshot_test.ts
@@ -1,7 +1,7 @@
 import { describe, it, assert } from 'vitest';
-import { DefaultSnapshotThreshold } from '@yorkie-js-sdk/test/helper/helper';
-import { withTwoClientsAndDocuments } from '@yorkie-js-sdk/test/integration/integration_helper';
-import { Text } from '@yorkie-js-sdk/src/yorkie';
+import { DefaultSnapshotThreshold } from '@yorkie-js/sdk/test/helper/helper';
+import { withTwoClientsAndDocuments } from '@yorkie-js/sdk/test/integration/integration_helper';
+import { Text } from '@yorkie-js/sdk/src/yorkie';
 
 describe('Snapshot', function () {
   it('should handle snapshot', async function ({ task }) {

--- a/packages/sdk/test/integration/text_test.ts
+++ b/packages/sdk/test/integration/text_test.ts
@@ -1,7 +1,7 @@
 import { describe, it, assert } from 'vitest';
-import { TextView } from '@yorkie-js-sdk/test/helper/helper';
-import { withTwoClientsAndDocuments } from '@yorkie-js-sdk/test/integration/integration_helper';
-import { Document, Text } from '@yorkie-js-sdk/src/yorkie';
+import { TextView } from '@yorkie-js/sdk/test/helper/helper';
+import { withTwoClientsAndDocuments } from '@yorkie-js/sdk/test/integration/integration_helper';
+import { Document, Text } from '@yorkie-js/sdk/src/yorkie';
 
 describe('Text', function () {
   it('should handle edit operations', function () {

--- a/packages/sdk/test/integration/tree_concurrency_test.ts
+++ b/packages/sdk/test/integration/tree_concurrency_test.ts
@@ -15,14 +15,14 @@
  */
 
 import { assert, describe, test } from 'vitest';
-import { TreeNode } from '@yorkie-js-sdk/src/document/crdt/tree';
-import { Document } from '@yorkie-js-sdk/src/document/document';
+import { TreeNode } from '@yorkie-js/sdk/src/document/crdt/tree';
+import { Document } from '@yorkie-js/sdk/src/document/document';
 import {
   testRPCAddr,
   toDocKey,
-} from '@yorkie-js-sdk/test/integration/integration_helper';
-import yorkie, { SyncMode, Tree } from '@yorkie-js-sdk/src/yorkie';
-import { Indexable } from '@yorkie-js-sdk/test/helper/helper';
+} from '@yorkie-js/sdk/test/integration/integration_helper';
+import yorkie, { SyncMode, Tree } from '@yorkie-js/sdk/src/yorkie';
+import { Indexable } from '@yorkie-js/sdk/test/helper/helper';
 
 function parseSimpleXML(s: string): Array<string> {
   const res: Array<string> = [];

--- a/packages/sdk/test/integration/tree_test.ts
+++ b/packages/sdk/test/integration/tree_test.ts
@@ -15,22 +15,22 @@
  */
 
 import { describe, it, assert } from 'vitest';
-import yorkie, { Tree, SyncMode, converter } from '@yorkie-js-sdk/src/yorkie';
+import yorkie, { Tree, SyncMode, converter } from '@yorkie-js/sdk/src/yorkie';
 import {
   testRPCAddr,
   toDocKey,
   withTwoClientsAndDocuments,
-} from '@yorkie-js-sdk/test/integration/integration_helper';
+} from '@yorkie-js/sdk/test/integration/integration_helper';
 import {
   EventCollector,
   DefaultSnapshotThreshold,
-} from '@yorkie-js-sdk/test/helper/helper';
+} from '@yorkie-js/sdk/test/helper/helper';
 import {
   TreeEditOpInfo,
   TreeStyleOpInfo,
-} from '@yorkie-js-sdk/src/document/operation/operation';
-import { Document, DocEventType } from '@yorkie-js-sdk/src/document/document';
-import { toXML } from '@yorkie-js-sdk/src/document/crdt/tree';
+} from '@yorkie-js/sdk/src/document/operation/operation';
+import { Document, DocEventType } from '@yorkie-js/sdk/src/document/document';
+import { toXML } from '@yorkie-js/sdk/src/document/crdt/tree';
 
 describe('Tree', () => {
   it('Can be created', function ({ task }) {

--- a/packages/sdk/test/integration/webhook_test.ts
+++ b/packages/sdk/test/integration/webhook_test.ts
@@ -20,18 +20,18 @@ import yorkie, {
   SyncMode,
   DocSyncStatus,
   DocEventType,
-} from '@yorkie-js-sdk/src/yorkie';
+} from '@yorkie-js/sdk/src/yorkie';
 import {
   assertThrowsAsync,
   EventCollector,
-} from '@yorkie-js-sdk/test/helper/helper';
+} from '@yorkie-js/sdk/test/helper/helper';
 import {
   toDocKey,
   testRPCAddr,
   testAPIID,
   testAPIPW,
   webhookAddr,
-} from '@yorkie-js-sdk/test/integration/integration_helper';
+} from '@yorkie-js/sdk/test/integration/integration_helper';
 import { ConnectError } from '@connectrpc/connect';
 import axios from 'axios';
 import express from 'express';

--- a/packages/sdk/test/unit/api/converter_test.ts
+++ b/packages/sdk/test/unit/api/converter_test.ts
@@ -15,10 +15,10 @@
  */
 
 import { describe, it, assert } from 'vitest';
-import { Document } from '@yorkie-js-sdk/src/document/document';
-import { converter } from '@yorkie-js-sdk/src/api/converter';
-import { Counter, Text, Tree } from '@yorkie-js-sdk/src/yorkie';
-import { CounterType } from '@yorkie-js-sdk/src/document/crdt/counter';
+import { Document } from '@yorkie-js/sdk/src/document/document';
+import { converter } from '@yorkie-js/sdk/src/api/converter';
+import { Counter, Text, Tree } from '@yorkie-js/sdk/src/yorkie';
+import { CounterType } from '@yorkie-js/sdk/src/document/crdt/counter';
 
 describe('Converter', function () {
   it('should encode/decode bytes', function () {

--- a/packages/sdk/test/unit/document/crdt/counter_test.ts
+++ b/packages/sdk/test/unit/document/crdt/counter_test.ts
@@ -15,13 +15,13 @@
  */
 
 import { describe, it, assert } from 'vitest';
-import { InitialTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
+import { InitialTimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
 import Long from 'long';
 import {
   CounterType,
   CRDTCounter,
-} from '@yorkie-js-sdk/src/document/crdt/counter';
-import { Primitive } from '@yorkie-js-sdk/src/document/crdt/primitive';
+} from '@yorkie-js/sdk/src/document/crdt/counter';
+import { Primitive } from '@yorkie-js/sdk/src/document/crdt/primitive';
 
 describe('Counter', function () {
   it('Can increase numeric data of Counter', function () {
@@ -53,12 +53,9 @@ describe('Counter', function () {
         ? counter.getValue()
         : operand.getValue();
 
-      assert.throw(
-        () => {
-          counter.increase(operand);
-        },
-        `Unsupported type of value: ${typeof errValue}`,
-      );
+      assert.throw(() => {
+        counter.increase(operand);
+      }, `Unsupported type of value: ${typeof errValue}`);
     }
 
     const str = Primitive.of('hello', InitialTimeTicket);

--- a/packages/sdk/test/unit/document/crdt/primitive_test.ts
+++ b/packages/sdk/test/unit/document/crdt/primitive_test.ts
@@ -16,11 +16,11 @@
 
 import Long from 'long';
 import { describe, it, assert } from 'vitest';
-import { InitialTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
+import { InitialTimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
 import {
   Primitive,
   PrimitiveType,
-} from '@yorkie-js-sdk/src/document/crdt/primitive';
+} from '@yorkie-js/sdk/src/document/crdt/primitive';
 
 describe('Primitive', function () {
   const primitiveTypes = [

--- a/packages/sdk/test/unit/document/crdt/rht_test.ts
+++ b/packages/sdk/test/unit/document/crdt/rht_test.ts
@@ -15,10 +15,10 @@
  */
 
 import { describe, it, assert } from 'vitest';
-import { RHT } from '@yorkie-js-sdk/src/document/crdt/rht';
-import { InitialTimeTicket as ITT } from '@yorkie-js-sdk/src/document/time/ticket';
-import { timeT } from '@yorkie-js-sdk/test/helper/helper';
-import { Indexable } from '@yorkie-js-sdk/test/helper/helper';
+import { RHT } from '@yorkie-js/sdk/src/document/crdt/rht';
+import { InitialTimeTicket as ITT } from '@yorkie-js/sdk/src/document/time/ticket';
+import { timeT } from '@yorkie-js/sdk/test/helper/helper';
+import { Indexable } from '@yorkie-js/sdk/test/helper/helper';
 
 describe('RHT interface', function () {
   it('should set and get a value', function () {

--- a/packages/sdk/test/unit/document/crdt/root_test.ts
+++ b/packages/sdk/test/unit/document/crdt/root_test.ts
@@ -1,19 +1,19 @@
 import { describe, it, assert } from 'vitest';
-import { InitialChangeID } from '@yorkie-js-sdk/src/document/change/change_id';
-import { CRDTRoot } from '@yorkie-js-sdk/src/document/crdt/root';
-import { CRDTObject } from '@yorkie-js-sdk/src/document/crdt/object';
-import { ElementRHT } from '@yorkie-js-sdk/src/document/crdt/element_rht';
-import { ChangeContext } from '@yorkie-js-sdk/src/document/change/context';
-import { ArrayProxy } from '@yorkie-js-sdk/src/document/json/array';
-import { InitialTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { MaxTimeTicket } from '@yorkie-js-sdk/src/document/time/ticket';
-import { RGATreeList } from '@yorkie-js-sdk/src/document/crdt/rga_tree_list';
-import { Primitive } from '@yorkie-js-sdk/src/document/crdt/primitive';
-import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';
-import { CRDTText } from '@yorkie-js-sdk/src/document/crdt/text';
-import { RGATreeSplit } from '@yorkie-js-sdk/src/document/crdt/rga_tree_split';
-import { Text } from '@yorkie-js-sdk/src/yorkie';
-import { MaxVersionVector } from '@yorkie-js-sdk/test/helper/helper';
+import { InitialChangeID } from '@yorkie-js/sdk/src/document/change/change_id';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
+import { CRDTObject } from '@yorkie-js/sdk/src/document/crdt/object';
+import { ElementRHT } from '@yorkie-js/sdk/src/document/crdt/element_rht';
+import { ChangeContext } from '@yorkie-js/sdk/src/document/change/context';
+import { ArrayProxy } from '@yorkie-js/sdk/src/document/json/array';
+import { InitialTimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { MaxTimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { RGATreeList } from '@yorkie-js/sdk/src/document/crdt/rga_tree_list';
+import { Primitive } from '@yorkie-js/sdk/src/document/crdt/primitive';
+import { CRDTArray } from '@yorkie-js/sdk/src/document/crdt/array';
+import { CRDTText } from '@yorkie-js/sdk/src/document/crdt/text';
+import { RGATreeSplit } from '@yorkie-js/sdk/src/document/crdt/rga_tree_split';
+import { Text } from '@yorkie-js/sdk/src/yorkie';
+import { MaxVersionVector } from '@yorkie-js/sdk/test/helper/helper';
 
 describe('ROOT', function () {
   it('basic test', function () {

--- a/packages/sdk/test/unit/document/crdt/tree_test.ts
+++ b/packages/sdk/test/unit/document/crdt/tree_test.ts
@@ -18,7 +18,7 @@ import { describe, it, assert } from 'vitest';
 import {
   InitialTimeTicket as ITT,
   MaxTimeTicket as MTT,
-} from '@yorkie-js-sdk/src/document/time/ticket';
+} from '@yorkie-js/sdk/src/document/time/ticket';
 import {
   CRDTTree,
   CRDTTreeNode,
@@ -26,9 +26,9 @@ import {
   CRDTTreePos,
   toXML,
   TreeNodeForTest,
-} from '@yorkie-js-sdk/src/document/crdt/tree';
-import { stringifyObjectValues } from '@yorkie-js-sdk/src/util/object';
-import { idT, posT, timeT } from '@yorkie-js-sdk/test/helper/helper';
+} from '@yorkie-js/sdk/src/document/crdt/tree';
+import { stringifyObjectValues } from '@yorkie-js/sdk/src/util/object';
+import { idT, posT, timeT } from '@yorkie-js/sdk/test/helper/helper';
 
 describe('CRDTTreeNode', function () {
   it('Can be created', function () {

--- a/packages/sdk/test/unit/document/document_test.ts
+++ b/packages/sdk/test/unit/document/document_test.ts
@@ -19,18 +19,18 @@ import {
   EventCollector,
   MaxVersionVector,
   DefaultSnapshotThreshold,
-} from '@yorkie-js-sdk/test/helper/helper';
+} from '@yorkie-js/sdk/test/helper/helper';
 
-import { Document, DocEventType } from '@yorkie-js-sdk/src/document/document';
-import { OperationInfo } from '@yorkie-js-sdk/src/document/operation/operation';
+import { Document, DocEventType } from '@yorkie-js/sdk/src/document/document';
+import { OperationInfo } from '@yorkie-js/sdk/src/document/operation/operation';
 import yorkie, {
   JSONArray,
   Text,
   Counter,
   Tree,
-} from '@yorkie-js-sdk/src/yorkie';
-import { CounterType } from '@yorkie-js-sdk/src/document/crdt/counter';
-import { withTwoClientsAndDocuments } from '@yorkie-js-sdk/test/integration/integration_helper';
+} from '@yorkie-js/sdk/src/yorkie';
+import { CounterType } from '@yorkie-js/sdk/src/document/crdt/counter';
+import { withTwoClientsAndDocuments } from '@yorkie-js/sdk/test/integration/integration_helper';
 
 describe.sequential('Document', function () {
   afterEach(() => {

--- a/packages/sdk/test/unit/document/gc_test.ts
+++ b/packages/sdk/test/unit/document/gc_test.ts
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-import { CRDTArray } from '@yorkie-js-sdk/src/document/crdt/array';
-import { CRDTTreeNode } from '@yorkie-js-sdk/src/document/crdt/tree';
-import { IndexTreeNode } from '@yorkie-js-sdk/src/util/index_tree';
-import yorkie, { Tree, Text } from '@yorkie-js-sdk/src/yorkie';
-import { MaxVersionVector } from '@yorkie-js-sdk/test/helper/helper';
+import { CRDTArray } from '@yorkie-js/sdk/src/document/crdt/array';
+import { CRDTTreeNode } from '@yorkie-js/sdk/src/document/crdt/tree';
+import { IndexTreeNode } from '@yorkie-js/sdk/src/util/index_tree';
+import yorkie, { Tree, Text } from '@yorkie-js/sdk/src/yorkie';
+import { MaxVersionVector } from '@yorkie-js/sdk/test/helper/helper';
 import { describe, it, assert } from 'vitest';
 
 // `getNodeLength` returns the number of nodes in the given tree.

--- a/packages/sdk/test/unit/util/index_tree_test.ts
+++ b/packages/sdk/test/unit/util/index_tree_test.ts
@@ -15,12 +15,12 @@
  */
 
 import { describe, it, assert } from 'vitest';
-import { buildIndexTree } from '@yorkie-js-sdk/test/helper/helper';
-import { CRDTTreeNode } from '@yorkie-js-sdk/src/document/crdt/tree';
+import { buildIndexTree } from '@yorkie-js/sdk/test/helper/helper';
+import { CRDTTreeNode } from '@yorkie-js/sdk/src/document/crdt/tree';
 import {
   findCommonAncestor,
   IndexTree,
-} from '@yorkie-js-sdk/src/util/index_tree';
+} from '@yorkie-js/sdk/src/util/index_tree';
 
 /**
  * `toDiagnostic` is a helper function that converts the given node to a

--- a/packages/sdk/test/unit/util/llrb_tree_test.ts
+++ b/packages/sdk/test/unit/util/llrb_tree_test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, assert } from 'vitest';
-import { LLRBTree } from '@yorkie-js-sdk/src/util/llrb_tree';
+import { LLRBTree } from '@yorkie-js/sdk/src/util/llrb_tree';
 
 const arrays = [
   [0, 1, 2, 3, 4, 5, 6, 7, 8, 9],

--- a/packages/sdk/test/unit/util/logger_test.ts
+++ b/packages/sdk/test/unit/util/logger_test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, assert } from 'vitest';
-import { logger, setLogLevel, LogLevel } from '@yorkie-js-sdk/src/util/logger';
+import { logger, setLogLevel, LogLevel } from '@yorkie-js/sdk/src/util/logger';
 
 describe('logger', function () {
   it('Can log according to the level.', function () {

--- a/packages/sdk/test/unit/util/splay_tree_test.ts
+++ b/packages/sdk/test/unit/util/splay_tree_test.ts
@@ -15,7 +15,7 @@
  */
 
 import { describe, it, assert } from 'vitest';
-import { SplayNode, SplayTree } from '@yorkie-js-sdk/src/util/splay_tree';
+import { SplayNode, SplayTree } from '@yorkie-js/sdk/src/util/splay_tree';
 
 class StringNode extends SplayNode<string> {
   public removed: Boolean = false;

--- a/packages/sdk/test/vitest.d.ts
+++ b/packages/sdk/test/vitest.d.ts
@@ -15,7 +15,7 @@
  */
 
 import type { Assertion, AsymmetricMatchersContaining } from 'vitest';
-import { Code } from '@yorkie-js-sdk/src/util/error';
+import { Code } from '@yorkie-js/sdk/src/util/error';
 
 interface CustomMatchers<R = unknown> {
   /**

--- a/packages/sdk/test/vitest.setup.ts
+++ b/packages/sdk/test/vitest.setup.ts
@@ -15,7 +15,7 @@
  */
 
 import { expect } from 'vitest';
-import { Code } from '@yorkie-js-sdk/src/util/error';
+import { Code } from '@yorkie-js/sdk/src/util/error';
 
 expect.extend({
   /**

--- a/packages/sdk/tsconfig.json
+++ b/packages/sdk/tsconfig.json
@@ -19,8 +19,8 @@
     /* Paths */
     "baseUrl": ".",
     "paths": {
-      "@yorkie-js-sdk/src/*": ["src/*"],
-      "@yorkie-js-sdk/test/*": ["test/*"]
+      "@yorkie-js/sdk/src/*": ["src/*"],
+      "@yorkie-js/sdk/test/*": ["test/*"]
     },
     "plugins": [
       { "transform": "typescript-transform-paths" },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Refactor import paths to use '@yorkie-js/sdk'

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Standardized module path aliases across all components, examples, and tests for improved consistency and maintainability.
  
- **Chore**
  - Updated project configurations and mapping settings to align with the new naming convention, ensuring smoother module resolution without affecting functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->