### PR TITLE
Cleanup ESLint packages/sdk

### DIFF
--- a/packages/sdk/.eslintrc.js
+++ b/packages/sdk/.eslintrc.js
@@ -14,4 +14,11 @@ module.exports = {
       },
     },
   ],
+  ignorePatterns: [
+    'dist/**/*',
+    '**/*.d.ts',
+    // TODO(pengooseDev): Consider unifying the test file naming convention (e.g. .test or _test)
+    '**/*_test.ts',
+    '**/*.bench.ts',
+  ],
 };

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -23,7 +23,8 @@
     "test:bench": "vitest bench",
     "test:ci": "vitest run --coverage",
     "test:yorkie.dev": "TEST_RPC_ADDR=https://api.yorkie.dev vitest run --coverage",
-    "prepare": "pnpm build"
+    "prepare": "pnpm build",
+    "lint": "eslint . --fix --max-warnings=0 --ext .ts,.tsx"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/packages/sdk/src/document/crdt/object.ts
+++ b/packages/sdk/src/document/crdt/object.ts
@@ -173,7 +173,7 @@ export class CRDTObject extends CRDTContainer {
    * `getKeys` returns array of keys in this object.
    */
   public getKeys(): Array<string> {
-    const keys = Array<string>();
+    const keys: Array<string> = [];
     for (const [key] of this) {
       keys.push(key);
     }
@@ -185,7 +185,7 @@ export class CRDTObject extends CRDTContainer {
    * `toSortedJSON` returns the sorted JSON encoding of this object.
    */
   public toSortedJSON(): string {
-    const keys = Array<string>();
+    const keys: Array<string> = [];
     for (const [key] of this) {
       keys.push(key);
     }

--- a/packages/sdk/src/document/json/tree.ts
+++ b/packages/sdk/src/document/json/tree.ts
@@ -647,7 +647,7 @@ export class Tree {
     }
 
     const ticket = this.context!.getLastTimeTicket();
-    let crdtNodes = new Array<CRDTTreeNode>();
+    let crdtNodes: Array<CRDTTreeNode> = [];
 
     if (contents[0]?.type === DefaultTextType) {
       let compVal = '';


### PR DESCRIPTION
#### What this PR does / why we need it?
Scope: `packages/sdk`
- Add Linting script
- Ignore ESLint scope(test, build, bench, d.ts)

---
#### Any background context you want to provide?
Follow #1016 

---

### Need Feedbacks
I have a question about our current test file naming conventions. Here’s a summary:

| Package           | Test Type      | Naming Pattern      |
|-------------------|----------------|---------------------|
| **packages/sdk**  | Unit           | `*_test.ts`         |
|                   | Integration    | `*_test.ts`         |
|                   | Bench          | `*.bench.ts`        |
| **packages/schema** | Unit         | `*.test.ts`         |

- The `_test` suffix in **packages/sdk** was carried over from Go’s testing conventions.
- We could unify on a single separator (either `.` or `_`) for consistency, **or**
- We could keep the current patterns to preserve the Go-inspired convention.

If team like to revise naming conventions, I can incorporate those changes in this PR. If team prefer to leave things as they are, I’ll remove the unnecessary TODO comments.

---
### Linting
<div align="center">
  <table>
    <tr>
      <th>Prev</th>
    </tr>
    <tr>
      <td valign="top">
<img width="830" alt="image" src="https://github.com/user-attachments/assets/6f8adcc9-bc3a-4836-aca1-a0040b9e1540" />
      </td>
    </tr>
    <tr>
      <th>Fixed</th>
    </tr>
    <tr>
      <td valign="top">
<img width="830" alt="image" src="https://github.com/user-attachments/assets/97a3b369-e2d6-4cef-abfb-c70a9d3ba427" />
      </td>
    </tr>
  </table>
</div>


### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments(Review skipped)
- [x] Didn't break anything
