### PR TITLE
Add support for document re-attachment with same client

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -540,6 +540,7 @@ export class Client {
 
         if (doc.getStatus() !== DocStatus.Removed) {
           doc.applyStatus(DocStatus.Detached);
+          doc.reset();
         }
 
         this.detachInternal(doc.getKey());

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -691,6 +691,35 @@ export class Document<R, P extends Indexable = Indexable> {
     setupDevtools(this);
   }
 
+  private resetChangeTracking(): void {
+    this.changeID = InitialChangeID;
+    this.checkpoint = InitialCheckpoint;
+    this.localChanges = [];
+  }
+
+  private resetClientState(): void {
+    this.onlineClients = new Set();
+    this.presences = new Map();
+  }
+
+  private resetHistory(): void {
+    this.internalHistory = new History();
+  }
+
+  /**
+   * `reset` resets the document state for reattachment.
+   * This method should be called before reattaching a detached document.
+   *
+   * @internal
+   */
+  public reset(): void {
+    this.resetChangeTracking();
+    this.resetClientState();
+    this.resetHistory();
+    this.status = DocStatus.Detached;
+    this.ensureClone();
+  }
+
   /**
    * `update` executes the given updater to update this document.
    */


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it

This PR improves the developer experience when using `yorkie-js-sdk` by allowing a previously detached document to be reattached using the same client instance.

In some use cases—such as apps that need to switch between documents while maintaining a single active client—it’s natural to detach one document and later reattach it. However, this flow currently results in an error, as the internal state of the document isn't reset upon detachment.

To address this, we expose a public `reset()` method that clears the document’s internal state, making it ready for reattachment. This allows developers to reattach previously detached documents safely and explicitly.

#### Background context

Here's a typical scenario:
- A persistent `client` is created and activated.
- A `doc1` is attached and then detached.
- A second `doc2` is attached and detached.
- Attempting to reattach `doc1` causes an error unless its internal state is reset.

By calling `doc1.reset()` before reattaching, this issue is resolved.

#### Test
<img width="637" alt="image" src="https://github.com/user-attachments/assets/d82d965b-5475-40d2-9a3f-484c7a813e5e" />


#### What are the relevant tickets?

Fixes yorkie-team/yorkie#1353  
> Reported issue: Reattaching a detached document with the same client causes failure.

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the ability to reset a document's state, enabling seamless detachment and re-attachment with the same client.

- **Tests**
  - Introduced an integration test confirming that a document can be detached and re-attached with the same client while preserving content and status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->