### PR TITLE
Add Subscription limit per docuement

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -912,6 +912,10 @@ export class Client {
                 }
               }
             } catch (err) {
+              // Note(emplam27): If the error is a connection limit exceeded error,
+              // check in this method and handle it.
+              this.checkIfConnectionLimitExceeded(err);
+
               attachment.doc.resetOnlineClients();
               attachment.doc.publish([
                 {
@@ -1138,5 +1142,18 @@ export class Client {
     }
 
     this.processNext();
+  }
+
+  /**
+   * `checkIfConnectionLimitExceeded` check an error if the given error is
+   * `ConnectError` and the error code is `ErrConnectionLimitExceeded`.
+   */
+  public checkIfConnectionLimitExceeded(err: any) {
+    if (
+      err instanceof ConnectError &&
+      errorCodeOf(err) === Code.ErrConnectionLimitExceeded
+    ) {
+      logger.error(`[WD] c:"${this.getKey()}" err :`, err.rawMessage);
+    }
   }
 }

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -1151,7 +1151,7 @@ export class Client {
   public checkIfConnectionLimitExceeded(err: any) {
     if (
       err instanceof ConnectError &&
-      errorCodeOf(err) === Code.ErrConnectionLimitExceeded
+      errorCodeOf(err) === Code.ErrSubscriptionLimitExceeded
     ) {
       logger.error(`[WD] c:"${this.getKey()}" err :`, err.rawMessage);
     }

--- a/packages/sdk/src/util/error.ts
+++ b/packages/sdk/src/util/error.ts
@@ -66,8 +66,8 @@ export enum Code {
   // ErrUnauthenticated is returned when the request does not have valid authentication credentials.
   ErrUnauthenticated = 'ErrUnauthenticated',
 
-  // ErrConnectionLimitExceeded is returned when the connection limit is exceeded.
-  ErrConnectionLimitExceeded = 'ErrConnectionLimitExceeded',
+  // ErrSubscriptionLimitExceeded is returned when the connection limit is exceeded.
+  ErrSubscriptionLimitExceeded = 'ErrSubscriptionLimitExceeded',
 }
 
 /**

--- a/packages/sdk/src/util/error.ts
+++ b/packages/sdk/src/util/error.ts
@@ -65,6 +65,9 @@ export enum Code {
 
   // ErrUnauthenticated is returned when the request does not have valid authentication credentials.
   ErrUnauthenticated = 'ErrUnauthenticated',
+
+  // ErrConnectionLimitExceeded is returned when the connection limit is exceeded.
+  ErrConnectionLimitExceeded = 'ErrConnectionLimitExceeded',
 }
 
 /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

- Add limit the number of subscription stream per document.
- When the `ErrSubscriptionLimitExceeded`error occured, client tries to reconnect subscription.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Didn't break anything
