### PR TITLE
Handle Attachment Limit per Document

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -1103,6 +1103,13 @@ export class Client {
       return true;
     }
 
+    // NOTE(emplam27): If the error is 'ErrTooManyAttachments' it means,
+    // that the client has reached the maximum number of allowed attachments.
+    // In this case, the client should remove some attachments.
+    if (errorCodeOf(err) === Code.ErrTooManyAttachments) {
+      return false;
+    }
+
     // NOTE(hackerwins): Some errors should fix the state of the client.
     if (
       errorCodeOf(err) === Code.ErrClientNotActivated ||

--- a/packages/sdk/src/util/error.ts
+++ b/packages/sdk/src/util/error.ts
@@ -68,6 +68,9 @@ export enum Code {
 
   // ErrTooManySubscribers is returned when the number of subscribers exceeds the limit.
   ErrTooManySubscribers = 'ErrTooManySubscribers',
+
+  // ErrTooManyAttachments is returned when the number of attachments exceeds the limit.
+  ErrTooManyAttachments = 'ErrTooManyAttachments',
 }
 
 /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

- Add limit the number of attachment per document.
- When the ErrAttachmentLimitExceedederror occured, client throw the error and not retry attach document.
- 
#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced error handling for attachment limits to prevent unnecessary retries when the maximum number of attachments is exceeded.
- **Chores**
  - Added a new error identifier to support the updated handling logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->