### PR TITLE
Add clientKey field to yorkie API requests for clients collection key-wide hashed sharding

### DIFF
--- a/packages/sdk/src/api/yorkie/v1/yorkie.proto
+++ b/packages/sdk/src/api/yorkie/v1/yorkie.proto
@@ -50,6 +50,7 @@ message ActivateClientResponse {
 
 message DeactivateClientRequest {
   string client_id = 1;
+  string client_key = 2;
 }
 
 message DeactivateClientResponse {
@@ -59,6 +60,7 @@ message AttachDocumentRequest {
   string client_id = 1;
   ChangePack change_pack = 2;
   string schema_key = 3;
+  string client_key = 4;
 }
 
 message AttachDocumentResponse {
@@ -73,6 +75,7 @@ message DetachDocumentRequest {
   string document_id = 2;
   ChangePack change_pack = 3;
   bool remove_if_not_attached = 4;
+  string client_key = 5;
 }
 
 message DetachDocumentResponse {
@@ -82,6 +85,7 @@ message DetachDocumentResponse {
 message WatchDocumentRequest {
   string client_id = 1;
   string document_id = 2;
+  string client_key = 3;
 }
 
 message WatchDocumentResponse {
@@ -99,6 +103,7 @@ message RemoveDocumentRequest {
   string client_id = 1;
   string document_id = 2;
   ChangePack change_pack = 3;
+  string client_key = 4;
 }
 
 message RemoveDocumentResponse {
@@ -110,6 +115,7 @@ message PushPullChangesRequest {
   string document_id = 2;
   ChangePack change_pack = 3;
   bool push_only = 4;
+  string client_key = 5;
 }
 
 message PushPullChangesResponse {
@@ -121,6 +127,7 @@ message BroadcastRequest {
   string document_id = 2;
   string topic = 3;
   bytes payload = 4;
+  string client_key = 5;
 }
 
 message BroadcastResponse {

--- a/packages/sdk/src/api/yorkie/v1/yorkie.proto
+++ b/packages/sdk/src/api/yorkie/v1/yorkie.proto
@@ -58,9 +58,9 @@ message DeactivateClientResponse {
 
 message AttachDocumentRequest {
   string client_id = 1;
+  string client_key = 4;
   ChangePack change_pack = 2;
   string schema_key = 3;
-  string client_key = 4;
 }
 
 message AttachDocumentResponse {
@@ -72,10 +72,10 @@ message AttachDocumentResponse {
 
 message DetachDocumentRequest {
   string client_id = 1;
+  string client_key = 5;
   string document_id = 2;
   ChangePack change_pack = 3;
   bool remove_if_not_attached = 4;
-  string client_key = 5;
 }
 
 message DetachDocumentResponse {
@@ -84,8 +84,8 @@ message DetachDocumentResponse {
 
 message WatchDocumentRequest {
   string client_id = 1;
-  string document_id = 2;
   string client_key = 3;
+  string document_id = 2;
 }
 
 message WatchDocumentResponse {
@@ -101,9 +101,9 @@ message WatchDocumentResponse {
 
 message RemoveDocumentRequest {
   string client_id = 1;
+  string client_key = 4;
   string document_id = 2;
   ChangePack change_pack = 3;
-  string client_key = 4;
 }
 
 message RemoveDocumentResponse {
@@ -112,10 +112,10 @@ message RemoveDocumentResponse {
 
 message PushPullChangesRequest {
   string client_id = 1;
+  string client_key = 5;
   string document_id = 2;
   ChangePack change_pack = 3;
   bool push_only = 4;
-  string client_key = 5;
 }
 
 message PushPullChangesResponse {
@@ -124,10 +124,10 @@ message PushPullChangesResponse {
 
 message BroadcastRequest {
   string client_id = 1;
+  string client_key = 5;
   string document_id = 2;
   string topic = 3;
   bytes payload = 4;
-  string client_key = 5;
 }
 
 message BroadcastResponse {

--- a/packages/sdk/src/api/yorkie/v1/yorkie_pb.ts
+++ b/packages/sdk/src/api/yorkie/v1/yorkie_pb.ts
@@ -111,6 +111,11 @@ export class DeactivateClientRequest extends Message<DeactivateClientRequest> {
    */
   clientId = "";
 
+  /**
+   * @generated from field: string client_key = 2;
+   */
+  clientKey = "";
+
   constructor(data?: PartialMessage<DeactivateClientRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -120,6 +125,7 @@ export class DeactivateClientRequest extends Message<DeactivateClientRequest> {
   static readonly typeName = "yorkie.v1.DeactivateClientRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DeactivateClientRequest {
@@ -189,6 +195,11 @@ export class AttachDocumentRequest extends Message<AttachDocumentRequest> {
    */
   schemaKey = "";
 
+  /**
+   * @generated from field: string client_key = 4;
+   */
+  clientKey = "";
+
   constructor(data?: PartialMessage<AttachDocumentRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -200,6 +211,7 @@ export class AttachDocumentRequest extends Message<AttachDocumentRequest> {
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "change_pack", kind: "message", T: ChangePack },
     { no: 3, name: "schema_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AttachDocumentRequest {
@@ -298,6 +310,11 @@ export class DetachDocumentRequest extends Message<DetachDocumentRequest> {
    */
   removeIfNotAttached = false;
 
+  /**
+   * @generated from field: string client_key = 5;
+   */
+  clientKey = "";
+
   constructor(data?: PartialMessage<DetachDocumentRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -310,6 +327,7 @@ export class DetachDocumentRequest extends Message<DetachDocumentRequest> {
     { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "change_pack", kind: "message", T: ChangePack },
     { no: 4, name: "remove_if_not_attached", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 5, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DetachDocumentRequest {
@@ -380,6 +398,11 @@ export class WatchDocumentRequest extends Message<WatchDocumentRequest> {
    */
   documentId = "";
 
+  /**
+   * @generated from field: string client_key = 3;
+   */
+  clientKey = "";
+
   constructor(data?: PartialMessage<WatchDocumentRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -390,6 +413,7 @@ export class WatchDocumentRequest extends Message<WatchDocumentRequest> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): WatchDocumentRequest {
@@ -515,6 +539,11 @@ export class RemoveDocumentRequest extends Message<RemoveDocumentRequest> {
    */
   changePack?: ChangePack;
 
+  /**
+   * @generated from field: string client_key = 4;
+   */
+  clientKey = "";
+
   constructor(data?: PartialMessage<RemoveDocumentRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -526,6 +555,7 @@ export class RemoveDocumentRequest extends Message<RemoveDocumentRequest> {
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "change_pack", kind: "message", T: ChangePack },
+    { no: 4, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RemoveDocumentRequest {
@@ -606,6 +636,11 @@ export class PushPullChangesRequest extends Message<PushPullChangesRequest> {
    */
   pushOnly = false;
 
+  /**
+   * @generated from field: string client_key = 5;
+   */
+  clientKey = "";
+
   constructor(data?: PartialMessage<PushPullChangesRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -618,6 +653,7 @@ export class PushPullChangesRequest extends Message<PushPullChangesRequest> {
     { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "change_pack", kind: "message", T: ChangePack },
     { no: 4, name: "push_only", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
+    { no: 5, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): PushPullChangesRequest {
@@ -698,6 +734,11 @@ export class BroadcastRequest extends Message<BroadcastRequest> {
    */
   payload = new Uint8Array(0);
 
+  /**
+   * @generated from field: string client_key = 5;
+   */
+  clientKey = "";
+
   constructor(data?: PartialMessage<BroadcastRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -710,6 +751,7 @@ export class BroadcastRequest extends Message<BroadcastRequest> {
     { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "topic", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 4, name: "payload", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
+    { no: 5, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): BroadcastRequest {

--- a/packages/sdk/src/api/yorkie/v1/yorkie_pb.ts
+++ b/packages/sdk/src/api/yorkie/v1/yorkie_pb.ts
@@ -186,6 +186,11 @@ export class AttachDocumentRequest extends Message<AttachDocumentRequest> {
   clientId = "";
 
   /**
+   * @generated from field: string client_key = 4;
+   */
+  clientKey = "";
+
+  /**
    * @generated from field: yorkie.v1.ChangePack change_pack = 2;
    */
   changePack?: ChangePack;
@@ -194,11 +199,6 @@ export class AttachDocumentRequest extends Message<AttachDocumentRequest> {
    * @generated from field: string schema_key = 3;
    */
   schemaKey = "";
-
-  /**
-   * @generated from field: string client_key = 4;
-   */
-  clientKey = "";
 
   constructor(data?: PartialMessage<AttachDocumentRequest>) {
     super();
@@ -209,9 +209,9 @@ export class AttachDocumentRequest extends Message<AttachDocumentRequest> {
   static readonly typeName = "yorkie.v1.AttachDocumentRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "change_pack", kind: "message", T: ChangePack },
     { no: 3, name: "schema_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 4, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): AttachDocumentRequest {
@@ -296,6 +296,11 @@ export class DetachDocumentRequest extends Message<DetachDocumentRequest> {
   clientId = "";
 
   /**
+   * @generated from field: string client_key = 5;
+   */
+  clientKey = "";
+
+  /**
    * @generated from field: string document_id = 2;
    */
   documentId = "";
@@ -310,11 +315,6 @@ export class DetachDocumentRequest extends Message<DetachDocumentRequest> {
    */
   removeIfNotAttached = false;
 
-  /**
-   * @generated from field: string client_key = 5;
-   */
-  clientKey = "";
-
   constructor(data?: PartialMessage<DetachDocumentRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -324,10 +324,10 @@ export class DetachDocumentRequest extends Message<DetachDocumentRequest> {
   static readonly typeName = "yorkie.v1.DetachDocumentRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 5, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "change_pack", kind: "message", T: ChangePack },
     { no: 4, name: "remove_if_not_attached", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 5, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): DetachDocumentRequest {
@@ -394,14 +394,14 @@ export class WatchDocumentRequest extends Message<WatchDocumentRequest> {
   clientId = "";
 
   /**
-   * @generated from field: string document_id = 2;
-   */
-  documentId = "";
-
-  /**
    * @generated from field: string client_key = 3;
    */
   clientKey = "";
+
+  /**
+   * @generated from field: string document_id = 2;
+   */
+  documentId = "";
 
   constructor(data?: PartialMessage<WatchDocumentRequest>) {
     super();
@@ -412,8 +412,8 @@ export class WatchDocumentRequest extends Message<WatchDocumentRequest> {
   static readonly typeName = "yorkie.v1.WatchDocumentRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): WatchDocumentRequest {
@@ -530,6 +530,11 @@ export class RemoveDocumentRequest extends Message<RemoveDocumentRequest> {
   clientId = "";
 
   /**
+   * @generated from field: string client_key = 4;
+   */
+  clientKey = "";
+
+  /**
    * @generated from field: string document_id = 2;
    */
   documentId = "";
@@ -538,11 +543,6 @@ export class RemoveDocumentRequest extends Message<RemoveDocumentRequest> {
    * @generated from field: yorkie.v1.ChangePack change_pack = 3;
    */
   changePack?: ChangePack;
-
-  /**
-   * @generated from field: string client_key = 4;
-   */
-  clientKey = "";
 
   constructor(data?: PartialMessage<RemoveDocumentRequest>) {
     super();
@@ -553,9 +553,9 @@ export class RemoveDocumentRequest extends Message<RemoveDocumentRequest> {
   static readonly typeName = "yorkie.v1.RemoveDocumentRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 4, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "change_pack", kind: "message", T: ChangePack },
-    { no: 4, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): RemoveDocumentRequest {
@@ -622,6 +622,11 @@ export class PushPullChangesRequest extends Message<PushPullChangesRequest> {
   clientId = "";
 
   /**
+   * @generated from field: string client_key = 5;
+   */
+  clientKey = "";
+
+  /**
    * @generated from field: string document_id = 2;
    */
   documentId = "";
@@ -636,11 +641,6 @@ export class PushPullChangesRequest extends Message<PushPullChangesRequest> {
    */
   pushOnly = false;
 
-  /**
-   * @generated from field: string client_key = 5;
-   */
-  clientKey = "";
-
   constructor(data?: PartialMessage<PushPullChangesRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -650,10 +650,10 @@ export class PushPullChangesRequest extends Message<PushPullChangesRequest> {
   static readonly typeName = "yorkie.v1.PushPullChangesRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 5, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "change_pack", kind: "message", T: ChangePack },
     { no: 4, name: "push_only", kind: "scalar", T: 8 /* ScalarType.BOOL */ },
-    { no: 5, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): PushPullChangesRequest {
@@ -720,6 +720,11 @@ export class BroadcastRequest extends Message<BroadcastRequest> {
   clientId = "";
 
   /**
+   * @generated from field: string client_key = 5;
+   */
+  clientKey = "";
+
+  /**
    * @generated from field: string document_id = 2;
    */
   documentId = "";
@@ -734,11 +739,6 @@ export class BroadcastRequest extends Message<BroadcastRequest> {
    */
   payload = new Uint8Array(0);
 
-  /**
-   * @generated from field: string client_key = 5;
-   */
-  clientKey = "";
-
   constructor(data?: PartialMessage<BroadcastRequest>) {
     super();
     proto3.util.initPartial(data, this);
@@ -748,10 +748,10 @@ export class BroadcastRequest extends Message<BroadcastRequest> {
   static readonly typeName = "yorkie.v1.BroadcastRequest";
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "client_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 5, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "document_id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 3, name: "topic", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 4, name: "payload", kind: "scalar", T: 12 /* ScalarType.BYTES */ },
-    { no: 5, name: "client_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
   ]);
 
   static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): BroadcastRequest {

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -364,7 +364,7 @@ export class Client {
     const task = async () => {
       try {
         await this.rpcClient.deactivateClient(
-          { clientId: this.id! },
+          { clientId: this.id!, clientKey: this.key },
           { headers: { 'x-shard-key': `${this.apiKey}/${this.key}` } },
         );
         this.deactivateInternal();
@@ -442,6 +442,7 @@ export class Client {
         const res = await this.rpcClient.attachDocument(
           {
             clientId: this.id!,
+            clientKey: this.key,
             changePack: converter.toChangePack(doc.createChangePack()),
             schemaKey: opts.schema,
           },
@@ -538,6 +539,7 @@ export class Client {
         const res = await this.rpcClient.detachDocument(
           {
             clientId: this.id!,
+            clientKey: this.key,
             documentId: attachment.docID,
             changePack: converter.toChangePack(doc.createChangePack()),
             removeIfNotAttached: opts.removeIfNotAttached ?? false,
@@ -697,6 +699,7 @@ export class Client {
         const res = await this.rpcClient.removeDocument(
           {
             clientId: this.id!,
+            clientKey: this.key,
             documentId: attachment.docID,
             changePack: pbChangePack,
           },
@@ -801,6 +804,7 @@ export class Client {
           await this.rpcClient.broadcast(
             {
               clientId: this.id!,
+              clientKey: this.key,
               documentId: attachment.docID,
               topic,
               payload: new TextEncoder().encode(JSON.stringify(payload)),
@@ -939,6 +943,7 @@ export class Client {
         const stream = this.rpcClient.watchDocument(
           {
             clientId: this.id!,
+            clientKey: this.key,
             documentId: attachment.docID,
           },
           {
@@ -1064,6 +1069,7 @@ export class Client {
       const res = await this.rpcClient.pushPullChanges(
         {
           clientId: this.id!,
+          clientKey: this.key,
           documentId: docID,
           changePack: converter.toChangePack(reqPack),
           pushOnly: syncMode === SyncMode.RealtimePushOnly,


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?


This PR for https://github.com/yorkie-team/yorkie/pull/1371

Add clientKey field to yorkie API requests for clients collection key-wide hashed sharding

#### Any background context you want to provide?

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->


### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for including a client key in various document and client-related requests, enhancing identification options for client operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->