### PR TITLE
Update CONTRIBUTING.md to use `pnpm i`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,7 +45,7 @@ For building yorkie-js-sdk, You'll first need Node.js installed(Node.js version 
 # install packages
 
 # In the root directory of the repository.
-$ pnpm sdk install
+$ pnpm i
 
 # build
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Update CONTRIBUTING.md to use `pnpm i`

`pnpm sdk install` causes ELIFECYCLE errors in Windows + WSL environments.
Replaced it with `pnpm i`, which works reliably across environments.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the package installation command in the build instructions to use a more standard method.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->