### PR TITLE
Support for object, array and enum in ruleset builder

### DIFF
--- a/packages/schema/src/rulesets.ts
+++ b/packages/schema/src/rulesets.ts
@@ -36,7 +36,7 @@ export type Rule =
   | ObjectRule
   | ArrayRule
   | YorkieTypeRule
-  | UnionRule;
+  | EnumRule;
 export type PrimitiveType =
   | 'boolean'
   | 'integer'
@@ -82,8 +82,8 @@ export type YorkieTypeRule = {
   type: YorkieType;
 } & RuleBase;
 
-export type UnionRule = {
-  type: 'union';
+export type EnumRule = {
+  type: 'enum';
   values: Array<string | number | boolean>;
 } & RuleBase;
 

--- a/packages/schema/src/rulesets.ts
+++ b/packages/schema/src/rulesets.ts
@@ -24,7 +24,6 @@ import {
   PropertySignatureContext,
   TypeAliasDeclarationContext,
   TypeReferenceContext,
-  UnionTypeContext,
   YorkieSchemaParser,
   YorkieTypeContext,
 } from '../antlr/YorkieSchemaParser';
@@ -220,7 +219,7 @@ export class RulesetBuilder implements YorkieSchemaListener {
   /**
    * `enterUnionType` is called when entering a union type.
    */
-  enterUnionType(ctx: UnionTypeContext) {
+  enterUnionType() {
     this.unionContext = { values: [] };
   }
 

--- a/packages/schema/src/rulesets.ts
+++ b/packages/schema/src/rulesets.ts
@@ -16,20 +16,23 @@
 
 import { CharStreams, CommonTokenStream } from 'antlr4ts';
 import { ParseTreeWalker } from 'antlr4ts/tree';
-import {
-  PrimitiveTypeContext,
-  TypeAliasDeclarationContext,
-  YorkieSchemaParser,
-  PropertySignatureContext,
-  YorkieTypeContext,
-} from '../antlr/YorkieSchemaParser';
 import { YorkieSchemaLexer } from '../antlr/YorkieSchemaLexer';
 import { YorkieSchemaListener } from '../antlr/YorkieSchemaListener';
+import {
+  LiteralContext,
+  PrimitiveTypeContext,
+  PropertySignatureContext,
+  TypeAliasDeclarationContext,
+  TypeReferenceContext,
+  UnionTypeContext,
+  YorkieSchemaParser,
+  YorkieTypeContext,
+} from '../antlr/YorkieSchemaParser';
 
 /**
  * `Rule` represents a rule for a field in the schema.
  */
-export type Rule = PrimitiveRule | ObjectRule | ArrayRule | YorkieTypeRule;
+export type Rule = PrimitiveRule | ObjectRule | ArrayRule | YorkieTypeRule | EnumRule;
 export type PrimitiveType =
   | 'null'
   | 'boolean'
@@ -45,7 +48,7 @@ export type YorkieType =
   | 'yorkie.Counter'
   | 'yorkie.Object'
   | 'yorkie.Array';
-export type RuleType = 'object' | 'array' | PrimitiveType | YorkieType;
+export type RuleType = 'object' | 'array' | 'enum' | PrimitiveType | YorkieType;
 
 export type RuleBase = {
   path: string;
@@ -70,119 +73,270 @@ export type YorkieTypeRule = {
   type: YorkieType;
 } & RuleBase;
 
+export type EnumRule = {
+  type: 'enum';
+  values: Array<string | number | boolean>;
+} & RuleBase;
+
+// Internal types for building
+type TypeDefinition = {
+  kind: 'primitive';
+  primitiveType: PrimitiveType;
+} | {
+  kind: 'yorkie';
+  yorkieType: YorkieType;
+} | {
+  kind: 'object';
+  properties: PropertyDefinition[];
+} | {
+  kind: 'reference';
+  typeName: string;
+} | {
+  kind: 'enum';
+  values: Array<string | number | boolean>;
+};
+
+type PropertyDefinition = {
+  name: string;
+  type: TypeDefinition;
+  optional: boolean;
+};
+
 /**
  * `RulesetBuilder` is a visitor that builds a ruleset from the given schema.
  */
 export class RulesetBuilder implements YorkieSchemaListener {
-  private currentPath: Array<string> = ['$'];
-  private ruleMap: Map<string, Rule> = new Map();
+  private typeDefinitions: Map<string, TypeDefinition> = new Map();
+  private currentTypeName: string | undefined = undefined;
+  private currentProperty: PropertyDefinition | undefined = undefined;
+  private typeStack: TypeDefinition[] = [];
+  private propertyStack: PropertyDefinition[][] = [];
+  private currentProperties: PropertyDefinition[] = [];
+  private unionContext: { isEnum: boolean; values: Array<string | number | boolean> } | undefined = undefined;
 
   /**
    * `enterTypeAliasDeclaration` is called when entering a type alias declaration.
    */
   enterTypeAliasDeclaration(ctx: TypeAliasDeclarationContext) {
-    const typeName = ctx.Identifier().text;
-    if (typeName === 'Document') {
-      this.currentPath = ['$'];
+    console.log('Entering type alias declaration:', ctx.text);
+    this.currentTypeName = ctx.Identifier().text;
+    this.currentProperties = [];
+    this.unionContext = undefined;
+  }
 
-      this.ruleMap.set('$', {
-        path: '$',
-        type: 'object',
-        properties: [],
-      });
+  /**
+   * `exitTypeAliasDeclaration` is called when exiting a type alias declaration.
+   */
+  exitTypeAliasDeclaration() {
+    if (this.currentTypeName && this.typeStack.length > 0) {
+      const typeDef = this.typeStack.pop()!;
+      this.typeDefinitions.set(this.currentTypeName, typeDef);
+      console.log(`Stored type definition: ${this.currentTypeName}`);
     }
+    this.currentTypeName = undefined;
   }
 
   /**
    * `enterPrimitiveType` is called when entering a primitive type.
    */
   enterPrimitiveType(ctx: PrimitiveTypeContext) {
-    const type = ctx.text as PrimitiveType;
-    const path = this.buildPath();
-    const rule: Rule = {
-      path,
-      type,
-    };
-
-    this.ruleMap.set(path, rule);
-  }
-
-  /**
-   * `exitPrimitiveType` is called when exiting a primitive type.
-   */
-  exitPrimitiveType() {
-    this.currentPath.pop();
-  }
-
-  /**
-   * `enterObjectType` is called when entering an object type.
-   */
-  enterObjectType() {
-    const path = this.buildPath();
-    const rule: ObjectRule = {
-      path,
-      type: 'object',
-      properties: [],
-    };
-
-    this.ruleMap.set(path, rule);
-  }
-
-  /**
-   * `enterPropertySignature` is called when entering a property signature.
-   */
-  enterPropertySignature(ctx: PropertySignatureContext) {
-    const propName = ctx.propertyName().text;
-    const parentPath = this.buildPath();
-    const parentRule = this.ruleMap.get(parentPath);
-
-    if (parentRule) {
-      if (parentRule.type === 'object') {
-        const objectRule = parentRule as ObjectRule;
-        objectRule.properties = objectRule.properties ?? [];
-        objectRule.properties.push(propName);
-
-        const isOptional = !!ctx.QUESTION();
-        if (isOptional) {
-          objectRule.optional = objectRule.optional ?? [];
-          objectRule.optional.push(propName);
-        }
-      }
-    }
-
-    this.currentPath.push(propName);
+    console.log('Entering primitive type:', ctx.text);
+    const primitiveType = ctx.text as PrimitiveType;
+    this.typeStack.push({ kind: 'primitive', primitiveType });
   }
 
   /**
    * `enterYorkieType` is called when entering a Yorkie type.
    */
   enterYorkieType(ctx: YorkieTypeContext) {
-    const type = ctx.text as YorkieType;
-    const path = this.buildPath();
-    const rule: YorkieTypeRule = {
-      path,
-      type,
-    };
-
-    this.ruleMap.set(path, rule);
+    console.log('Entering Yorkie type:', ctx.text);
+    const yorkieType = ctx.text as YorkieType;
+    this.typeStack.push({ kind: 'yorkie', yorkieType });
   }
 
   /**
-   * `exitYorkieType` is called when exiting a Yorkie type.
+   * `enterTypeReference` is called when entering a type reference.
    */
-  exitYorkieType() {
-    this.currentPath.pop();
+  enterTypeReference(ctx: TypeReferenceContext) {
+    console.log('Entering type reference:', ctx.text);
+    const typeName = ctx.Identifier().text;
+    this.typeStack.push({ kind: 'reference', typeName });
   }
 
-  private buildPath(): string {
-    return this.currentPath.join('.');
+  /**
+   * `enterObjectType` is called when entering an object type.
+   */
+  enterObjectType() {
+    console.log('Entering object type');
+    this.propertyStack.push(this.currentProperties);
+    this.currentProperties = [];
+  }
+
+  /**
+   * `exitObjectType` is called when exiting an object type.
+   */
+  exitObjectType() {
+    console.log('Exiting object type');
+    const properties = this.currentProperties;
+    this.currentProperties = this.propertyStack.pop() || [];
+    this.typeStack.push({ kind: 'object', properties });
+  }
+
+  /**
+   * `enterPropertySignature` is called when entering a property signature.
+   */
+  enterPropertySignature(ctx: PropertySignatureContext) {
+    console.log('Entering property signature:', ctx.text);
+    const propName = ctx.propertyName().text;
+    const isOptional = !!ctx.QUESTION();
+    
+    this.currentProperty = {
+      name: propName,
+      type: { kind: 'primitive', primitiveType: 'string' }, // temporary
+      optional: isOptional,
+    };
+  }
+
+  /**
+   * `exitPropertySignature` is called when exiting a property signature.
+   */
+  exitPropertySignature() {
+    console.log('Exiting property signature');
+    if (this.currentProperty && this.typeStack.length > 0) {
+      this.currentProperty.type = this.typeStack.pop()!;
+      this.currentProperties.push(this.currentProperty);
+    }
+    this.currentProperty = undefined;
+  }
+
+  /**
+   * `enterUnionType` is called when entering a union type.
+   */
+  enterUnionType(ctx: UnionTypeContext) {
+    console.log('Entering union type:', ctx.text);
+    // Check if this is an enum (union of literals)
+    const text = ctx.text;
+    if (text.includes('"') || /\b\d+\b/.test(text)) {
+      this.unionContext = { isEnum: true, values: [] };
+    }
+  }
+
+  /**
+   * `exitUnionType` is called when exiting a union type.
+   */
+  exitUnionType() {
+    console.log('Exiting union type');
+    if (this.unionContext && this.unionContext.isEnum && this.unionContext.values.length > 0) {
+      this.typeStack.push({ kind: 'enum', values: this.unionContext.values });
+    }
+    this.unionContext = undefined;
+  }
+
+  /**
+   * `enterLiteral` is called when entering a literal.
+   */
+  enterLiteral(ctx: LiteralContext) {
+    console.log('Entering literal:', ctx.text);
+    const text = ctx.text;
+    let value: string | number | boolean;
+    
+    if (text.startsWith('"') && text.endsWith('"')) {
+      // String literal
+      value = text.slice(1, -1);
+    } else if (!isNaN(Number(text))) {
+      // Number literal
+      value = Number(text);
+    } else if (text === 'true' || text === 'false') {
+      // Boolean literal
+      value = text === 'true';
+    } else {
+      return; // Invalid literal
+    }
+    
+    if (this.unionContext && this.unionContext.isEnum) {
+      this.unionContext.values.push(value);
+    } else {
+      // Single literal (not part of enum)
+      this.typeStack.push({ kind: 'enum', values: [value] });
+    }
   }
 
   /**
    * `build` returns the built ruleset.
    */
   build(): Array<Rule> {
-    return Array.from(this.ruleMap.values());
+    console.log('Building ruleset from type definitions:', Array.from(this.typeDefinitions.keys()));
+    
+    const documentType = this.typeDefinitions.get('Document');
+    if (!documentType) {
+      console.warn('Document type not found');
+      return [];
+    }
+    
+    const rules: Array<Rule> = [];
+    this.expandType(documentType, '$', rules);
+    
+    return rules;
+  }
+
+  private expandType(typeDef: TypeDefinition, path: string, rules: Array<Rule>): void {
+    console.log(`Expanding type at path: ${path}`);
+    
+    switch (typeDef.kind) {
+      case 'primitive':
+        rules.push({
+          path,
+          type: typeDef.primitiveType,
+        });
+        break;
+        
+      case 'yorkie':
+        rules.push({
+          path,
+          type: typeDef.yorkieType,
+        });
+        break;
+        
+      case 'enum':
+        rules.push({
+          path,
+          type: 'enum',
+          values: typeDef.values,
+        });
+        break;
+        
+      case 'object': {
+        const objectRule: ObjectRule = {
+          path,
+          type: 'object',
+          properties: typeDef.properties.map(p => p.name),
+        };
+        
+        const optionalProps = typeDef.properties.filter(p => p.optional).map(p => p.name);
+        if (optionalProps.length > 0) {
+          objectRule.optional = optionalProps;
+        }
+        
+        rules.push(objectRule);
+        
+        // Recursively expand properties
+        for (const property of typeDef.properties) {
+          const propertyPath = `${path}.${property.name}`;
+          this.expandType(property.type, propertyPath, rules);
+        }
+        break;
+      }
+        
+      case 'reference': {
+        const referencedType = this.typeDefinitions.get(typeDef.typeName);
+        if (referencedType) {
+          this.expandType(referencedType, path, rules);
+        } else {
+          console.warn(`Type reference not found: ${typeDef.typeName}`);
+        }
+        break;
+      }
+    }
   }
 }
 

--- a/packages/schema/src/rulesets.ts
+++ b/packages/schema/src/rulesets.ts
@@ -44,7 +44,8 @@ export type PrimitiveType =
   | 'long'
   | 'string'
   | 'date'
-  | 'bytes';
+  | 'bytes'
+  | 'null';
 export type YorkieType =
   | 'yorkie.Text'
   | 'yorkie.Tree'
@@ -55,9 +56,11 @@ export type RuleType =
   | 'object'
   | 'array'
   | 'union'
+  | 'enum'
+  | 'null'
   | PrimitiveType
   | YorkieType
-  | 'enum';
+  ;
 
 export type RuleBase = {
   path: string;

--- a/packages/schema/src/rulesets.ts
+++ b/packages/schema/src/rulesets.ts
@@ -163,22 +163,23 @@ export class RulesetBuilder implements YorkieSchemaListener {
    * `exitArrayType` is called when exiting an array type.
    */
   exitArrayType(ctx: ArrayTypeContext) {
-    console.log('Exiting array type:', ctx.text);
-    this.arrayDepth--;
-
-    const text = ctx.text;
-    const hasArrayBrackets = text.includes('[]');
-    const hasArrayGeneric = text.match(/^Array<.+>$/);
-
-    if ((hasArrayBrackets || hasArrayGeneric) && this.typeStack.length > 0) {
-      console.log('Creating array type for:', text);
-      const elementType = this.typeStack.pop()!;
-      this.typeStack.push({
-        kind: 'array',
-        itemType: elementType,
-      });
-      console.log('Created array type with element:', elementType);
-    }
+  console.log('Exiting array type:', ctx.text);
+  this.arrayDepth--;
+  
+  const hasArrayBrackets = ctx.children?.some(child => child.text === '[' || child.text === ']');
+  const hasArrayKeyword = ctx.children?.some(child => child.text === 'Array');
+  
+  console.log(`Array context check - brackets: ${hasArrayBrackets}, keyword: ${hasArrayKeyword}`);
+  
+  if ((hasArrayBrackets || hasArrayKeyword) && this.typeStack.length > 0) {
+    console.log('Creating array type for:', ctx.text);
+    const elementType = this.typeStack.pop()!;
+    this.typeStack.push({
+      kind: 'array',
+      itemType: elementType,
+    });
+    console.log('Created array type with element:', elementType);
+  }
   }
 
   /**

--- a/packages/schema/test/ruleset.test.ts
+++ b/packages/schema/test/ruleset.test.ts
@@ -169,7 +169,7 @@ describe('RulesetBuilder', () => {
     ]);
   });
 
-  it.todo('should handle array types - Array<T>', () => {
+  it('should handle array types - Array<T>', () => {
     const schema = `
       type Document = {
         todos: Array<Todo>;

--- a/packages/schema/test/ruleset.test.ts
+++ b/packages/schema/test/ruleset.test.ts
@@ -242,6 +242,45 @@ describe('RulesetBuilder', () => {
   it.todo('should handle recursive types', () => {
     const schema = `
       type Document = {
+        linkedList: Node;
+      };
+
+      type Node = {
+        value: string;
+        next: Node;
+      };
+    `;
+
+    const ruleset = buildRuleset(schema);
+    expect(ruleset).to.deep.equal([
+      {
+        path: '$',
+        properties: ['linkedList'],
+        type: 'object',
+      },
+      {
+        path: '$.linkedList',
+        type: 'object',
+        properties: ['value', 'next'],
+      },
+      { path: '$.linkedList.value', type: 'string' },
+      {
+        path: '$.linkedList.next',
+        type: 'object',
+        properties: ['value', 'next'],
+      },
+      { path: '$.linkedList.next[*].value', type: 'string' },
+      {
+        path: '$.linkedList.next[*].next',
+        type: 'object',
+        properties: ['value', 'next'],
+      },
+    ]);
+  });
+
+  it('should handle recursive array types', () => {
+    const schema = `
+      type Document = {
         tree: Node;
       };
 

--- a/packages/schema/test/ruleset.test.ts
+++ b/packages/schema/test/ruleset.test.ts
@@ -204,7 +204,7 @@ describe('RulesetBuilder', () => {
     ]);
   });
 
-  it.todo('should handle array types - T[]', () => {
+  it('should handle array types - T[]', () => {
     const schema = `
       type Document = {
         todos: Todo[];

--- a/packages/schema/test/ruleset.test.ts
+++ b/packages/schema/test/ruleset.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { buildRuleset } from '../src/rulesets';
 
 describe('RulesetBuilder', () => {
@@ -99,7 +99,7 @@ describe('RulesetBuilder', () => {
     ]);
   });
 
-  it.todo('should handle nested objects regardless of order', () => {
+  it('should handle nested objects regardless of order', () => {
     const schema = `
       type Document = {
         user: User;
@@ -360,7 +360,7 @@ describe('RulesetBuilder', () => {
     ]);
   });
 
-  it.todo('should handle enum types', () => {
+  it('should handle enum types', () => {
     const schema = `
       type Document = {
         theme: "light" | "dark";

--- a/packages/schema/test/ruleset.test.ts
+++ b/packages/schema/test/ruleset.test.ts
@@ -239,7 +239,7 @@ describe('RulesetBuilder', () => {
     ]);
   });
 
-  it.todo('should handle recursive types', () => {
+  it('should handle recursive types', () => {
     const schema = `
       type Document = {
         linkedList: Node;

--- a/packages/schema/test/validator.test.ts
+++ b/packages/schema/test/validator.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { validate } from '../src/validator';
 
 describe('Schema:TypeScript', () => {
@@ -314,5 +314,17 @@ describe('Schema:Semantic', () => {
       };
     `;
     expect(validate(schema).errors.length).toBeGreaterThan(0);
+  });
+
+  it.todo('should validate complex union types', () => {
+    const schema = `
+      type Document = {
+        union: string | integer;
+        complexUnion: (string | integer)[] | boolean;
+        nestedUnion: (string | { value: integer }) | null;
+        multipleUnion: string | integer | boolean | null;
+      };
+    `;
+    expect(validate(schema).errors.length).toBe(0);
   });
 });


### PR DESCRIPTION
#### What this PR does / why we need it?
Enhances the schema ruleset builder to support below types.
- Enum 
- Nested objects (regardless of order)
- Array types (Array<T>, T[])
- Recursive, Recursive Array

Introduces a Map-based approach to handle nested object types and type references, allowing for order-independent type definition resolution.
Introduces a `visited` Set, `currentTypeName` to prevent infinite recursion.


#### Any background context you want to provide?
As I worked on it, I thought that the enum should be treated as a literal union. 
This is the part that connects to the complex union test case later.
Please let me know if I missed anything.

#### What are the relevant tickets?
Related https://github.com/yorkie-team/yorkie/pull/971

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for union types, literals, and enum rules in schema definitions.

* **Refactor**
  * Enhanced type definition handling with hierarchical construction and improved reference resolution with cycle detection.
  * Reintroduced the 'null' primitive type in schema rules.

* **Tests**
  * Activated tests for nested objects, recursive types, array types, and enum type handling.
  * Added new tests for recursive array types and complex union type validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->