### PR TITLE
Add beforeunload deactivation handler directly to Client

### DIFF
--- a/examples/nextjs-scheduler/app/page.tsx
+++ b/examples/nextjs-scheduler/app/page.tsx
@@ -94,10 +94,6 @@ export default function Editor() {
       apiKey: ENV.apiKey,
     });
 
-    window.addEventListener('beforeunload', () => {
-      client.deactivate({ keepalive: true });
-    });
-
     // subscribe document event of "PresenceChanged"(="peers-changed")
     doc.subscribe('presence', (event) => {
       if (event.type !== DocEventType.PresenceChanged) {

--- a/examples/profile-stack/main.js
+++ b/examples/profile-stack/main.js
@@ -21,10 +21,6 @@ async function main() {
       color: getRandomColor(),
     },
   });
-
-  window.addEventListener('beforeunload', () => {
-    client.deactivate({ keepalive: true });
-  });
 }
 
 const MAX_PEER_VIEW = 4;

--- a/examples/react-tldraw/src/hooks/types.ts
+++ b/examples/react-tldraw/src/hooks/types.ts
@@ -1,11 +1,6 @@
 // Yorkie type for typescript
 import type { TDAsset, TDBinding, TDShape, TDUser } from '@tldraw/tldraw';
 import type { JSONObject } from '@yorkie-js/sdk';
-export type Options = {
-  apiKey?: string;
-  syncLoopDuration: number;
-  reconnectStreamDelay: number;
-};
 
 export type YorkieDocType = {
   shapes: JSONObject<Record<string, JSONObject<TDShape>>>;

--- a/examples/react-tldraw/src/hooks/useMultiplayerState.ts
+++ b/examples/react-tldraw/src/hooks/useMultiplayerState.ts
@@ -14,7 +14,7 @@ import randomColor from 'randomcolor';
 import { uniqueNamesGenerator, names } from 'unique-names-generator';
 import _ from 'lodash';
 
-import type { Options, YorkieDocType, YorkiePresenceType } from './types';
+import type { YorkieDocType, YorkiePresenceType } from './types';
 
 // Yorkie Client declaration
 let client: yorkie.Client;
@@ -158,14 +158,6 @@ export function useMultiplayerState(roomId: string) {
   useEffect(() => {
     if (!app) return;
 
-    // Detach & deactive yorkie client before unload
-    function handleDisconnect() {
-      if (client === undefined || doc === undefined) return;
-      client.deactivate({ keepalive: true });
-    }
-
-    window.addEventListener('beforeunload', handleDisconnect);
-
     // Subscribe to changes
     function handleChanges() {
       const root = doc.getRoot();
@@ -192,16 +184,12 @@ export function useMultiplayerState(roomId: string) {
       try {
         // 01. Create client with RPCAddr and options with apiKey if provided.
         //     Then activate client.
-        const options: Options = {
+        client = new yorkie.Client({
+          rpcAddr: import.meta.env.VITE_YORKIE_API_ADDR,
           apiKey: import.meta.env.VITE_YORKIE_API_KEY,
           syncLoopDuration: 0,
           reconnectStreamDelay: 1000,
-        };
-
-        client = new yorkie.Client(
-          import.meta.env.VITE_YORKIE_API_ADDR,
-          options,
-        );
+        });
         await client.activate();
 
         // 02. Create document with tldraw custom object type.
@@ -283,7 +271,6 @@ export function useMultiplayerState(roomId: string) {
     setupDocument();
 
     return () => {
-      window.removeEventListener('beforeunload', handleDisconnect);
       stillAlive = false;
     };
   }, [app]);

--- a/examples/simultaneous-cursors/src/App.jsx
+++ b/examples/simultaneous-cursors/src/App.jsx
@@ -41,10 +41,6 @@ const App = () => {
           pointerDown: false,
         },
       });
-
-      window.addEventListener('beforeunload', () => {
-        client.deactivate({ keepalive: true });
-      });
     };
 
     setup();

--- a/examples/vanilla-codemirror6/src/main.ts
+++ b/examples/vanilla-codemirror6/src/main.ts
@@ -22,10 +22,6 @@ async function main() {
   });
   await client.activate();
 
-  window.addEventListener('beforeunload', () => {
-    client.deactivate({ keepalive: true });
-  });
-
   // 02-1. create a document then attach it into the client.
   const doc = new yorkie.Document<YorkieDoc, YorkiePresence>(
     `codemirror6-${new Date()

--- a/examples/vanilla-document-limit/src/main.ts
+++ b/examples/vanilla-document-limit/src/main.ts
@@ -24,9 +24,6 @@ async function main() {
     apiKey: import.meta.env.VITE_YORKIE_API_KEY,
   });
   await client.activate();
-  window.addEventListener('beforeunload', () => {
-    client.deactivate({ keepalive: true });
-  });
 
   const doc = new yorkie.Document('vanilla-document-limit', {
     enableDevtools: true,

--- a/examples/vanilla-quill/src/main.ts
+++ b/examples/vanilla-quill/src/main.ts
@@ -46,10 +46,6 @@ async function main() {
   });
   await client.activate();
 
-  window.addEventListener('beforeunload', () => {
-    client.deactivate({ keepalive: true });
-  });
-
   // 02-1. create a document then attach it into the client.
   const doc = new yorkie.Document<YorkieDoc, YorkiePresence>(documentKey, {
     enableDevtools: true,

--- a/examples/vuejs-kanban/src/App.vue
+++ b/examples/vuejs-kanban/src/App.vue
@@ -38,10 +38,6 @@ const client = new yorkie.Client(import.meta.env.VITE_YORKIE_API_ADDR, {
   apiKey: import.meta.env.VITE_YORKIE_API_KEY,
 });
 
-window.addEventListener('beforeunload', () => {
-  client.deactivate({ keepalive: true });
-});
-
 const doc = new yorkie.Document(
   `vuejs-kanban-${new Date().toISOString().substring(0, 10).replace(/-/g, '')}`,
   { enableDevtools: true },

--- a/packages/sdk/public/quill-two-clients.html
+++ b/packages/sdk/public/quill-two-clients.html
@@ -486,9 +486,6 @@
 
             syncText(doc, quill);
             updateAllCursors();
-            window.addEventListener('beforeunload', async () => {
-              await client.deactivate({ keepalive: true });
-            });
 
             return { client, doc, quill };
           }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Add beforeunload deactivation handler to Client

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #972

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Streamlined asynchronous operations for connection handling, enhancing overall stability and responsiveness.
  
- **Chores**
  - Removed legacy logic that automatically deactivated sessions when leaving the page, leading to more consistent client behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->