### PR TITLE
Add three reverse op about Array

### DIFF
--- a/packages/sdk/src/document/operation/add_operation.ts
+++ b/packages/sdk/src/document/operation/add_operation.ts
@@ -22,6 +22,7 @@ import {
   Operation,
   ExecutionResult,
 } from '@yorkie-js/sdk/src/document/operation/operation';
+import { RemoveOperation } from '@yorkie-js/sdk/src/document/operation/remove_operation';
 import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
@@ -35,7 +36,7 @@ export class AddOperation extends Operation {
     parentCreatedAt: TimeTicket,
     prevCreatedAt: TimeTicket,
     value: CRDTElement,
-    executedAt: TimeTicket,
+    executedAt?: TimeTicket,
   ) {
     super(parentCreatedAt, executedAt);
     this.prevCreatedAt = prevCreatedAt;
@@ -49,7 +50,7 @@ export class AddOperation extends Operation {
     parentCreatedAt: TimeTicket,
     prevCreatedAt: TimeTicket,
     value: CRDTElement,
-    executedAt: TimeTicket,
+    executedAt?: TimeTicket,
   ): AddOperation {
     return new AddOperation(parentCreatedAt, prevCreatedAt, value, executedAt);
   }
@@ -84,7 +85,18 @@ export class AddOperation extends Operation {
           index: Number(array.subPathOf(this.getEffectedCreatedAt())),
         },
       ],
+      reverseOp: this.toReverseOperation(),
     };
+  }
+
+  private toReverseOperation(): Operation {
+    // NOTE(KMSstudio): executedAt is assigned just before execution, when Document.undo() is called.
+    const reverseOp = RemoveOperation.create(
+      this.getParentCreatedAt(),
+      this.value.getCreatedAt()
+    );
+
+    return reverseOp;
   }
 
   /**

--- a/packages/sdk/src/document/operation/add_operation.ts
+++ b/packages/sdk/src/document/operation/add_operation.ts
@@ -93,7 +93,7 @@ export class AddOperation extends Operation {
     // NOTE(KMSstudio): executedAt is assigned just before execution, when Document.undo() is called.
     const reverseOp = RemoveOperation.create(
       this.getParentCreatedAt(),
-      this.value.getCreatedAt()
+      this.value.getCreatedAt(),
     );
 
     return reverseOp;

--- a/packages/sdk/src/document/operation/move_operation.ts
+++ b/packages/sdk/src/document/operation/move_operation.ts
@@ -34,7 +34,7 @@ export class MoveOperation extends Operation {
     parentCreatedAt: TimeTicket,
     prevCreatedAt: TimeTicket,
     createdAt: TimeTicket,
-    executedAt: TimeTicket,
+    executedAt?: TimeTicket,
   ) {
     super(parentCreatedAt, executedAt);
     this.prevCreatedAt = prevCreatedAt;
@@ -48,7 +48,7 @@ export class MoveOperation extends Operation {
     parentCreatedAt: TimeTicket,
     prevCreatedAt: TimeTicket,
     createdAt: TimeTicket,
-    executedAt: TimeTicket,
+    executedAt?: TimeTicket,
   ): MoveOperation {
     return new MoveOperation(
       parentCreatedAt,
@@ -76,6 +76,8 @@ export class MoveOperation extends Operation {
       );
     }
     const array = parentObject as CRDTArray;
+    const reverseOp = this.toReverseOperation(array);
+    
     const previousIndex = Number(array.subPathOf(this.createdAt));
     array.moveAfter(this.prevCreatedAt, this.createdAt, this.getExecutedAt());
     const index = Number(array.subPathOf(this.createdAt));
@@ -88,7 +90,20 @@ export class MoveOperation extends Operation {
           previousIndex,
         },
       ],
+      reverseOp: reverseOp,
     };
+  }
+
+  private toReverseOperation(
+    array: CRDTArray,
+  ): Operation {
+    const preservePrevCreatedAt = array.getPrevCreatedAt(this.createdAt);
+    // NOTE(KMSstudio): executedAt is assigned just before execution, when Document.undo() is called.
+    return MoveOperation.create(
+      this.getParentCreatedAt(),
+      this.createdAt,
+      preservePrevCreatedAt
+    );
   }
 
   /**

--- a/packages/sdk/src/document/operation/move_operation.ts
+++ b/packages/sdk/src/document/operation/move_operation.ts
@@ -77,7 +77,7 @@ export class MoveOperation extends Operation {
     }
     const array = parentObject as CRDTArray;
     const reverseOp = this.toReverseOperation(array);
-    
+
     const previousIndex = Number(array.subPathOf(this.createdAt));
     array.moveAfter(this.prevCreatedAt, this.createdAt, this.getExecutedAt());
     const index = Number(array.subPathOf(this.createdAt));
@@ -90,19 +90,17 @@ export class MoveOperation extends Operation {
           previousIndex,
         },
       ],
-      reverseOp: reverseOp,
+      reverseOp,
     };
   }
 
-  private toReverseOperation(
-    array: CRDTArray,
-  ): Operation {
+  private toReverseOperation(array: CRDTArray): Operation {
     const preservePrevCreatedAt = array.getPrevCreatedAt(this.createdAt);
     // NOTE(KMSstudio): executedAt is assigned just before execution, when Document.undo() is called.
     return MoveOperation.create(
       this.getParentCreatedAt(),
       this.createdAt,
-      preservePrevCreatedAt
+      preservePrevCreatedAt,
     );
   }
 

--- a/packages/sdk/src/document/operation/remove_operation.ts
+++ b/packages/sdk/src/document/operation/remove_operation.ts
@@ -29,6 +29,7 @@ import {
 import { CRDTObject } from '@yorkie-js/sdk/src/document/crdt/object';
 import { CRDTArray } from '@yorkie-js/sdk/src/document/crdt/array';
 import { SetOperation } from '@yorkie-js/sdk/src/document/operation/set_operation';
+import { AddOperation } from '@yorkie-js/sdk/src/document/operation/add_operation';
 import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
@@ -91,6 +92,8 @@ export class RemoveOperation extends Operation {
       }
     }
     const key = container.subPathOf(this.createdAt);
+    // NOTE(KMSstudio): Both `toReverseOperation` and `container.delete` internally
+    // look up the CRDTElement using `createdAt`.
     const reverseOp = this.toReverseOperation(container);
 
     const elem = container.delete(this.createdAt, this.getExecutedAt());
@@ -122,7 +125,18 @@ export class RemoveOperation extends Operation {
   private toReverseOperation(
     parentObject: CRDTContainer,
   ): Operation | undefined {
-    // TODO(Hyemmie): consider CRDTArray
+    if (parentObject instanceof CRDTArray) {
+      const value = parentObject.getByID(this.createdAt);
+      if (value !== undefined) {
+        const prevCreatedAt: TimeTicket = parentObject.getPrevCreatedAt(this.createdAt);
+        // NOTE(KMSstudio): executedAt is assigned just before execution, when Document.undo() is called.
+        return AddOperation.create(
+          this.getParentCreatedAt(),
+          prevCreatedAt,
+          value.deepcopy()
+        );
+      }
+    }
     if (parentObject instanceof CRDTObject) {
       const key = parentObject.subPathOf(this.createdAt);
       if (key !== undefined) {

--- a/packages/sdk/src/document/operation/remove_operation.ts
+++ b/packages/sdk/src/document/operation/remove_operation.ts
@@ -128,12 +128,14 @@ export class RemoveOperation extends Operation {
     if (parentObject instanceof CRDTArray) {
       const value = parentObject.getByID(this.createdAt);
       if (value !== undefined) {
-        const prevCreatedAt: TimeTicket = parentObject.getPrevCreatedAt(this.createdAt);
+        const prevCreatedAt: TimeTicket = parentObject.getPrevCreatedAt(
+          this.createdAt,
+        );
         // NOTE(KMSstudio): executedAt is assigned just before execution, when Document.undo() is called.
         return AddOperation.create(
           this.getParentCreatedAt(),
           prevCreatedAt,
-          value.deepcopy()
+          value.deepcopy(),
         );
       }
     }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR adds support for generating reverse operations for array operations in CRDT:
- `AddOperation` → reverted by `RemoveOperation`
- `RemoveOperation` → reverted by `AddOperation` with original value and position
- `MoveOperation` → reverted by a `MoveOperation` to restore previous position

These reverse operations are essential for enabling undo/redo functionality in collaborative editing environments.

#### Any background context you want to provide?

- Array operations use `add/remove`, whereas Object operations use `set/remove`.  
  They only overlap on `remove`, which may indicate inconsistent semantics.  
  It's unclear whether this is intentional. A clearer separation might be preferable,  
  but for now it's left untouched due to potential side effects.

- There are multiple lookups by `createdAt`, for example:
  ```ts
  const reverseOp = this.toReverseOperation(container);
  const elem = container.delete(this.createdAt, this.getExecutedAt());
  ```
In this pattern, the element is retrieved twice from the internal map using the same `createdAt`.
It may be more efficient to retrieve the element once and pass it through as a `Element`,
but this would require structural changes to `delete()`, so it's deferred for now.

- This PR does not address the issue described in yorkie iss990.
It assumes the following algebraic properties hold during execution:

For arbitrary operations, a + b = b + a (commutativity).
For nested operations, a + (b * c) = (a + b) * c (distributivity-like associativity).
The first property is achievable from time-based conflict resolution using TimeTicket.

#### What are the relevant tickets?

About [yorkie iss652](https://github.com/yorkie-team/yorkie/issues/652)
About [yorkie iss990](https://github.com/yorkie-team/yorkie/issues/990) but not deal about it

### Checklist
- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything
