### PR TITLE
Fix eslint cleanup sdk

### DIFF
--- a/examples/nextjs-quill/lib/utils.ts
+++ b/examples/nextjs-quill/lib/utils.ts
@@ -23,8 +23,8 @@ export const toDeltaOperation = <T extends TextValueType>(textValue: T): Op => {
 };
 
 // Convert array of Yorkie OperationInfo to array of Quill Delta Operations
-export const getDeltaOperations = (ops: OperationInfo[]): Op[] => {
-  const operations: Op[] = [];
+export const getDeltaOperations = (ops: Array<OperationInfo>): Array<Op> => {
+  const operations: Array<Op> = [];
   let prevTo = 0;
 
   for (const op of ops) {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,8 @@
     "eslint": "^8.57.1",
     "eslint-plugin-jsdoc": "^50.7.1",
     "eslint-plugin-prettier": "^5.2.3",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
     "husky": "^9.1.7",
     "lint-staged": "^15.4.3",
     "only-allow": "^1.2.1"

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "dev": "plasmo dev --build-path=dist",
     "build": "plasmo build --build-path=dist --zip",
-    "test": "plasmo test"
+    "test": "plasmo test",
+    "lint": "eslint . --fix --max-warnings=0 --ext .ts,.tsx"
   },
   "dependencies": {
     "@microlink/react-json-view": "^1.23.0",

--- a/packages/devtools/src/devtools/components/Code.tsx
+++ b/packages/devtools/src/devtools/components/Code.tsx
@@ -62,6 +62,16 @@ const theme: PrismTheme = {
   ],
 };
 
+/**
+ * Renders a syntax-highlighted code block using Prism.
+ *
+ * @param code - The source code string to be highlighted.
+ * @param language - The language identifier supported by Prism
+ *   (See https://prismjs.com/index.html#supported-languages for supported languages).
+ * @param withLineNumbers - Whether to display line numbers before each line.
+ *   Defaults to `false`.
+ * @returns A React element containing the highlighted code block.
+ */
 export function Code({
   code,
   language,

--- a/packages/devtools/src/devtools/components/Detail.tsx
+++ b/packages/devtools/src/devtools/components/Detail.tsx
@@ -28,7 +28,10 @@ type FlatTreeNodeInfo = Devtools.TreeNodeInfo & {
 };
 
 /**
- * `nodeIDToString` converts the given CRDTTreeNodeIDStruct to a simple string.
+ * Convert a CRDTTreeNodeIDStruct into a readable identifier string.
+ *
+ * @param id - CRDTTreeNodeIDStruct with creation metadata and offset.
+ * @returns A string formatted as `${lamport}:${actorID.slice(-2)}:${delimiter}/${offset}`.
  */
 const nodeIDToString = (id: CRDTTreeNodeIDStruct) => {
   const {
@@ -38,6 +41,11 @@ const nodeIDToString = (id: CRDTTreeNodeIDStruct) => {
   return `${lamport}:${actorID.slice(-2)}:${delimiter}/${offset}`;
 };
 
+/**
+ * Render one tree node with depth-based styling and tooltip info.
+ *
+ * @param props.node - FlatTreeNodeInfo including type, value, id, depth, childIndex, etc.
+ */
 function TreeNode({ node }: { node: FlatTreeNodeInfo }) {
   // NOTE(chacha912): The 'depth' variable is used for styling purposes.
   // For 'text' nodes, when they are not the first child node, 'depth' is
@@ -94,6 +102,11 @@ function TreeNode({ node }: { node: FlatTreeNodeInfo }) {
   );
 }
 
+/**
+ * Flatten the tree and render each node via TreeNode.
+ *
+ * @param props.tree - Root Devtools.TreeNodeInfo to flatten and display.
+ */
 function TreeGraph({ tree }: { tree: Devtools.TreeNodeInfo }) {
   const flattenTreeWithDepth = useCallback(
     (
@@ -119,6 +132,12 @@ function TreeGraph({ tree }: { tree: Devtools.TreeNodeInfo }) {
   );
 }
 
+/**
+ * Show selected node details with JSON or graph view toggle.
+ *
+ * @param props.node - The currently selected RootTreeNode.
+ * @param props.tree - The full Devtools.TreeNodeInfo for graph mode.
+ */
 export function TreeDetail({
   node,
   tree,
@@ -162,6 +181,11 @@ export function TreeDetail({
   );
 }
 
+/**
+ * Display a JSON string in a syntax‑highlighted code block with line numbers.
+ *
+ * @param props.json - The JSON text to render.
+ */
 export function JSONDetail({ json }: { json: string }) {
   return <Code code={json ?? ''} language="json" withLineNumbers />;
 }

--- a/packages/devtools/src/devtools/components/JsonView.tsx
+++ b/packages/devtools/src/devtools/components/JsonView.tsx
@@ -16,6 +16,12 @@
 
 import ReactJsonView from '@microlink/react-json-view';
 
+/**
+ * Render JSON data using ReactJsonView with custom styling and options.
+ *
+ * @param props.src - The JSON object or array to display.
+ * @returns A React element that visualizes the provided JSON.
+ */
 export function JSONView({ src }) {
   return (
     <ReactJsonView

--- a/packages/devtools/src/devtools/components/ResizableSeparator.tsx
+++ b/packages/devtools/src/devtools/components/ResizableSeparator.tsx
@@ -17,6 +17,14 @@
 import { useState } from 'react';
 import classNames from 'classnames';
 
+/**
+ * Render a focusable separator bar with drag and focus styling.
+ *
+ * @param props.id - Element id and test-id (default: 'drag-bar').
+ * @param props.dir - Orientation: 'horizontal' or 'vertical'.
+ * @param props.isDragging - Whether the separator is being dragged.
+ * @param props... - Additional props spread onto the root div.
+ */
 export function Separator({ id = 'drag-bar', dir, isDragging, ...props }: any) {
   const [isFocused, setIsFocused] = useState(false);
 

--- a/packages/devtools/src/devtools/contexts/SelectedNode.tsx
+++ b/packages/devtools/src/devtools/contexts/SelectedNode.tsx
@@ -23,11 +23,19 @@ type SelectedNodeContext = [
   RootTreeNode,
   Dispatch<SetStateAction<RootTreeNode>>,
 ];
+// eslint-disable-next-line @typescript-eslint/ban-types
 const SelectedNodeContext = createContext<SelectedNodeContext | null>(null);
 
 type Props = {
   children?: ReactNode;
 };
+
+/**
+ * Provides selected node context to descendant components.
+ *
+ * @param props.children - React elements that consume the selected node context.
+ * @returns A context provider wrapping the given children.
+ */
 export function SelectedNodeProvider({ children }: Props) {
   const selectedNodeState = useState(null);
 
@@ -38,6 +46,12 @@ export function SelectedNodeProvider({ children }: Props) {
   );
 }
 
+/**
+ * Hook to access and update the currently selected tree node.
+ *
+ * @throws YorkieError if called outside of a SelectedNodeProvider.
+ * @returns A tuple [selectedNode, setSelectedNode].
+ */
 export function useSelectedNode() {
   const value = useContext(SelectedNodeContext);
   if (value === undefined) {

--- a/packages/devtools/src/devtools/contexts/SelectedPresence.tsx
+++ b/packages/devtools/src/devtools/contexts/SelectedPresence.tsx
@@ -23,6 +23,7 @@ type SelectedPresenceContext = [
   PresenceJsonNode,
   Dispatch<SetStateAction<PresenceJsonNode>>,
 ];
+// eslint-disable-next-line @typescript-eslint/ban-types
 const SelectedPresenceContext = createContext<SelectedPresenceContext | null>(
   null,
 );
@@ -30,6 +31,13 @@ const SelectedPresenceContext = createContext<SelectedPresenceContext | null>(
 type Props = {
   children?: ReactNode;
 };
+
+/**
+ * Provides selected presence context to descendant components.
+ *
+ * @param props.children - React elements that consume the selected presence context.
+ * @returns A context provider wrapping the given children.
+ */
 export function SelectedPresenceProvider({ children }: Props) {
   const selectedPresenceState = useState(null);
 
@@ -40,6 +48,12 @@ export function SelectedPresenceProvider({ children }: Props) {
   );
 }
 
+/**
+ * Hook to access and update the currently selected presence node.
+ *
+ * @throws YorkieError if called outside of a SelectedPresenceProvider.
+ * @returns A tuple [selectedPresence, setSelectedPresence].
+ */
 export function useSelectedPresence() {
   const value = useContext(SelectedPresenceContext);
   if (value === undefined) {

--- a/packages/devtools/src/devtools/contexts/YorkieSource.tsx
+++ b/packages/devtools/src/devtools/contexts/YorkieSource.tsx
@@ -40,6 +40,12 @@ type Props = {
   children?: ReactNode;
 };
 
+/**
+ * Provides the current document key and events for replay.
+ *
+ * @param props.children - React elements that consume the document context.
+ * @returns A context provider wrapping the given children.
+ */
 export function YorkieSourceProvider({ children }: Props) {
   const [currentDocKey, setCurrentDocKey] = useState<string>('');
   const [doc, setDoc] = useState(null);
@@ -118,6 +124,12 @@ export function YorkieSourceProvider({ children }: Props) {
   );
 }
 
+/**
+ * Hook to access the current document key.
+ *
+ * @throws YorkieError if called outside of a YorkieSourceProvider.
+ * @returns The current document key.
+ */
 export function useCurrentDocKey() {
   const value = useContext(DocKeyContext);
   if (value === undefined) {
@@ -129,6 +141,12 @@ export function useCurrentDocKey() {
   return value;
 }
 
+/**
+ * Hook to access the current Yorkie document.
+ *
+ * @throws YorkieError if called outside of a YorkieSourceProvider.
+ * @returns The current Yorkie document.
+ */
 export function useYorkieDoc() {
   const value = useContext(YorkieDocContext);
   if (value === undefined) {
@@ -167,6 +185,12 @@ export const getDocEventsScope = (
   return DocEventScope.Presence;
 };
 
+/**
+ * Hook to access and manipulate document events for replay.
+ *
+ * @throws YorkieError if called outside of a YorkieSourceProvider.
+ * @returns An object containing the original events, filtered events, and methods to control filtering.
+ */
 export function useDocEventsForReplay() {
   const { events, hidePresenceEvents, setHidePresenceEvents } = useContext(
     DocEventsForReplayContext,

--- a/packages/devtools/src/devtools/icons/index.tsx
+++ b/packages/devtools/src/devtools/icons/index.tsx
@@ -16,6 +16,12 @@
 
 import type { ComponentProps } from 'react';
 
+/**
+ * Render an SVG icon for an object node.
+ *
+ * @param props - SVG props for styling and size.
+ * @returns A React component that renders the object icon.
+ */
 export function ObjectIcon(props: ComponentProps<'svg'>) {
   return (
     <svg
@@ -35,6 +41,12 @@ export function ObjectIcon(props: ComponentProps<'svg'>) {
   );
 }
 
+/**
+ * Render an SVG icon for an array node.
+ *
+ * @param props - SVG props for styling and size.
+ * @returns A React component that renders the array icon.
+ */
 export function ArrayIcon(props: ComponentProps<'svg'>) {
   return (
     <svg
@@ -54,6 +66,12 @@ export function ArrayIcon(props: ComponentProps<'svg'>) {
   );
 }
 
+/**
+ * Render an SVG icon for a primitive node.
+ *
+ * @param props - SVG props for styling and size.
+ * @returns A React component that renders the primitive icon.
+ */
 export function PrimitiveIcon(props: ComponentProps<'svg'>) {
   return (
     <svg
@@ -73,6 +91,12 @@ export function PrimitiveIcon(props: ComponentProps<'svg'>) {
   );
 }
 
+/**
+ * Render an SVG icon for a text node.
+ *
+ * @param props - SVG props for styling and size.
+ * @returns A React component that renders the text icon.
+ */
 export function TextIcon(props: ComponentProps<'svg'>) {
   return (
     <svg
@@ -92,6 +116,12 @@ export function TextIcon(props: ComponentProps<'svg'>) {
   );
 }
 
+/**
+ * Render an SVG icon for a tree node.
+ *
+ * @param props - SVG props for styling and size.
+ * @returns A React component that renders the tree icon.
+ */
 export function TreeIcon(props: ComponentProps<'svg'>) {
   return (
     <svg
@@ -111,6 +141,12 @@ export function TreeIcon(props: ComponentProps<'svg'>) {
   );
 }
 
+/**
+ * Render an SVG icon for a counter node.
+ *
+ * @param props - SVG props for styling and size.
+ * @returns A React component that renders the counter icon.
+ */
 export function CounterIcon(props: ComponentProps<'svg'>) {
   return (
     <svg
@@ -130,6 +166,12 @@ export function CounterIcon(props: ComponentProps<'svg'>) {
   );
 }
 
+/**
+ * Render an SVG icon for a user node.
+ *
+ * @param props - SVG props for styling and size.
+ * @returns A React component that renders the user icon.
+ */
 export function UserIcon(props: ComponentProps<'svg'>) {
   return (
     <svg
@@ -149,6 +191,12 @@ export function UserIcon(props: ComponentProps<'svg'>) {
   );
 }
 
+/**
+ * Render an SVG icon for a close button.
+ *
+ * @param props - SVG props for styling and size.
+ * @returns A React component that renders the close icon.
+ */
 export function CloseIcon(props: ComponentProps<'svg'>) {
   return (
     <svg
@@ -168,6 +216,12 @@ export function CloseIcon(props: ComponentProps<'svg'>) {
   );
 }
 
+/**
+ * Render an SVG icon for a code node.
+ *
+ * @param props - SVG props for styling and size.
+ * @returns A React component that renders the code icon.
+ */
 export function CodeIcon(props: ComponentProps<'svg'>) {
   return (
     <svg
@@ -187,6 +241,12 @@ export function CodeIcon(props: ComponentProps<'svg'>) {
   );
 }
 
+/**
+ * Render an SVG icon for a graph node.
+ *
+ * @param props - SVG props for styling and size.
+ * @returns A React component that renders the graph icon.
+ */
 export function GraphIcon(props: ComponentProps<'svg'>) {
   return (
     <svg
@@ -206,6 +266,12 @@ export function GraphIcon(props: ComponentProps<'svg'>) {
   );
 }
 
+/**
+ * Render an SVG icon for a cursor node.
+ *
+ * @param props - SVG props for styling and size.
+ * @returns A React component that renders the cursor icon.
+ */
 export function CursorIcon(props: ComponentProps<'svg'>) {
   return (
     <svg
@@ -225,6 +291,12 @@ export function CursorIcon(props: ComponentProps<'svg'>) {
   );
 }
 
+/**
+ * Render an SVG icon for a document node.
+ *
+ * @param props - SVG props for styling and size.
+ * @returns A React component that renders the document icon.
+ */
 export function DocumentIcon(props: ComponentProps<'svg'>) {
   return (
     <svg

--- a/packages/devtools/src/devtools/index.tsx
+++ b/packages/devtools/src/devtools/index.tsx
@@ -23,6 +23,9 @@ chrome.devtools.panels.create(
   yorkiePanelHTML.split('/').pop(),
 );
 
+/**
+ * Render the main application component into the DOM.
+ */
 function Page() {
   return null;
 }

--- a/packages/devtools/src/devtools/panel/index.tsx
+++ b/packages/devtools/src/devtools/panel/index.tsx
@@ -168,6 +168,11 @@ const Panel = () => {
   );
 };
 
+/**
+ * Main application component that provides the Yorkie source context.
+ *
+ * @returns A React element that renders the Yorkie source provider and panel.
+ */
 function PanelApp() {
   return (
     <YorkieSourceProvider>
@@ -177,4 +182,5 @@ function PanelApp() {
 }
 
 const root = createRoot(document.getElementById('root'));
+// @ts-ignore
 root.render(<PanelApp />);

--- a/packages/devtools/src/devtools/tabs/Document.tsx
+++ b/packages/devtools/src/devtools/tabs/Document.tsx
@@ -23,6 +23,13 @@ import { useSelectedNode } from '../contexts/SelectedNode';
 import { useCurrentDocKey, useYorkieDoc } from '../contexts/YorkieSource';
 import { CloseIcon } from '../icons';
 
+/**
+ * Renders the Document tab showing the Yorkie tree and selected node details.
+ *
+ * @param props.style - Inline styles for the root container.
+ * @param props.hidePresenceTab - Whether the Presence tab is hidden.
+ * @param props.setHidePresenceTab - Setter function to toggle the Presence tab.
+ */
 export function Document({ style, hidePresenceTab, setHidePresenceTab }) {
   const currentDocKey = useCurrentDocKey();
   const [doc] = useYorkieDoc();

--- a/packages/devtools/src/devtools/tabs/History.tsx
+++ b/packages/devtools/src/devtools/tabs/History.tsx
@@ -21,8 +21,15 @@ import { JSONView } from '../components/JsonView';
 import { CursorIcon, DocumentIcon } from '../icons';
 import { DocEventScope, useDocEventsForReplay } from '../contexts/YorkieSource';
 
+// eslint-disable-next-line @typescript-eslint/naming-convention
 const SLIDER_MARK_WIDTH = 24;
 
+/**
+ * Extracts event information from a Devtools.DocEventsForReplay object.
+ *
+ * @param event - The Devtools.DocEventsForReplay object to process.
+ * @returns An array of event information objects.
+ */
 const getEventInfo = (event: Devtools.DocEventsForReplay) => {
   const info = [];
   for (const docEvent of event) {
@@ -58,6 +65,14 @@ const getEventInfo = (event: Devtools.DocEventsForReplay) => {
   return info;
 };
 
+/**
+ * Renders the History tab showing the document events and their details.
+ *
+ * @param props.style - Inline styles for the root container.
+ * @param props.selectedEvent - The currently selected event.
+ * @param props.selectedEventIndexInfo - The index and last status of the selected event.
+ * @param props.setSelectedEventIndexInfo - Setter function to update the selected event index.
+ */
 export function History({
   style,
   selectedEvent,

--- a/packages/devtools/src/devtools/tabs/Presence.tsx
+++ b/packages/devtools/src/devtools/tabs/Presence.tsx
@@ -21,6 +21,12 @@ import { useSelectedPresence } from '../contexts/SelectedPresence';
 import { useYorkieDoc } from '../contexts/YorkieSource';
 import { CloseIcon } from '../icons';
 
+/**
+ * Displays the Presence tab, listing self and others, and shows details
+ * of the currently selected presence entry.
+ *
+ * @returns A React element rendering the presence list and selected details.
+ */
 export function Presence() {
   const [doc] = useYorkieDoc();
   const [selectedPresence, setSelectedPresence] = useSelectedPresence();

--- a/packages/devtools/src/popup/index.tsx
+++ b/packages/devtools/src/popup/index.tsx
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+/**
+ * Renders the popup component that displays a message when the extension is opened.
+ *
+ * @returns A React element rendering the popup content.
+ */
 function Popup() {
   return (
     <div

--- a/packages/schema/src/rulesets.ts
+++ b/packages/schema/src/rulesets.ts
@@ -364,7 +364,10 @@ export class RulesetBuilder implements YorkieSchemaListener {
         const elementPath = `${path}[*]`;
 
         if (typeDef.itemType.kind === 'reference') {
-          if (currentTypeName === typeDef.itemType.typeName && path.includes('[*]')) {
+          if (
+            currentTypeName === typeDef.itemType.typeName &&
+            path.includes('[*]')
+          ) {
             return;
           }
 
@@ -433,7 +436,13 @@ export class RulesetBuilder implements YorkieSchemaListener {
         // Recursively expand properties
         for (const property of typeDef.properties) {
           const propertyPath = `${path}.${property.name}`;
-          this.expandType(property.type, propertyPath, rules, currentTypeName, visited);
+          this.expandType(
+            property.type,
+            propertyPath,
+            rules,
+            currentTypeName,
+            visited,
+          );
         }
         break;
       }
@@ -445,7 +454,8 @@ export class RulesetBuilder implements YorkieSchemaListener {
         }
 
         if (currentTypeName === typeDef.typeName) {
-          if (path.includes('[*]')) { // e.g. Node[] type in Node
+          if (path.includes('[*]')) {
+            // e.g. Node[] type in Node
             if (referencedType.kind === 'object') {
               const objectRule: ObjectRule = {
                 path,
@@ -457,7 +467,8 @@ export class RulesetBuilder implements YorkieSchemaListener {
             return;
           }
 
-          if (referencedType.kind === 'object') { // e.g. Node type in Node
+          if (referencedType.kind === 'object') {
+            // e.g. Node type in Node
             const objectRule: ObjectRule = {
               path,
               type: 'object',

--- a/packages/sdk/.eslintrc.js
+++ b/packages/sdk/.eslintrc.js
@@ -15,10 +15,9 @@ module.exports = {
     },
   ],
   ignorePatterns: [
-    'dist/**/*',
-    '**/*.d.ts',
-    // TODO(pengooseDev): Consider unifying the test file naming convention (e.g. .test or _test)
-    '**/*_test.ts',
-    '**/*.bench.ts',
+    'dist/*',
+    'src/api/yorkie/v1/*.d.ts',
+    'test/vitest.d.ts',
+    'lib',
   ],
 };

--- a/packages/sdk/.eslintrc.js
+++ b/packages/sdk/.eslintrc.js
@@ -14,4 +14,11 @@ module.exports = {
       },
     },
   ],
+  ignorePatterns: [
+    'dist/**/*',
+    '**/*.d.ts',
+    // TODO(pengooseDev): Consider unifying the test file naming convention (e.g. .test or _test)
+    '**/*_test.ts',
+    '**/*.bench.ts',
+  ],
 };

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -23,7 +23,8 @@
     "test:bench": "vitest bench",
     "test:ci": "vitest run --coverage",
     "test:yorkie.dev": "TEST_RPC_ADDR=https://api.yorkie.dev vitest run --coverage",
-    "prepare": "pnpm build"
+    "prepare": "pnpm build",
+    "lint": "eslint . --fix --max-warnings=0 --ext .ts,.tsx"
   },
   "engines": {
     "node": ">=18.0.0",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -28,7 +28,8 @@
   },
   "engines": {
     "node": ">=18.0.0",
-    "npm": ">=7.1.0"
+    "npm": ">=7.1.0",
+    "pnpm": ">=9.6.0"
   },
   "repository": {
     "type": "git",

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -52,8 +52,6 @@
     "@types/express": "^4.17.21",
     "@types/google-protobuf": "^3.15.5",
     "@types/long": "^4.0.1",
-    "@typescript-eslint/eslint-plugin": "^6.21.0",
-    "@typescript-eslint/parser": "^6.21.0",
     "@vitest/coverage-istanbul": "^0.34.5",
     "@vitest/coverage-v8": "^0.34.5",
     "axios": "^1.7.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,12 @@ importers:
 
   .:
     devDependencies:
+      '@typescript-eslint/eslint-plugin':
+        specifier: ^6.21.0
+        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)
+      '@typescript-eslint/parser':
+        specifier: ^6.21.0
+        version: 6.21.0(eslint@8.57.1)(typescript@5.8.2)
       eslint:
         specifier: ^8.57.1
         version: 8.57.1
@@ -618,12 +624,6 @@ importers:
       '@types/long':
         specifier: ^4.0.1
         version: 4.0.2
-      '@typescript-eslint/eslint-plugin':
-        specifier: ^6.21.0
-        version: 6.21.0(@typescript-eslint/parser@6.21.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.3.3))(eslint@9.23.0(jiti@2.4.2))(typescript@5.3.3)
-      '@typescript-eslint/parser':
-        specifier: ^6.21.0
-        version: 6.21.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.3.3)
       '@vitest/coverage-istanbul':
         specifier: ^0.34.5
         version: 0.34.6(vitest@0.34.6(less@4.2.2)(lightningcss@1.29.3)(sass@1.86.0))
@@ -7505,11 +7505,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  semver@7.7.1:
-    resolution: {integrity: sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==}
-    engines: {node: '>=10'}
-    hasBin: true
-
   semver@7.7.2:
     resolution: {integrity: sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==}
     engines: {node: '>=10'}
@@ -11881,6 +11876,26 @@ snapshots:
       '@types/node': 20.9.0
       '@types/send': 0.17.4
 
+  '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2))(eslint@8.57.1)(typescript@5.8.2)':
+    dependencies:
+      '@eslint-community/regexpp': 4.12.1
+      '@typescript-eslint/parser': 6.21.0(eslint@8.57.1)(typescript@5.8.2)
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/type-utils': 6.21.0(eslint@8.57.1)(typescript@5.8.2)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.8.2)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.4.1
+      eslint: 8.57.1
+      graphemer: 1.4.0
+      ignore: 5.3.2
+      natural-compare: 1.4.0
+      semver: 7.7.2
+      ts-api-utils: 1.4.3(typescript@5.8.2)
+    optionalDependencies:
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.3.3))(eslint@9.23.0(jiti@2.4.2))(typescript@5.3.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
@@ -11889,15 +11904,28 @@ snapshots:
       '@typescript-eslint/type-utils': 6.21.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.3.3)
       '@typescript-eslint/utils': 6.21.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0
+      debug: 4.4.1
       eslint: 9.23.0(jiti@2.4.2)
       graphemer: 1.4.0
       ignore: 5.3.2
       natural-compare: 1.4.0
-      semver: 7.7.1
+      semver: 7.7.2
       ts-api-utils: 1.4.3(typescript@5.3.3)
     optionalDependencies:
       typescript: 5.3.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/parser@6.21.0(eslint@8.57.1)(typescript@5.8.2)':
+    dependencies:
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.2)
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.4.1
+      eslint: 8.57.1
+    optionalDependencies:
+      typescript: 5.8.2
     transitivePeerDependencies:
       - supports-color
 
@@ -11907,7 +11935,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0
+      debug: 4.4.1
       eslint: 9.23.0(jiti@2.4.2)
     optionalDependencies:
       typescript: 5.3.3
@@ -11919,11 +11947,23 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
 
+  '@typescript-eslint/type-utils@6.21.0(eslint@8.57.1)(typescript@5.8.2)':
+    dependencies:
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.2)
+      '@typescript-eslint/utils': 6.21.0(eslint@8.57.1)(typescript@5.8.2)
+      debug: 4.4.1
+      eslint: 8.57.1
+      ts-api-utils: 1.4.3(typescript@5.8.2)
+    optionalDependencies:
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/type-utils@6.21.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.3.3)':
     dependencies:
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
       '@typescript-eslint/utils': 6.21.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.3.3)
-      debug: 4.4.0
+      debug: 4.4.1
       eslint: 9.23.0(jiti@2.4.2)
       ts-api-utils: 1.4.3(typescript@5.3.3)
     optionalDependencies:
@@ -11939,7 +11979,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.0
+      debug: 4.4.1
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.3
@@ -11950,6 +11990,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@6.21.0(typescript@5.8.2)':
+    dependencies:
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/visitor-keys': 6.21.0
+      debug: 4.4.1
+      globby: 11.1.0
+      is-glob: 4.0.3
+      minimatch: 9.0.3
+      semver: 7.7.2
+      ts-api-utils: 1.4.3(typescript@5.8.2)
+    optionalDependencies:
+      typescript: 5.8.2
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/utils@6.21.0(eslint@8.57.1)(typescript@5.8.2)':
+    dependencies:
+      '@eslint-community/eslint-utils': 4.5.1(eslint@8.57.1)
+      '@types/json-schema': 7.0.15
+      '@types/semver': 7.7.0
+      '@typescript-eslint/scope-manager': 6.21.0
+      '@typescript-eslint/types': 6.21.0
+      '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.2)
+      eslint: 8.57.1
+      semver: 7.7.2
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@typescript-eslint/utils@6.21.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.3.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.5.1(eslint@9.23.0(jiti@2.4.2))
@@ -11959,7 +12028,7 @@ snapshots:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
       eslint: 9.23.0(jiti@2.4.2)
-      semver: 7.7.1
+      semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -13588,7 +13657,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0)(eslint@9.23.0(jiti@2.4.2)))(eslint@9.23.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@6.21.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0)(eslint@9.23.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -13610,7 +13679,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.23.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0(eslint-plugin-import@2.31.0)(eslint@9.23.0(jiti@2.4.2)))(eslint@9.23.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@6.21.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.3.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.0)(eslint@9.23.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -16178,8 +16247,6 @@ snapshots:
     dependencies:
       lru-cache: 6.0.0
 
-  semver@7.7.1: {}
-
   semver@7.7.2: {}
 
   send@0.19.0:
@@ -16712,6 +16779,10 @@ snapshots:
   ts-api-utils@1.4.3(typescript@5.3.3):
     dependencies:
       typescript: 5.3.3
+
+  ts-api-utils@1.4.3(typescript@5.8.2):
+    dependencies:
+      typescript: 5.8.2
 
   ts-interface-checker@0.1.13: {}
 


### PR DESCRIPTION
#### What this PR does / why we need it?
Scope: `packages/sdk`, `packages/devtools`, `packages/schema`
- Add Linting script
- Ignore ESLint scope(test, build, bench, d.ts)
- Add `pnpm>=9.6.0` to engines to ensures all contributors and CI use pnpm version **9.6.0 or higher**

---
#### Any background context you want to provide?
Follow #1016 
Closes #1028 

---
### pnpm install(pnpm<9.6.0)
<div align="center">
  <table>
    <tr>
      <th>It should fail when the pnpm version is lower</th>
    </tr>
    <tr>
      <td valign="top">
<img width="830" alt="image" src="https://github.com/user-attachments/assets/6ef9f1e5-cad1-40f9-b023-38f17cb8d895" />
      </td>
    </tr>
  </table>
</div>


### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated linting configuration to ignore build outputs, TypeScript declaration files, and specific test files.
  * Added new npm scripts to run ESLint with automatic fixing and strict warning handling in multiple packages.
  * Specified a minimum required version for pnpm in the package requirements.
  * Enhanced documentation across multiple components, hooks, and icons for improved clarity and usage guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->