### PR TITLE
Remove obsolete version field from docker-compose.yml

### DIFF
--- a/docker/docker-compose-ci.yml
+++ b/docker/docker-compose-ci.yml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 services:
   yorkie:
     image: 'yorkieteam/yorkie:latest'

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.3'
-
 services:
   yorkie:
     image: 'yorkieteam/yorkie:latest'


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Removes the obsolete version field from `docker/docker-compose.yml`.
This field is no longer required in recent versions of Docker Compose and currently causes a warning when running docker compose

#### Any background context you want to provide?

docker compose Version top-level element is obsolete. [docker compose spec](https://github.com/compose-spec/compose-spec/blob/main/spec.md#version-and-name-top-level-elements)

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1004 

### Checklist
- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything
