### PR TITLE
Remove recursion in registerElement to avoid duplicate registrations

### DIFF
--- a/packages/sdk/src/document/crdt/root.ts
+++ b/packages/sdk/src/document/crdt/root.ts
@@ -203,10 +203,10 @@ export class CRDTRoot {
     addDataSizes(this.docSize.live, element.getDataSize());
 
     if (element instanceof CRDTContainer) {
-      element.getDescendants((elem) => {
+      element.getDescendants((elem, par) => {
         this.elementPairMapByCreatedAt.set(elem.getCreatedAt().toIDString(), {
+          parent: par,
           element: elem,
-          parent: element,
         });
         addDataSizes(this.docSize.live, elem.getDataSize());
         return false;

--- a/packages/sdk/src/document/crdt/root.ts
+++ b/packages/sdk/src/document/crdt/root.ts
@@ -203,8 +203,12 @@ export class CRDTRoot {
     addDataSizes(this.docSize.live, element.getDataSize());
 
     if (element instanceof CRDTContainer) {
-      element.getDescendants((elem, parent) => {
-        this.registerElement(elem, parent);
+      element.getDescendants((elem) => {
+        this.elementPairMapByCreatedAt.set(elem.getCreatedAt().toIDString(), {
+          element: elem,
+          parent: element,
+        });
+        addDataSizes(this.docSize.live, elem.getDataSize());
         return false;
       });
     }

--- a/packages/sdk/test/unit/document/document_size_test.ts
+++ b/packages/sdk/test/unit/document/document_size_test.ts
@@ -114,25 +114,6 @@ describe('Document Size', () => {
     assert.deepEqual(doc.getDocSize().gc, { data: 2, meta: 48 });
   });
 
-  it('gc test', function () {
-    const doc = new Document<JSONObject<{ num?: number; str: string }>>(
-      'test-doc',
-    );
-
-    doc.update((root) => {
-      root['num'] = 1;
-      root['str'] = 'hello';
-    });
-    assert.deepEqual(doc.getDocSize().live, { data: 14, meta: 120 });
-
-    doc.update((root) => {
-      delete root['num'];
-    });
-    assert.deepEqual(doc.getDocSize().live, { data: 10, meta: 72 });
-    // NOTE(hackerwins): P(CreatedAt, MovedAt, RemovedAt)
-    assert.deepEqual(doc.getDocSize().gc, { data: 4, meta: 72 });
-  });
-
   it('counter test', function () {
     const doc = new Document<{ counter: Counter }>('test-doc');
     doc.update((root) => (root.counter = new Counter(CounterType.Int, 0)));
@@ -239,5 +220,41 @@ describe('Document Size', () => {
     assert.equal(doc.getRoot().tree.toXML(), `<doc><p>world</p></doc>`);
     assert.deepEqual(doc.getDocSize().live, { data: 10, meta: 168 });
     assert.deepEqual(doc.getDocSize().gc, { data: 36, meta: 168 });
+  });
+
+  it('gc test', function () {
+    const doc = new Document<JSONObject<{ num?: number; str: string }>>(
+      'test-doc',
+    );
+
+    doc.update((root) => {
+      root['num'] = 1;
+      root['str'] = 'hello';
+    });
+    assert.deepEqual(doc.getDocSize().live, { data: 14, meta: 120 });
+
+    doc.update((root) => {
+      delete root['num'];
+    });
+    assert.deepEqual(doc.getDocSize().live, { data: 10, meta: 72 });
+    // NOTE(hackerwins): P(CreatedAt, MovedAt, RemovedAt)
+    assert.deepEqual(doc.getDocSize().gc, { data: 4, meta: 72 });
+  });
+
+  it('deep copy test', function () {
+    const doc = new Document<{ counter: Counter }>('test-doc');
+    doc.update((root) => (root.counter = new Counter(CounterType.Int, 0)));
+    const clone = doc.getClone()!.root.deepcopy();
+    assert.deepEqual(doc.getDocSize(), clone.getDocSize());
+  });
+
+  it('deep copy for nested element test', function () {
+    const doc = new Document<{ arr: Array<Counter> }>('test-doc');
+
+    doc.update((root) => (root['arr'] = []));
+    doc.update((root) => root['arr'].push(new Counter(CounterType.Int, 0)));
+
+    const clone = doc.getClone()!.root.deepcopy();
+    assert.deepEqual(clone.getDocSize(), doc.getDocSize());
   });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
This PR addresses an issue where the `registerElement` function was being called recursively, leading to duplicate calls due to the behavior of `getDescendants`. The recursion has been eliminated, ensuring that each element is registered only once, which improves performance and prevents potential inconsistencies.

#### Any background context you want to provide?
The `getDescendants` method was unintentionally causing `registerElement` to be invoked multiple times for the same element due to its recursive design. By refactoring the logic to remove this recursion, we ensure that registration is streamlined and that each element is only processed once.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related https://github.com/yorkie-team/yorkie/pull/1290

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added new tests to verify that deep copies of documents maintain the same document size, including for nested elements.
  - Reorganized the order of existing test cases for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->