### PR TITLE
Support StrictMode in React Standalone Mode

### DIFF
--- a/examples/react-flow/src/main.tsx
+++ b/examples/react-flow/src/main.tsx
@@ -2,6 +2,7 @@ import { createRoot } from 'react-dom/client';
 import { DocumentProvider, YorkieProvider } from '@yorkie-js/react';
 import './index.css';
 import App from './App';
+import { StrictMode } from 'react';
 
 const initialNodes = [
   {
@@ -42,18 +43,21 @@ const initialGraph = {
 };
 
 createRoot(document.getElementById('root')!).render(
-  <YorkieProvider
-    apiKey={import.meta.env.VITE_YORKIE_API_KEY}
-    rpcAddr={import.meta.env.VITE_YORKIE_API_ADDR}
-  >
-    <DocumentProvider
-      docKey={`react-flow-${new Date()
-        .toISOString()
-        .substring(0, 10)
-        .replace(/-/g, '')}`}
-      initialRoot={initialGraph}
+  <StrictMode>
+    <YorkieProvider
+      apiKey={import.meta.env.VITE_YORKIE_API_KEY}
+      rpcAddr={import.meta.env.VITE_YORKIE_API_ADDR}
     >
-      <App />
-    </DocumentProvider>
-  </YorkieProvider>,
+      <DocumentProvider
+        docKey={`react-flow-${new Date()
+          .toISOString()
+          .substring(0, 10)
+          .replace(/-/g, '')}`}
+        initialRoot={initialGraph}
+      >
+        <App />
+      </DocumentProvider>
+    </YorkieProvider>
+    ,
+  </StrictMode>,
 );


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This commit adds support for StrictMode in React's standalone mode,
updating the interface to be on par with the Provider mode.
Additionally, it removes existing duplicate logic to streamline the
codebase and enhance maintainability.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced `StrictMode` for enhanced runtime validations and warnings.
  - Added custom hooks for improved management of Yorkie client and document states, including `useYorkieClient` and `useYorkieDocument`.
  - Enhanced presence tracking in document management.

- **Refactor**
  - Restructured state management for document and client interactions, leading to more responsive real-time updates.
  - Optimized provider coordination for smoother application performance and reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->