### PR TITLE
Doc size

### DIFF
--- a/packages/sdk/public/index.html
+++ b/packages/sdk/public/index.html
@@ -73,6 +73,12 @@
             ></path>
           </svg>
           <div><span id="network-status"></span></div>
+          <!--          <div id="doc-size" style="margin-left: 16px; font-family: monospace;">-->
+          <!--            Size: 0.00 KB-->
+          <!--          </div>-->
+          <div style="margin-left: 8px; font-family: monospace">
+            <span id="memory-usage-text">Memory: -</span>
+          </div>
         </div>
         <div class="center-tools tools">
           <label style="display: flex; align-items: center">
@@ -310,6 +316,20 @@
         }
       }
 
+      function updateMemoryUsageDisplay(doc) {
+        const usage = doc.getMemoryUsage();
+        if (!usage) return;
+
+        document.getElementById('memory-usage-text').textContent =
+          `Memory: live=${usage.live}B, ` +
+          `gc=${usage.gc}B, ` +
+          `total=${usage.total}B`;
+
+        //           `Memory: live=${(usage.live / 1024).toFixed(2)}KiB, ` +
+        //           `gc=${(usage.gc / 1024).toFixed(2)}KiB, ` +
+        //           `total=${(usage.total / 1024).toFixed(2)}KiB`;
+      }
+
       async function main() {
         try {
           // 01. create an instance of codemirror.
@@ -323,6 +343,7 @@
           const client = new yorkie.Client({
             rpcAddr: 'http://localhost:8080',
           });
+
           // 02-2. activate client
           await client.activate();
 
@@ -372,6 +393,7 @@
             if (event.type === 'remote-change') {
               const { actor, operations } = event.value;
               handleOperations(operations, actor);
+              updateMemoryUsageDisplay(doc);
 
               const textLength = codemirror.getValue().length;
               if (
@@ -416,6 +438,7 @@
             ) {
               debugger;
             }
+            updateMemoryUsageDisplay(doc);
           });
 
           codemirror.on('beforeSelectionChange', (cm, change) => {
@@ -457,6 +480,7 @@
 
           // 05. synchronize text of document and codemirror.
           codemirror.setValue(doc.getRoot().content.toString());
+          updateMemoryUsageDisplay(doc);
           devtool.displayLog(doc, codemirror);
           for (const user of doc.getPresences()) {
             if (user.clientID === client.getID()) continue;

--- a/packages/sdk/src/document/crdt/array.ts
+++ b/packages/sdk/src/document/crdt/array.ts
@@ -126,7 +126,13 @@ export class CRDTArray extends CRDTContainer {
    * `delete` deletes the element of the given creation time.
    */
   public delete(createdAt: TimeTicket, editedAt: TimeTicket): CRDTElement {
-    return this.elements.delete(createdAt, editedAt);
+    const [deletedElem, memoryUsage] = this.elements.delete(
+      createdAt,
+      editedAt,
+    );
+    this.updateUsage(memoryUsage);
+
+    return deletedElem;
   }
 
   /**
@@ -136,7 +142,15 @@ export class CRDTArray extends CRDTContainer {
     index: number,
     editedAt: TimeTicket,
   ): CRDTElement | undefined {
-    return this.elements.deleteByIndex(index, editedAt);
+    const result = this.elements.deleteByIndex(index, editedAt);
+
+    if (!result) {
+      return;
+    }
+    const [deletedElem, memoryUsage] = result;
+    this.updateUsage(memoryUsage);
+
+    return deletedElem;
   }
 
   /**

--- a/packages/sdk/src/document/crdt/element.ts
+++ b/packages/sdk/src/document/crdt/element.ts
@@ -16,6 +16,7 @@
 
 import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
 import type * as Devtools from '@yorkie-js/sdk/src/devtools/types';
+import { MemoryUsage } from '@yorkie-js/sdk/src/util/memory';
 
 /**
  * `CRDTElement` represents an element that has `TimeTicket`s.
@@ -27,8 +28,35 @@ export abstract class CRDTElement {
   private movedAt?: TimeTicket;
   private removedAt?: TimeTicket;
 
+  private usage: MemoryUsage;
+  protected parent?: CRDTContainer;
+
   constructor(createdAt: TimeTicket) {
     this.createdAt = createdAt;
+    this.usage = new MemoryUsage();
+  }
+
+  /**
+   * `setParent` sets the parent of this element.
+   */
+  public setParent(parent: CRDTContainer): void {
+    this.parent = parent;
+  }
+
+  /**
+   * `updateUsage` updates the memory usage of this element.
+   */
+  public updateUsage(diff: MemoryUsage): void {
+    this.usage.merge(diff);
+    this.parent?.updateUsage(diff);
+  }
+
+  /**
+   * `getMemoryUsage` summaries the memory usage of this element,
+   * distinguishing between live and logically removed elements.
+   */
+  public getMemoryUsage(): MemoryUsage {
+    return this.usage;
   }
 
   /**

--- a/packages/sdk/src/document/crdt/object.ts
+++ b/packages/sdk/src/document/crdt/object.ts
@@ -22,6 +22,10 @@ import {
 } from '@yorkie-js/sdk/src/document/crdt/element';
 import { ElementRHT } from '@yorkie-js/sdk/src/document/crdt/element_rht';
 import type * as Devtools from '@yorkie-js/sdk/src/devtools/types';
+import {
+  calculateValueSize,
+  MemoryUsage,
+} from '@yorkie-js/sdk/src/util/memory';
 
 /**
  * `CRDTObject` represents an object data type, but unlike regular JSON,
@@ -34,6 +38,23 @@ export class CRDTObject extends CRDTContainer {
   constructor(createdAt: TimeTicket, memberNodes: ElementRHT) {
     super(createdAt);
     this.memberNodes = memberNodes;
+  }
+
+  /**
+   * `calculateUsage` returns the size in bytes of CRDTObject.
+   */
+  public calculateUsage(): MemoryUsage {
+    const usage = this.memberNodes.calculateUsage();
+
+    usage.meta += calculateValueSize(this.getCreatedAt());
+    if (this.getMovedAt()) {
+      usage.meta += calculateValueSize(this.getMovedAt());
+    }
+    if (this.getRemovedAt()) {
+      usage.meta += calculateValueSize(this.getRemovedAt());
+    }
+
+    return usage;
   }
 
   /**

--- a/packages/sdk/src/util/llrb_tree.ts
+++ b/packages/sdk/src/util/llrb_tree.ts
@@ -18,6 +18,12 @@ import {
   Comparator,
   DefaultComparator,
 } from '@yorkie-js/sdk/src/util/comparator';
+import {
+  calculateValueSize,
+  MemoryMeasurable,
+  MemoryUsage,
+  PTRSize,
+} from '@yorkie-js/sdk/src/util/memory';
 
 interface Entry<K, V> {
   key: K;
@@ -27,7 +33,7 @@ interface Entry<K, V> {
 /**
  * `LLRBNode` is node of LLRBTree.
  */
-class LLRBNode<K, V> {
+class LLRBNode<K, V> implements MemoryMeasurable {
   public key: K;
   public value: V;
   public parent?: LLRBNode<K, V>;
@@ -39,6 +45,16 @@ class LLRBNode<K, V> {
     this.key = key;
     this.value = value;
     this.isRed = isRed;
+  }
+
+  /**
+   * `calculateUsage` returns the size in bytes of LLRBNode.
+   */
+  calculateUsage(): MemoryUsage {
+    const keySize = calculateValueSize(this.key);
+    const ptr = PTRSize * 3;
+
+    return new MemoryUsage(keySize + ptr + PTRSize, 0);
   }
 }
 

--- a/packages/sdk/src/util/memory.ts
+++ b/packages/sdk/src/util/memory.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * `memory.ts` provides utility functions to memory usage and
+ * serialized size of various JS values and CRDT components.
+ */
+
+export const PTRSize = 8;
+
+/**
+ * `MemoryUsage` represents the memory usage of a CRDT element,
+ * separated into live and garbage-collected components.
+ */
+export class MemoryUsage {
+  constructor(
+    public meta: number = 0,
+    public content: number = 0,
+    public gc: number = 0,
+  ) {}
+
+  /**
+   * `live` returns the total memory usage of metadata and content (excluding GC).
+   */
+  get live(): number {
+    return this.meta + this.content;
+  }
+
+  /**
+   * `total` returns the total memory usage, which is the sum of live and gc memory.
+   */
+  get total(): number {
+    return this.live + this.gc;
+  }
+
+  /**
+   * `merge` combines the memory usage of two CRDT elements.
+   */
+  merge(other: MemoryUsage): void {
+    this.meta += other.meta;
+    this.content += other.content;
+    this.gc += other.gc;
+  }
+
+  /**
+   * `transferLiveToGC` transfers the live (meta + content) usage of the given
+   * element to the GC usage.
+   */
+  transferLiveToGC(other: MemoryUsage): void {
+    this.meta -= other.meta;
+    this.content -= other.content;
+    this.gc += other.meta + other.content;
+  }
+}
+
+/**
+ * `MemoryMeasurable` defines an interface for elements that can calculate their memory usage.
+ */
+export interface MemoryMeasurable {
+  calculateUsage(): MemoryUsage;
+}
+
+/**
+ * `isMemoryMeasurable` checks if the given object implements MemoryMeasurable.
+ */
+export function isMemoryMeasurable(obj: unknown): obj is MemoryMeasurable {
+  return (
+    !!obj && typeof (obj as MemoryMeasurable).calculateUsage === 'function'
+  );
+}
+
+/**
+ * `calculateValueSize` returns the size of various types.
+ */
+export function calculateValueSize(value: unknown): number {
+  switch (typeof value) {
+    case 'string':
+      return value.length * 2;
+    case 'number':
+      return 8;
+    case 'boolean':
+      return 4;
+    case 'bigint':
+      return value.toString().length * 2;
+    case 'undefined':
+      return 4;
+    case 'object':
+      return calculateObjectSize(value as Record<string, unknown>);
+    default:
+      return 0;
+  }
+}
+
+/**
+ * `calculateObjectSize` returns the size in bytes of a plain object,
+ * including keys and values.
+ */
+export function calculateObjectSize(obj: Record<string, unknown>): number {
+  let size = 0;
+  for (const [key, value] of Object.entries(obj)) {
+    size += calculateValueSize(key) + calculateValueSize(value);
+  }
+  return size;
+}

--- a/packages/sdk/src/util/splay_tree.ts
+++ b/packages/sdk/src/util/splay_tree.ts
@@ -15,11 +15,16 @@
  */
 
 import { Code, YorkieError } from './error';
+import {
+  MemoryMeasurable,
+  MemoryUsage,
+  PTRSize,
+} from '@yorkie-js/sdk/src/util/memory';
 
 /**
  * `SplayNode` is a node of SplayTree.
  */
-export abstract class SplayNode<V> {
+export abstract class SplayNode<V> implements MemoryMeasurable {
   protected value: V;
 
   private left?: SplayNode<V>;
@@ -30,6 +35,13 @@ export abstract class SplayNode<V> {
   constructor(value: V) {
     this.value = value;
     this.initWeight();
+  }
+
+  /**
+   * `calculateUsage` returns the size in bytes of SplayNode.
+   */
+  calculateUsage(): MemoryUsage {
+    return new MemoryUsage(PTRSize * 4 + 8, 0);
   }
 
   abstract getLength(): number;


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR introduces memory usage estimation for CRDT data structures, starting with `CRDTText`.

We track estimated memory usage of a document by calculating the live and GC (garbage-collectable) memory at the time of every edit.  
The tracked values are accumulated and cached within each `CRDTElement`, and propagated up to the root via `updateEstimatedSize`.

This is essential groundwork for monitoring and limiting document size in runtime environments.

#### Any background context you want to provide?
- `MemoryUsage`: A utility class representing live, GC, and total memory.
- `MemoryMeasurable`: Interface for CRDT types to implement `estimateMemoryUsage()`.
- Changes are applied incrementally on mutation (e.g., `edit`) to avoid deep traversal.
- Final memory usage can be retrieved via `Document.getMemoryUsage()`.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related https://github.com/yorkie-team/yorkie/issues/158

### Checklist
- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything
