### PR TITLE
Refactor client initialization to use options for rpcAddr

### DIFF
--- a/examples/nextjs-scheduler/app/page.tsx
+++ b/examples/nextjs-scheduler/app/page.tsx
@@ -89,7 +89,8 @@ export default function Editor() {
 
   useEffect(() => {
     // create Yorkie Client at client-side
-    const client = new yorkie.Client(ENV.url, {
+    const client = new yorkie.Client({
+      rpcAddr: ENV.url,
       apiKey: ENV.apiKey,
     });
 

--- a/examples/react-todomvc/src/App.tsx
+++ b/examples/react-todomvc/src/App.tsx
@@ -1,4 +1,9 @@
-import { JSONArray, JSONObject, useDocument } from '@yorkie-js/react';
+import {
+  JSONArray,
+  JSONObject,
+  useDocument,
+  useYorkieDoc,
+} from '@yorkie-js/react';
 
 import Header from './Header';
 import MainSection from './MainSection';
@@ -11,9 +16,20 @@ import 'todomvc-app-css/index.css';
  * `App` is the root component of the application.
  */
 export default function App() {
-  const { root, update, loading, error } = useDocument<{
+  const { root, update, loading, error } = useYorkieDoc<{
     todos: JSONArray<Todo>;
-  }>();
+  }>(
+    import.meta.env.VITE_YORKIE_API_KEY,
+    `react-todomvc-${new Date()
+      .toISOString()
+      .substring(0, 10)
+      .replace(/-/g, '')}`,
+    {
+      initialRoot: {
+        todos: [],
+      },
+    },
+  );
 
   if (loading) return <div>Loading...</div>;
   if (error) return <div>Error: {error.message}</div>;

--- a/examples/react-todomvc/src/main.tsx
+++ b/examples/react-todomvc/src/main.tsx
@@ -1,6 +1,7 @@
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import { DocumentProvider, YorkieProvider } from '@yorkie-js/react';
+import { StrictMode } from 'react';
 
 const initalRoot = {
   todos: [
@@ -11,15 +12,7 @@ const initalRoot = {
 };
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  <YorkieProvider
-    apiKey={import.meta.env.VITE_YORKIE_API_KEY}
-    rpcAddr={import.meta.env.VITE_YORKIE_API_ADDR}
-  >
-    <DocumentProvider
-      docKey={`react-todomvc-${new Date().toISOString().substring(0, 10).replace(/-/g, '')}`}
-      initialRoot={initalRoot}
-    >
-      <App />
-    </DocumentProvider>
-  </YorkieProvider>,
+  <StrictMode>
+    <App />
+  </StrictMode>,
 );

--- a/examples/vanilla-codemirror6/src/main.ts
+++ b/examples/vanilla-codemirror6/src/main.ts
@@ -16,7 +16,8 @@ const networkStatusElem = document.getElementById('network-status')!;
 
 async function main() {
   // 01. create client with RPCAddr then activate it.
-  const client = new yorkie.Client(import.meta.env.VITE_YORKIE_API_ADDR, {
+  const client = new yorkie.Client({
+    rpcAddr: import.meta.env.VITE_YORKIE_API_ADDR,
     apiKey: import.meta.env.VITE_YORKIE_API_KEY,
   });
   await client.activate();

--- a/examples/vanilla-document-limit/src/main.ts
+++ b/examples/vanilla-document-limit/src/main.ts
@@ -19,7 +19,8 @@ const counterContainerElem = document.getElementById('counter-container');
  * Main function
  */
 async function main() {
-  const client = new yorkie.Client(import.meta.env.VITE_YORKIE_API_ADDR, {
+  const client = new yorkie.Client({
+    rpcAddr: import.meta.env.VITE_YORKIE_API_ADDR,
     apiKey: import.meta.env.VITE_YORKIE_API_KEY,
   });
   await client.activate();

--- a/examples/vanilla-quill/src/main.ts
+++ b/examples/vanilla-quill/src/main.ts
@@ -40,7 +40,8 @@ function toDeltaOperation<T extends TextValueType>(
 
 async function main() {
   // 01-1. create client with RPCAddr then activate it.
-  const client = new yorkie.Client(import.meta.env.VITE_YORKIE_API_ADDR, {
+  const client = new yorkie.Client({
+    rpcAddr: import.meta.env.VITE_YORKIE_API_ADDR,
     apiKey: import.meta.env.VITE_YORKIE_API_KEY,
   });
   await client.activate();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "private": true,
   "description": "A collection of tools and examples for Yorkie",
   "scripts": {
+    "prepare": "husky",
     "preinstall": "npx only-allow pnpm",
+    "build:examples": "pnpm --filter './examples/*' run build",
+    "build:packages": "pnpm --filter './packages/*' run build",
+    "lint": "eslint . --fix --max-warnings=0 --ext .ts",
     "sdk": "pnpm --filter=@yorkie-js/sdk",
     "devtools": "pnpm --filter=@yorkie-js/devtools",
     "react": "pnpm --filter=@yorkie-js/react",
@@ -20,10 +24,7 @@
     "vanilla-quill": "pnpm --filter=vanilla-quill",
     "vuejs-kanban": "pnpm --filter=vuejs-kanban",
     "react-document-limit": "pnpm --filter=react-document-limit",
-    "vanilla-document-limit": "pnpm --filter=vanilla-document-limit",
-    "build:examples": "pnpm --filter './examples/*' run build",
-    "lint": "eslint . --fix --max-warnings=0 --ext .ts",
-    "prepare": "husky"
+    "vanilla-document-limit": "pnpm --filter=vanilla-document-limit"
   },
   "keywords": [],
   "author": {

--- a/packages/react/src/YorkieProvider.tsx
+++ b/packages/react/src/YorkieProvider.tsx
@@ -73,7 +73,8 @@ export function useYorkieClient(apiKey: string, rpcAddr: string) {
       }
 
       try {
-        const newClient = new Client(rpcAddr, {
+        const newClient = new Client({
+          rpcAddr,
           apiKey,
         });
         await newClient.activate();

--- a/packages/sdk/public/counter.html
+++ b/packages/sdk/public/counter.html
@@ -37,7 +37,9 @@
       async function main() {
         try {
           // 01. create client with RPCAddr then activate it.
-          const client = new yorkie.Client('http://localhost:8080');
+          const client = new yorkie.Client({
+            rpcAddr: 'http://localhost:8080',
+          });
           await client.activate();
 
           // 02. create a document then attach it into the client.

--- a/packages/sdk/public/drawing.html
+++ b/packages/sdk/public/drawing.html
@@ -38,7 +38,8 @@
       async function main() {
         try {
           // 01. create client with RPCAddr then activate it.
-          const client = new yorkie.Client('http://localhost:8080', {
+          const client = new yorkie.Client({
+            rpcAddr: 'http://localhost:8080',
             syncLoopDuration: 0,
             reconnectStreamDelay: 1000,
           });

--- a/packages/sdk/public/index.html
+++ b/packages/sdk/public/index.html
@@ -320,7 +320,9 @@
           devtool.setCodeMirror(codemirror);
 
           // 02-1. create client with RPCAddr.
-          const client = new yorkie.Client('http://localhost:8080');
+          const client = new yorkie.Client({
+            rpcAddr: 'http://localhost:8080',
+          });
           // 02-2. activate client
           await client.activate();
 

--- a/packages/sdk/public/multi.html
+++ b/packages/sdk/public/multi.html
@@ -79,7 +79,9 @@
       async function main() {
         try {
           // 01-1. create client with RPCAddr.
-          const client = new yorkie.Client('http://localhost:8080');
+          const client = new yorkie.Client({
+            rpcAddr: 'http://localhost:8080',
+          });
           // 01-2. activate client
           await client.activate();
 

--- a/packages/sdk/public/prosemirror.html
+++ b/packages/sdk/public/prosemirror.html
@@ -252,7 +252,7 @@
        * main is the entry point of the example.
        */
       async function main() {
-        const client = new yorkie.Client('http://localhost:8080');
+        const client = new yorkie.Client({ rpcAddr: 'http://localhost:8080' });
         await client.activate();
 
         // 01. Build yorkie.Text from ProseMirror doc.

--- a/packages/sdk/public/quill-two-clients.html
+++ b/packages/sdk/public/quill-two-clients.html
@@ -142,7 +142,9 @@
         try {
           async function initializeRealtimeEditor(clientElem) {
             // 01. create client with RPCAddr(envoy) then activate it.
-            const client = new yorkie.Client('http://localhost:8080');
+            const client = new yorkie.Client({
+              rpcAddr: 'http://localhost:8080',
+            });
             await client.activate();
             const clientID = client.getID().slice(-2);
             clientElem.querySelector('.client-id').textContent = clientID;

--- a/packages/sdk/public/quill.html
+++ b/packages/sdk/public/quill.html
@@ -64,7 +64,9 @@
       async function main() {
         try {
           // 01. create client with RPCAddr then activate it.
-          const client = new yorkie.Client('http://localhost:8080');
+          const client = new yorkie.Client({
+            rpcAddr: 'http://localhost:8080',
+          });
           await client.activate();
 
           // 02. create a document then attach it into the client.

--- a/packages/sdk/public/whiteboard.html
+++ b/packages/sdk/public/whiteboard.html
@@ -254,7 +254,9 @@
       async function main() {
         try {
           // 01. create client with RPCAddr then activate it.
-          const client = new yorkie.Client('http://localhost:8080');
+          const client = new yorkie.Client({
+            rpcAddr: 'http://localhost:8080',
+          });
           await client.activate();
           const myClientID = client.getID();
 

--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -1426,8 +1426,8 @@ export class CRDTTree extends CRDTElement implements GCParent {
       const treePos = node.isText
         ? { node, offset: 0 }
         : parentNode && leftChildNode
-        ? this.toTreePos(parentNode, leftChildNode)
-        : null;
+          ? this.toTreePos(parentNode, leftChildNode)
+          : null;
 
       if (treePos) {
         index = this.indexTree.indexOf(treePos);

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -483,14 +483,14 @@ export type DocKey = string;
 type OperationInfoOfElement<TElement> = TElement extends Text
   ? TextOperationInfo
   : TElement extends Counter
-  ? CounterOperationInfo
-  : TElement extends Tree
-  ? TreeOperationInfo
-  : TElement extends BaseArray<any>
-  ? ArrayOperationInfo
-  : TElement extends BaseObject<any>
-  ? ObjectOperationInfo
-  : OperationInfo;
+    ? CounterOperationInfo
+    : TElement extends Tree
+      ? TreeOperationInfo
+      : TElement extends BaseArray<any>
+        ? ArrayOperationInfo
+        : TElement extends BaseObject<any>
+          ? ObjectOperationInfo
+          : OperationInfo;
 
 /**
  * `OperationInfoOfInternal` represents the type of the operation info of the
@@ -511,24 +511,24 @@ type OperationInfoOfInternal<
 > = TDepth extends 0
   ? TElement
   : TKeyOrPath extends `${infer TFirst}.${infer TRest}`
-  ? TFirst extends keyof TElement
-    ? TElement[TFirst] extends BaseArray<unknown>
-      ? OperationInfoOfInternal<
-          TElement[TFirst],
-          number,
-          DecreasedDepthOf<TDepth>
-        >
-      : OperationInfoOfInternal<
-          TElement[TFirst],
-          TRest,
-          DecreasedDepthOf<TDepth>
-        >
-    : OperationInfo
-  : TKeyOrPath extends keyof TElement
-  ? TElement[TKeyOrPath] extends BaseArray<unknown>
-    ? ArrayOperationInfo
-    : OperationInfoOfElement<TElement[TKeyOrPath]>
-  : OperationInfo;
+    ? TFirst extends keyof TElement
+      ? TElement[TFirst] extends BaseArray<unknown>
+        ? OperationInfoOfInternal<
+            TElement[TFirst],
+            number,
+            DecreasedDepthOf<TDepth>
+          >
+        : OperationInfoOfInternal<
+            TElement[TFirst],
+            TRest,
+            DecreasedDepthOf<TDepth>
+          >
+      : OperationInfo
+    : TKeyOrPath extends keyof TElement
+      ? TElement[TKeyOrPath] extends BaseArray<unknown>
+        ? ArrayOperationInfo
+        : OperationInfoOfElement<TElement[TKeyOrPath]>
+      : OperationInfo;
 
 /**
  * `DecreasedDepthOf` represents the type of the decreased depth of the given depth.
@@ -536,24 +536,24 @@ type OperationInfoOfInternal<
 type DecreasedDepthOf<Depth extends number = 0> = Depth extends 10
   ? 9
   : Depth extends 9
-  ? 8
-  : Depth extends 8
-  ? 7
-  : Depth extends 7
-  ? 6
-  : Depth extends 6
-  ? 5
-  : Depth extends 5
-  ? 4
-  : Depth extends 4
-  ? 3
-  : Depth extends 3
-  ? 2
-  : Depth extends 2
-  ? 1
-  : Depth extends 1
-  ? 0
-  : -1;
+    ? 8
+    : Depth extends 8
+      ? 7
+      : Depth extends 7
+        ? 6
+        : Depth extends 6
+          ? 5
+          : Depth extends 5
+            ? 4
+            : Depth extends 4
+              ? 3
+              : Depth extends 3
+                ? 2
+                : Depth extends 2
+                  ? 1
+                  : Depth extends 1
+                    ? 0
+                    : -1;
 
 /**
  * `PathOfInternal` represents the type of the path of the given element.
@@ -565,29 +565,29 @@ type PathOfInternal<
 > = Depth extends 0
   ? Prefix
   : TElement extends Record<string, any>
-  ? {
-      [TKey in keyof TElement]: TElement[TKey] extends LeafElement
-        ? `${Prefix}${TKey & string}`
-        : TElement[TKey] extends BaseArray<infer TArrayElement>
-        ?
-            | `${Prefix}${TKey & string}`
-            | `${Prefix}${TKey & string}.${number}`
-            | PathOfInternal<
-                TArrayElement,
-                `${Prefix}${TKey & string}.${number}.`,
-                DecreasedDepthOf<Depth>
-              >
-        :
-            | `${Prefix}${TKey & string}`
-            | PathOfInternal<
-                TElement[TKey],
-                `${Prefix}${TKey & string}.`,
-                DecreasedDepthOf<Depth>
-              >;
-    }[keyof TElement]
-  : Prefix extends `${infer TRest}.`
-  ? TRest
-  : Prefix;
+    ? {
+        [TKey in keyof TElement]: TElement[TKey] extends LeafElement
+          ? `${Prefix}${TKey & string}`
+          : TElement[TKey] extends BaseArray<infer TArrayElement>
+            ?
+                | `${Prefix}${TKey & string}`
+                | `${Prefix}${TKey & string}.${number}`
+                | PathOfInternal<
+                    TArrayElement,
+                    `${Prefix}${TKey & string}.${number}.`,
+                    DecreasedDepthOf<Depth>
+                  >
+            :
+                | `${Prefix}${TKey & string}`
+                | PathOfInternal<
+                    TElement[TKey],
+                    `${Prefix}${TKey & string}.`,
+                    DecreasedDepthOf<Depth>
+                  >;
+      }[keyof TElement]
+    : Prefix extends `${infer TRest}.`
+      ? TRest
+      : Prefix;
 
 /**
  * `OperationInfoOf` represents the type of the operation info of the given
@@ -616,7 +616,7 @@ type PathOf<TDocument, Depth extends number = 10> = PathOfInternal<
  *
  * @public
  */
-export class Document<T, P extends Indexable = Indexable> {
+export class Document<R, P extends Indexable = Indexable> {
   private key: DocKey;
   private status: DocStatus;
   private opts: DocumentOptions;
@@ -694,7 +694,7 @@ export class Document<T, P extends Indexable = Indexable> {
    * `update` executes the given updater to update this document.
    */
   public update(
-    updater: (root: JSONObject<T>, presence: Presence<P>) => void,
+    updater: (root: JSONObject<R>, presence: Presence<P>) => void,
     message?: string,
   ): void {
     if (this.getStatus() === DocStatus.Removed) {
@@ -712,7 +712,7 @@ export class Document<T, P extends Indexable = Indexable> {
     );
 
     try {
-      const proxy = createJSON<JSONObject<T>>(
+      const proxy = createJSON<JSONObject<R>>(
         context,
         this.clone!.root.getObject(),
       );
@@ -879,8 +879,8 @@ export class Document<T, P extends Indexable = Indexable> {
    * The callback will be called when the targetPath or any of its nested values change.
    */
   public subscribe<
-    TPath extends PathOf<T>,
-    TOperationInfo extends OperationInfoOf<T, TPath>,
+    TPath extends PathOf<R>,
+    TOperationInfo extends OperationInfoOf<R, TPath>,
   >(
     targetPath: TPath,
     next: NextFn<
@@ -929,8 +929,8 @@ export class Document<T, P extends Indexable = Indexable> {
    * `subscribe` registers a callback to subscribe to events on the document.
    */
   public subscribe<
-    TPath extends PathOf<T>,
-    TOperationInfo extends OperationInfoOf<T, TPath>,
+    TPath extends PathOf<R>,
+    TOperationInfo extends OperationInfoOf<R, TPath>,
   >(
     arg1: TPath | DocEventTopic | DocEventCallbackMap<P>['default'],
     arg2?:
@@ -1353,7 +1353,7 @@ export class Document<T, P extends Indexable = Indexable> {
   /**
    * `getRoot` returns a new proxy of cloned root.
    */
-  public getRoot(): JSONObject<T> {
+  public getRoot(): JSONObject<R> {
     this.ensureClone();
 
     const context = ChangeContext.create(
@@ -1361,7 +1361,7 @@ export class Document<T, P extends Indexable = Indexable> {
       this.clone!.root,
       this.clone!.presences.get(this.changeID.getActorID()) || ({} as P),
     );
-    return createJSON<T>(context, this.clone!.root.getObject());
+    return createJSON<R>(context, this.clone!.root.getObject());
   }
 
   /**

--- a/packages/sdk/src/document/json/array.ts
+++ b/packages/sdk/src/document/json/array.ts
@@ -557,8 +557,8 @@ export class ArrayProxy {
       deleteCount === undefined
         ? length
         : deleteCount < 0
-        ? from
-        : Math.min(from + deleteCount, length);
+          ? from
+          : Math.min(from + deleteCount, length);
     const removeds: JSONArray<JSONElement> = [];
     for (let i = from; i < to; i++) {
       const removed = ArrayProxy.deleteInternalByIndex(context, target, from);
@@ -598,8 +598,8 @@ export class ArrayProxy {
       fromIndex === undefined
         ? 0
         : fromIndex < 0
-        ? Math.max(fromIndex + length, 0)
-        : fromIndex;
+          ? Math.max(fromIndex + length, 0)
+          : fromIndex;
 
     if (from >= length) return false;
 
@@ -634,8 +634,8 @@ export class ArrayProxy {
       fromIndex === undefined
         ? 0
         : fromIndex < 0
-        ? Math.max(fromIndex + length, 0)
-        : fromIndex;
+          ? Math.max(fromIndex + length, 0)
+          : fromIndex;
 
     if (from >= length) return -1;
 
@@ -670,8 +670,8 @@ export class ArrayProxy {
       fromIndex === undefined || fromIndex >= length
         ? length - 1
         : fromIndex < 0
-        ? fromIndex + length
-        : fromIndex;
+          ? fromIndex + length
+          : fromIndex;
 
     if (from < 0) return -1;
 

--- a/packages/sdk/test/helper/helper.ts
+++ b/packages/sdk/test/helper/helper.ts
@@ -122,10 +122,13 @@ export function deepSort(target: any): any {
   if (typeof target === 'object') {
     return Object.keys(target)
       .sort()
-      .reduce((result, key) => {
-        result[key] = deepSort(target[key]);
-        return result;
-      }, {} as Record<string, any>);
+      .reduce(
+        (result, key) => {
+          result[key] = deepSort(target[key]);
+          return result;
+        },
+        {} as Record<string, any>,
+      );
   }
   return target;
 }

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -45,7 +45,8 @@ describe.sequential('Client', function () {
 
   it('Can be activated, deactivated', async function ({ task }) {
     const clientKey = `${task.name}-${new Date().getTime()}`;
-    const clientWithKey = new yorkie.Client(testRPCAddr, {
+    const clientWithKey = new yorkie.Client({
+      rpcAddr: testRPCAddr,
       key: clientKey,
       syncLoopDuration: 50,
       reconnectStreamDelay: 1000,
@@ -57,7 +58,7 @@ describe.sequential('Client', function () {
     await clientWithKey.deactivate();
     assert.isFalse(clientWithKey.isActive());
 
-    const clientWithoutKey = new yorkie.Client(testRPCAddr);
+    const clientWithoutKey = new yorkie.Client({ rpcAddr: testRPCAddr });
     assert.isFalse(clientWithoutKey.isActive());
     await clientWithoutKey.activate();
     assert.isTrue(clientWithoutKey.isActive());
@@ -68,7 +69,7 @@ describe.sequential('Client', function () {
   });
 
   it('Can attach/detach document', async function ({ task }) {
-    const cli = new yorkie.Client(testRPCAddr);
+    const cli = new yorkie.Client({ rpcAddr: testRPCAddr });
     await cli.activate();
     const doc = new yorkie.Document(
       toDocKey(`${task.name}-${new Date().getTime()}`),
@@ -166,8 +167,8 @@ describe.sequential('Client', function () {
   it('Can recover from temporary disconnect (realtime sync)', async function ({
     task,
   }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -256,8 +257,8 @@ describe.sequential('Client', function () {
   });
 
   it('Can change sync mode(realtime <-> manual)', async function ({ task }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -318,9 +319,9 @@ describe.sequential('Client', function () {
     // | c2 | PushPull | SyncOff  | PushOnly | PushPull |
     // | c3 | PushPull | PushPull | PushPull | PushPull |
 
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
-    const c3 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c3 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
     await c3.activate();
@@ -448,8 +449,8 @@ describe.sequential('Client', function () {
   it('Should apply previous changes when switching to realtime sync', async function ({
     task,
   }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -509,7 +510,7 @@ describe.sequential('Client', function () {
   it('Should not include changes applied in push-only mode when switching to realtime sync', async function ({
     task,
   }) {
-    const c1 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
 
     // 01. cli attach to the document having counter.
@@ -574,8 +575,8 @@ describe.sequential('Client', function () {
   it('Should prevent remote changes in push-only mode', async function ({
     task,
   }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -657,8 +658,8 @@ describe.sequential('Client', function () {
   it('Should prevent remote changes in sync-off mode', async function ({
     task,
   }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -740,8 +741,8 @@ describe.sequential('Client', function () {
   it('Should avoid unnecessary syncs in push-only mode', async function ({
     task,
   }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -797,7 +798,7 @@ describe.sequential('Client', function () {
 
   it('Should handle each request one by one', async function ({ task }) {
     for (let i = 0; i < 10; i++) {
-      const cli = new yorkie.Client(testRPCAddr);
+      const cli = new yorkie.Client({ rpcAddr: testRPCAddr });
       await cli.activate();
 
       const doc = new yorkie.Document<{ t: Text }>(
@@ -813,7 +814,8 @@ describe.sequential('Client', function () {
   it('Should retry on network failure and eventually succeed', async ({
     task,
   }) => {
-    const cli = new yorkie.Client(testRPCAddr, {
+    const cli = new yorkie.Client({
+      rpcAddr: testRPCAddr,
       retrySyncLoopDelay: 10,
     });
     await cli.activate();
@@ -873,7 +875,7 @@ describe.sequential('Client', function () {
   it('Should successfully broadcast serializeable payload', async ({
     task,
   }) => {
-    const cli = new yorkie.Client(testRPCAddr);
+    const cli = new yorkie.Client({ rpcAddr: testRPCAddr });
     await cli.activate();
 
     const doc = new yorkie.Document<{ t: Text }>(toDocKey(`${task.name}`));
@@ -891,7 +893,7 @@ describe.sequential('Client', function () {
     task,
   }) => {
     const eventCollector = new EventCollector<string>();
-    const cli = new yorkie.Client(testRPCAddr);
+    const cli = new yorkie.Client({ rpcAddr: testRPCAddr });
     await cli.activate();
 
     const doc = new yorkie.Document<{ t: Text }>(toDocKey(`${task.name}`));

--- a/packages/sdk/test/integration/counter_test.ts
+++ b/packages/sdk/test/integration/counter_test.ts
@@ -227,8 +227,8 @@ describe('Counter', function () {
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
 
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client1.activate();
     await client2.activate();
 

--- a/packages/sdk/test/integration/document_test.ts
+++ b/packages/sdk/test/integration/document_test.ts
@@ -38,8 +38,8 @@ describe('Document', function () {
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
 
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client1.activate();
     await client2.activate();
 
@@ -69,8 +69,8 @@ describe('Document', function () {
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
 
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client1.activate();
     await client2.activate();
 
@@ -101,7 +101,7 @@ describe('Document', function () {
     // 5. client3 attaches the document.
     // The content of the removed document should not be exposed.
     const doc3 = new yorkie.Document<TestDoc>(docKey);
-    const client3 = new yorkie.Client(testRPCAddr);
+    const client3 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client3.activate();
     await client3.attach(doc3);
     assert.equal('{}', doc3.toSortedJSON());
@@ -112,8 +112,8 @@ describe('Document', function () {
   });
 
   it('Can watch documents', async function ({ task }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -150,8 +150,8 @@ describe('Document', function () {
   });
 
   it('detects the events from doc.subscribe', async function ({ task }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -283,8 +283,8 @@ describe('Document', function () {
   });
 
   it('specify the topic to subscribe to', async function ({ task }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -370,8 +370,8 @@ describe('Document', function () {
   });
 
   it('specify the nested topic to subscribe to', async function ({ task }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -467,8 +467,8 @@ describe('Document', function () {
     const d1 = new yorkie.Document<TestDoc>(docKey);
     const d2 = new yorkie.Document<TestDoc>(docKey);
 
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -502,7 +502,7 @@ describe('Document', function () {
     type TestDoc = { k1: Array<number> };
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const d1 = new yorkie.Document<TestDoc>(docKey);
-    const c1 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
     const c1Key = c1.getKey();
 
     // 01. client is not activated.
@@ -558,7 +558,7 @@ describe('Document', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
 
     // 01. c1 creates d1 and removes it.
-    const c1 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     const d1 = new yorkie.Document<TestDoc>(docKey);
     d1.update((root) => {
@@ -569,7 +569,7 @@ describe('Document', function () {
     await c1.remove(d1);
 
     // 02. c2 creates d2 with the same key.
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c2.activate();
     const d2 = new yorkie.Document<TestDoc>(docKey);
     await c2.attach(d2);
@@ -591,7 +591,7 @@ describe('Document', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
 
     // 01. c1 attaches d1 and c2 watches same doc.
-    const c1 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     const d1 = new yorkie.Document<TestDoc>(docKey);
     d1.update((root) => {
@@ -600,7 +600,7 @@ describe('Document', function () {
     await c1.attach(d1, { syncMode: SyncMode.Manual });
     assert.equal(d1.toSortedJSON(), '{"k1":[1,2]}');
 
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c2.activate();
     const d2 = new yorkie.Document<TestDoc>(docKey);
     await c2.attach(d2, { syncMode: SyncMode.Manual });
@@ -630,7 +630,7 @@ describe('Document', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
 
     // 01. c1 attaches d1 and c2 watches same doc.
-    const c1 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     const d1 = new yorkie.Document<TestDoc>(docKey);
     d1.update((root) => {
@@ -639,7 +639,7 @@ describe('Document', function () {
     await c1.attach(d1, { syncMode: SyncMode.Manual });
     assert.equal(d1.toSortedJSON(), '{"k1":[1,2]}');
 
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c2.activate();
     const d2 = new yorkie.Document<TestDoc>(docKey);
     await c2.attach(d2, { syncMode: SyncMode.Manual });
@@ -664,7 +664,7 @@ describe('Document', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
 
     // 01. c1 attaches d1 and c2 watches same doc.
-    const c1 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     const d1 = new yorkie.Document<TestDoc>(docKey);
     d1.update((root) => {
@@ -673,7 +673,7 @@ describe('Document', function () {
     await c1.attach(d1, { syncMode: SyncMode.Manual });
     assert.equal(d1.toSortedJSON(), '{"k1":[1,2]}');
 
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c2.activate();
     const d2 = new yorkie.Document<TestDoc>(docKey);
     await c2.attach(d2, { syncMode: SyncMode.Manual });
@@ -703,7 +703,7 @@ describe('Document', function () {
   it('document state transition test', async function ({ task }) {
     type TestDoc = { k1: Array<number> };
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
-    const c1 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
 
     // 01. abnormal behavior on detached state
@@ -770,8 +770,8 @@ describe('Document', function () {
   it('Can subscribe to events related to document status changes', async function ({
     task,
   }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
     const c1ID = c1.getID()!;
@@ -869,8 +869,8 @@ describe('Document', function () {
   it('Should properly handle removed document when deactivating', async function ({
     task,
   }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
     const c1ID = c1.getID()!;
@@ -1105,8 +1105,8 @@ describe('Document', function () {
 
   describe('Document with InitialRoot', function () {
     it('Can attach with InitialRoot', async function ({ task }) {
-      const c1 = new yorkie.Client(testRPCAddr);
-      const c2 = new yorkie.Client(testRPCAddr);
+      const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+      const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
       await c1.activate();
       await c2.activate();
       const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
@@ -1146,8 +1146,8 @@ describe('Document', function () {
     it('Can handle concurrent attach with InitialRoot', async function ({
       task,
     }) {
-      const c1 = new yorkie.Client(testRPCAddr);
-      const c2 = new yorkie.Client(testRPCAddr);
+      const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+      const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
       await c1.activate();
       await c2.activate();
 
@@ -1253,7 +1253,7 @@ describe('Document', function () {
 
       for (const { name: name, input, expectedJSON } of testCases) {
         it(`Can support various types: ${name}`, async function ({ task }) {
-          const c1 = new yorkie.Client(testRPCAddr);
+          const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
           await c1.activate();
           const docKey = toDocKey(
             `${task.name}-${name}-${new Date().getTime()}`,

--- a/packages/sdk/test/integration/gc_test.ts
+++ b/packages/sdk/test/integration/gc_test.ts
@@ -19,8 +19,8 @@ describe('Garbage Collection', function () {
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
 
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
 
     await client1.activate();
     await client2.activate();
@@ -76,8 +76,8 @@ describe('Garbage Collection', function () {
     const doc1 = new yorkie.Document<{ t: Tree }>(docKey);
     const doc2 = new yorkie.Document<{ t: Tree }>(docKey);
 
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
 
     await client1.activate();
     await client2.activate();
@@ -230,8 +230,8 @@ describe('Garbage Collection', function () {
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
 
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
 
     await client1.activate();
     await client2.activate();
@@ -367,8 +367,8 @@ describe('Garbage Collection', function () {
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
 
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
 
     await client1.activate();
     await client2.activate();
@@ -513,8 +513,8 @@ describe('Garbage Collection', function () {
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
 
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
 
     await client1.activate();
     await client2.activate();
@@ -628,7 +628,7 @@ describe('Garbage Collection', function () {
     type TestDoc = { point: { x: number; y: number } };
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc = new yorkie.Document<TestDoc>(docKey);
-    const cli = new yorkie.Client(testRPCAddr);
+    const cli = new yorkie.Client({ rpcAddr: testRPCAddr });
     await cli.activate();
 
     await cli.attach(doc, { syncMode: SyncMode.Manual });
@@ -675,7 +675,7 @@ describe('Garbage Collection', function () {
     type TestDoc = { list: Array<number | Array<number>> };
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc = new yorkie.Document<TestDoc>(docKey);
-    const cli = new yorkie.Client(testRPCAddr);
+    const cli = new yorkie.Client({ rpcAddr: testRPCAddr });
 
     await cli.activate();
     await cli.attach(doc, { syncMode: SyncMode.Manual });
@@ -729,8 +729,8 @@ describe('Garbage Collection', function () {
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
 
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
 
     await client1.activate();
     await client2.activate();
@@ -865,8 +865,8 @@ describe('Garbage Collection', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client1.activate();
     await client2.activate();
     await client1.attach(doc1, { syncMode: SyncMode.Manual });
@@ -1034,8 +1034,8 @@ describe('Garbage Collection', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client1.activate();
     await client2.activate();
     await client1.attach(doc1, { syncMode: SyncMode.Manual });
@@ -1230,8 +1230,8 @@ describe('Garbage Collection', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client1.activate();
     await client2.activate();
 
@@ -1375,8 +1375,8 @@ describe('Garbage Collection', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client1.activate();
     await client2.activate();
 
@@ -1613,8 +1613,8 @@ describe('Garbage Collection', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client1.activate();
     await client2.activate();
 
@@ -1708,8 +1708,8 @@ describe('Garbage Collection', function () {
     const docKey = toDocKey(`${new Date().getTime()}-${task.name}`);
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client1.activate();
     await client2.activate();
 
@@ -1882,8 +1882,8 @@ describe('Garbage Collection', function () {
     const docKey = toDocKey(`${new Date().getTime()}-${task.name}`);
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client1.activate();
     await client2.activate();
 
@@ -2048,9 +2048,9 @@ describe('Garbage Collection', function () {
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
     const doc3 = new yorkie.Document<TestDoc>(docKey);
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
-    const client3 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client3 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client1.activate();
     await client2.activate();
     await client3.activate();
@@ -2237,9 +2237,9 @@ describe('Garbage Collection', function () {
     const doc1 = new yorkie.Document<TestDoc>(docKey);
     const doc2 = new yorkie.Document<TestDoc>(docKey);
     const doc3 = new yorkie.Document<TestDoc>(docKey);
-    const client1 = new yorkie.Client(testRPCAddr);
-    const client2 = new yorkie.Client(testRPCAddr);
-    const client3 = new yorkie.Client(testRPCAddr);
+    const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const client3 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client1.activate();
     await client2.activate();
     await client3.activate();

--- a/packages/sdk/test/integration/integration_helper.ts
+++ b/packages/sdk/test/integration/integration_helper.ts
@@ -47,8 +47,8 @@ export async function withTwoClientsAndDocuments<
   title: string,
   syncMode: SyncMode = SyncMode.Manual,
 ): Promise<void> {
-  const client1 = new yorkie.Client(testRPCAddr);
-  const client2 = new yorkie.Client(testRPCAddr);
+  const client1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+  const client2 = new yorkie.Client({ rpcAddr: testRPCAddr });
   await client1.activate();
   await client2.activate();
 

--- a/packages/sdk/test/integration/object_test.ts
+++ b/packages/sdk/test/integration/object_test.ts
@@ -377,8 +377,8 @@ describe('Object', function () {
       const doc1 = new Document<TestDoc>(docKey);
       const doc2 = new Document<TestDoc>(docKey);
 
-      const client1 = new Client(testRPCAddr);
-      const client2 = new Client(testRPCAddr);
+      const client1 = new Client({ rpcAddr: testRPCAddr });
+      const client2 = new Client({ rpcAddr: testRPCAddr });
       await client1.activate();
       await client2.activate();
 
@@ -421,8 +421,8 @@ describe('Object', function () {
       const doc1 = new Document<TestDoc>(docKey);
       const doc2 = new Document<TestDoc>(docKey);
 
-      const client1 = new Client(testRPCAddr);
-      const client2 = new Client(testRPCAddr);
+      const client1 = new Client({ rpcAddr: testRPCAddr });
+      const client2 = new Client({ rpcAddr: testRPCAddr });
       await client1.activate();
       await client2.activate();
 
@@ -471,8 +471,8 @@ describe('Object', function () {
       const doc1 = new Document<TestDoc>(docKey);
       const doc2 = new Document<TestDoc>(docKey);
 
-      const client1 = new Client(testRPCAddr);
-      const client2 = new Client(testRPCAddr);
+      const client1 = new Client({ rpcAddr: testRPCAddr });
+      const client2 = new Client({ rpcAddr: testRPCAddr });
       await client1.activate();
       await client2.activate();
 
@@ -541,8 +541,8 @@ describe('Object', function () {
       const doc1 = new Document<TestDoc>(docKey);
       const doc2 = new Document<TestDoc>(docKey);
 
-      const client1 = new Client(testRPCAddr);
-      const client2 = new Client(testRPCAddr);
+      const client1 = new Client({ rpcAddr: testRPCAddr });
+      const client2 = new Client({ rpcAddr: testRPCAddr });
       await client1.activate();
       await client2.activate();
 
@@ -587,8 +587,8 @@ describe('Object', function () {
       const doc1 = new Document<TestDoc>(docKey);
       const doc2 = new Document<TestDoc>(docKey);
 
-      const client1 = new Client(testRPCAddr);
-      const client2 = new Client(testRPCAddr);
+      const client1 = new Client({ rpcAddr: testRPCAddr });
+      const client2 = new Client({ rpcAddr: testRPCAddr });
       await client1.activate();
       await client2.activate();
 
@@ -646,8 +646,8 @@ describe('Object', function () {
       const doc1 = new Document<TestDoc>(docKey);
       const doc2 = new Document<TestDoc>(docKey);
 
-      const client1 = new Client(testRPCAddr);
-      const client2 = new Client(testRPCAddr);
+      const client1 = new Client({ rpcAddr: testRPCAddr });
+      const client2 = new Client({ rpcAddr: testRPCAddr });
       await client1.activate();
       await client2.activate();
 
@@ -722,8 +722,8 @@ describe('Object', function () {
       const doc1 = new Document<TestDoc>(docKey);
       const doc2 = new Document<TestDoc>(docKey);
 
-      const client1 = new Client(testRPCAddr);
-      const client2 = new Client(testRPCAddr);
+      const client1 = new Client({ rpcAddr: testRPCAddr });
+      const client2 = new Client({ rpcAddr: testRPCAddr });
       await client1.activate();
       await client2.activate();
 
@@ -798,8 +798,8 @@ describe('Object', function () {
       const doc1 = new Document<TestDoc>(docKey);
       const doc2 = new Document<TestDoc>(docKey);
 
-      const client1 = new Client(testRPCAddr);
-      const client2 = new Client(testRPCAddr);
+      const client1 = new Client({ rpcAddr: testRPCAddr });
+      const client2 = new Client({ rpcAddr: testRPCAddr });
       await client1.activate();
       await client2.activate();
 
@@ -854,8 +854,8 @@ describe('Object', function () {
       const doc1 = new Document<TestDoc>(docKey, { disableGC: true });
       const doc2 = new Document<TestDoc>(docKey, { disableGC: true });
 
-      const client1 = new Client(testRPCAddr);
-      const client2 = new Client(testRPCAddr);
+      const client1 = new Client({ rpcAddr: testRPCAddr });
+      const client2 = new Client({ rpcAddr: testRPCAddr });
       await client1.activate();
       await client2.activate();
 
@@ -907,8 +907,8 @@ describe('Object', function () {
       const doc1 = new Document<TestDoc>(docKey, { disableGC: true });
       const doc2 = new Document<TestDoc>(docKey, { disableGC: true });
 
-      const client1 = new Client(testRPCAddr);
-      const client2 = new Client(testRPCAddr);
+      const client1 = new Client({ rpcAddr: testRPCAddr });
+      const client2 = new Client({ rpcAddr: testRPCAddr });
       await client1.activate();
       await client2.activate();
 
@@ -955,8 +955,8 @@ describe('Object', function () {
       const doc1 = new Document<TestDoc>(docKey);
       const doc2 = new Document<TestDoc>(docKey);
 
-      const client1 = new Client(testRPCAddr);
-      const client2 = new Client(testRPCAddr);
+      const client1 = new Client({ rpcAddr: testRPCAddr });
+      const client2 = new Client({ rpcAddr: testRPCAddr });
       await client1.activate();
       await client2.activate();
 

--- a/packages/sdk/test/integration/presence_test.ts
+++ b/packages/sdk/test/integration/presence_test.ts
@@ -23,8 +23,8 @@ describe('Presence', function () {
   });
 
   it('Can be built from a snapshot', async function ({ task }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -53,8 +53,8 @@ describe('Presence', function () {
   it('Can be set initial value in attach and be removed in detach', async function ({
     task,
   }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -88,8 +88,8 @@ describe('Presence', function () {
   it('Should be initialized as an empty object if no initial value is set during attach', async function ({
     task,
   }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -112,8 +112,8 @@ describe('Presence', function () {
   });
 
   it('Should be synced eventually', async function ({ task }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
     const c1ID = c1.getID()!;
@@ -196,8 +196,8 @@ describe('Presence', function () {
   it('Can be updated partially by doc.update function', async function ({
     task,
   }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -230,9 +230,9 @@ describe('Presence', function () {
   });
 
   it(`Should return only online clients`, async function ({ task }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
-    const c3 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c3 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
     await c3.activate();
@@ -299,8 +299,8 @@ describe('Presence', function () {
   it('Can get presence value using p.get() within doc.update function', async function ({
     task,
   }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
 
@@ -332,8 +332,8 @@ describe('Presence', function () {
   it(`Should not be accessible to other clients' presence when the stream is disconnected`, async function ({
     task,
   }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
     const c2ID = c2.getID()!;
@@ -380,8 +380,8 @@ describe(`Document.Subscribe('presence')`, function () {
   it(`Should receive presence-changed event for final presence if there are multiple presence changes within doc.update`, async function ({
     task,
   }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
     const c1ID = c1.getID()!;
@@ -437,8 +437,8 @@ describe(`Document.Subscribe('presence')`, function () {
   it(`Can receive 'unwatched' event when a client detaches`, async function ({
     task,
   }) {
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
     const c1ID = c1.getID()!;
@@ -488,9 +488,9 @@ describe(`Document.Subscribe('presence')`, function () {
     type PresenceType = { name: string; cursor: { x: number; y: number } };
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
 
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
-    const c3 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c3 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c1.activate();
     await c2.activate();
     await c3.activate();
@@ -614,7 +614,7 @@ describe('Undo/Redo', function () {
       root.counter = new Counter(yorkie.IntType, 100);
     }, 'init counter');
 
-    const client = new yorkie.Client(testRPCAddr);
+    const client = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client.activate();
     await client.attach(doc, { initialPresence: { color: 'red' } });
 
@@ -668,7 +668,7 @@ describe('Undo/Redo', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc = new yorkie.Document<{}, Presence>(docKey);
 
-    const client = new yorkie.Client(testRPCAddr);
+    const client = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client.activate();
     await client.attach(doc, {
       initialPresence: { color: 'red', cursor: { x: 0, y: 0 } },
@@ -788,7 +788,7 @@ describe('Undo/Redo', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc = new yorkie.Document<{}, Presence>(docKey);
 
-    const client = new yorkie.Client(testRPCAddr);
+    const client = new yorkie.Client({ rpcAddr: testRPCAddr });
     await client.activate();
     await client.attach(doc, { initialPresence: { color: 'red' } });
 

--- a/packages/sdk/test/integration/tree_concurrency_test.ts
+++ b/packages/sdk/test/integration/tree_concurrency_test.ts
@@ -227,8 +227,8 @@ async function runTest(
   desc: string,
 ): Promise<TestResult> {
   const docKey = `${toDocKey(desc)}-${new Date().getTime()}`;
-  const c1 = new yorkie.Client(testRPCAddr);
-  const c2 = new yorkie.Client(testRPCAddr);
+  const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+  const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
   await c1.activate();
   await c2.activate();
 

--- a/packages/sdk/test/integration/tree_test.ts
+++ b/packages/sdk/test/integration/tree_test.ts
@@ -1551,8 +1551,8 @@ describe('Tree.style', function () {
     const d1 = new yorkie.Document<TestDoc>(docKey);
     const d2 = new yorkie.Document<TestDoc>(docKey);
 
-    const c1 = new yorkie.Client(testRPCAddr);
-    const c2 = new yorkie.Client(testRPCAddr);
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
 
     await c1.activate();
     await c2.activate();
@@ -1755,7 +1755,7 @@ describe('Tree.style', function () {
 
     // A new client has been added.
     const d3 = new yorkie.Document<TestDoc>(docKey);
-    const c3 = new yorkie.Client(testRPCAddr);
+    const c3 = new yorkie.Client({ rpcAddr: testRPCAddr });
     await c3.activate();
     await c3.attach(d3, { syncMode: SyncMode.Manual });
     assert.equal(

--- a/packages/sdk/test/integration/webhook_test.ts
+++ b/packages/sdk/test/integration/webhook_test.ts
@@ -142,13 +142,15 @@ describe('Auth Webhook', () => {
     task,
   }) => {
     // client with token
-    const c1 = new yorkie.Client(testRPCAddr, {
+    const c1 = new yorkie.Client({
+      rpcAddr: testRPCAddr,
       apiKey,
       authTokenInjector: async () => {
         return `token-${Date.now() + 1000 * 60 * 60}`; // expire in 1 hour
       },
     });
-    const c2 = new yorkie.Client(testRPCAddr, {
+    const c2 = new yorkie.Client({
+      rpcAddr: testRPCAddr,
       apiKey,
       authTokenInjector: async () => {
         return `token-${Date.now() + 1000 * 60 * 60}`; // expire in 1 hour
@@ -192,7 +194,8 @@ describe('Auth Webhook', () => {
 
   it('should return unauthenticated error for client with empty token (401)', async () => {
     // client without token
-    const cliWithoutToken = new yorkie.Client(testRPCAddr, {
+    const cliWithoutToken = new yorkie.Client({
+      rpcAddr: testRPCAddr,
       apiKey,
     });
     await assertThrowsAsync(
@@ -209,7 +212,8 @@ describe('Auth Webhook', () => {
     const invalidTokenInjector = vi.fn(async () => {
       return 'invalid-token';
     });
-    const cliWithInvalidToken = new yorkie.Client(testRPCAddr, {
+    const cliWithInvalidToken = new yorkie.Client({
+      rpcAddr: testRPCAddr,
       apiKey,
       authTokenInjector: invalidTokenInjector,
     });
@@ -227,7 +231,8 @@ describe('Auth Webhook', () => {
     const notAllowedTokenInjector = vi.fn(async () => {
       return NotAllowedToken;
     });
-    const cliNotAllowed = new yorkie.Client(testRPCAddr, {
+    const cliNotAllowed = new yorkie.Client({
+      rpcAddr: testRPCAddr,
       apiKey,
       authTokenInjector: notAllowedTokenInjector,
     });
@@ -257,7 +262,8 @@ describe('Auth Webhook', () => {
       return `token-${Date.now() - TokenExpirationMs}`; // token expired
     });
     // client with token
-    const client = new yorkie.Client(testRPCAddr, {
+    const client = new yorkie.Client({
+      rpcAddr: testRPCAddr,
       apiKey,
       authTokenInjector,
     });
@@ -375,7 +381,8 @@ describe('Auth Webhook', () => {
       return `token-${Date.now() - TokenExpirationMs}`; // token expired
     });
     // client with token
-    const client = new yorkie.Client(testRPCAddr, {
+    const client = new yorkie.Client({
+      rpcAddr: testRPCAddr,
       apiKey,
       authTokenInjector,
     });
@@ -438,7 +445,8 @@ describe('Auth Webhook', () => {
       return `token-${Date.now()}`;
     });
     // client with token
-    const client = new yorkie.Client(testRPCAddr, {
+    const client = new yorkie.Client({
+      rpcAddr: testRPCAddr,
       apiKey,
       authTokenInjector,
       retrySyncLoopDelay: 100,
@@ -516,7 +524,8 @@ describe('Auth Webhook', () => {
       return `token-${Date.now()}`;
     });
     // client with token
-    const client = new yorkie.Client(testRPCAddr, {
+    const client = new yorkie.Client({
+      rpcAddr: testRPCAddr,
       apiKey,
       authTokenInjector,
       reconnectStreamDelay: 100,
@@ -535,7 +544,8 @@ describe('Auth Webhook', () => {
     });
 
     // Another client for verifying if the watchDocument is working properly
-    const client2 = new yorkie.Client(testRPCAddr, {
+    const client2 = new yorkie.Client({
+      rpcAddr: testRPCAddr,
       apiKey,
       authTokenInjector: async () => {
         return `token-${Date.now() + 1000 * 60 * 60}`; // expire in 1 hour
@@ -611,7 +621,8 @@ describe('Auth Webhook', () => {
       return `token-${Date.now()}`;
     });
     // client with token
-    const client = new yorkie.Client(testRPCAddr, {
+    const client = new yorkie.Client({
+      rpcAddr: testRPCAddr,
       apiKey,
       authTokenInjector,
       reconnectStreamDelay: 100,
@@ -630,7 +641,8 @@ describe('Auth Webhook', () => {
     });
 
     // Another client for verifying if the broadcast is working properly
-    const client2 = new yorkie.Client(testRPCAddr, {
+    const client2 = new yorkie.Client({
+      rpcAddr: testRPCAddr,
       apiKey,
       authTokenInjector: async () => {
         return `token-${Date.now() + 1000 * 60 * 60}`; // expire in 1 hour

--- a/packages/sdk/test/unit/document/crdt/counter_test.ts
+++ b/packages/sdk/test/unit/document/crdt/counter_test.ts
@@ -53,9 +53,12 @@ describe('Counter', function () {
         ? counter.getValue()
         : operand.getValue();
 
-      assert.throw(() => {
-        counter.increase(operand);
-      }, `Unsupported type of value: ${typeof errValue}`);
+      assert.throw(
+        () => {
+          counter.increase(operand);
+        },
+        `Unsupported type of value: ${typeof errValue}`,
+      );
     }
 
     const str = Primitive.of('hello', InitialTimeTicket);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Refactored the client initialization logic to accept an `opts`
parameter for setting the `rpcAddr`, improving flexibility and
consistency. Also updated `YorkieProvider` to use the same
options-based approach for configuration.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Refactor**
	- Client configuration has been streamlined with a shift to using a configuration object with explicit parameter names. This update improves clarity and consistency across modules and examples.
- **Tests**
	- Test cases have been updated to use the new client configuration format, ensuring uniformity and reliability in client setup during testing.
- **New Features**
	- The `useYorkieDoc` hook has been enhanced for better type safety and performance through memoization.
	- The `App` component in the TodoMVC example now utilizes the new `useYorkieDoc` hook for improved document management capabilities.
	- The rendering logic in the `main.tsx` file has been updated to remove the previous provider setup, now using `StrictMode`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->