### PR TITLE
Update deprecated pprof flag

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   yorkie:
     image: 'yorkieteam/yorkie:latest'
     container_name: 'yorkie'
-    command: ['server', '--enable-pprof']
+    command: ['server', '--pprof-enabled']
     restart: always
     ports:
       - '8080:8080'


### PR DESCRIPTION
#### What this PR does / why we need it?

<div align="center">
  <table>
    <tr>
      <th>Prev(CONNECTION ERROR)</th>
    </tr>
    <tr>
      <td valign="top">
<img width="830" alt="image" src="https://github.com/user-attachments/assets/1314c9ce-3b2d-4204-8b93-98b6f4eb2a99" />
      </td>
    </tr>
    <tr>
      <th>Fixed</th>
    </tr>
    <tr>
      <td valign="top">
<img width="830" alt="image" src="https://github.com/user-attachments/assets/7a01ab9d-84f7-405f-a0fe-745a1af7f68c" />
      </td>
    </tr>
  </table>
</div>

The `--enable-pprof` flag has been replaced with `--pprof-enabled` the Yorkie server. This update switches the Docker Compose command to the new --pprof-enabled option to enable runtime profiling
Follow https://github.com/yorkie-team/yorkie/pull/1364

#### What are the relevant tickets?
Fixes #1019 

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the profiling flag for the Yorkie service in the Docker Compose configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->