### PR TITLE
Change VersionVector actorID encoding from hex to base64

### DIFF
--- a/packages/sdk/src/api/converter.ts
+++ b/packages/sdk/src/api/converter.ts
@@ -194,7 +194,8 @@ function toVersionVector(vector?: VersionVector): PbVersionVector | undefined {
 
   const pbVector = new PbVersionVector();
   for (const [actorID, lamport] of vector) {
-    pbVector.vector[actorID] = BigInt(lamport.toString());
+    const base64ActorID = uint8ArrayToBase64(toUint8Array(actorID));
+    pbVector.vector[base64ActorID] = BigInt(lamport.toString());
   }
   return pbVector;
 }
@@ -840,7 +841,8 @@ function fromVersionVector(
 
   const vector = new VersionVector();
   Object.entries(pbVersionVector.vector).forEach(([key, value]) => {
-    vector.set(key, BigInt(value.toString()));
+    const hexKey = bytesToHex(base64ToUint8Array(key));
+    vector.set(hexKey, BigInt(value.toString()));
   });
   return vector;
 }
@@ -1589,12 +1591,26 @@ function hexToBytes(hex: string): Uint8Array {
 }
 
 /**
+ * `base64ToUint8Array` converts the given base64 string to Uint8Array.
+ */
+function base64ToUint8Array(base64: string): Uint8Array {
+  const buffer = Buffer.from(base64, 'base64');
+  return new Uint8Array(buffer);
+}
+
+/**
  * `toUnit8Array` converts the given hex string to byte array.
  */
 function toUint8Array(hex: string): Uint8Array {
   return hexToBytes(hex);
 }
 
+/**
+ * `uint8ArrayToBase64` converts the given Uint8Array to base64 string.
+ */
+function uint8ArrayToBase64(bytes: Uint8Array): string {
+  return Buffer.from(bytes).toString('base64');
+}
 /**
  * `bytesToChangeID` creates a ChangeID from the given bytes.
  */

--- a/packages/sdk/src/api/converter.ts
+++ b/packages/sdk/src/api/converter.ts
@@ -1594,8 +1594,20 @@ function hexToBytes(hex: string): Uint8Array {
  * `base64ToUint8Array` converts the given base64 string to Uint8Array.
  */
 function base64ToUint8Array(base64: string): Uint8Array {
-  const buffer = Buffer.from(base64, 'base64');
-  return new Uint8Array(buffer);
+  if (typeof window !== 'undefined' && typeof window.atob === 'function') {
+    const binary = window.atob(base64);
+    const len = binary.length;
+    const bytes = new Uint8Array(len);
+    for (let i = 0; i < len; i++) {
+      bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+  } else if (typeof Buffer !== 'undefined') {
+    // Node.js fallback
+    return new Uint8Array(Buffer.from(base64, 'base64'));
+  } else {
+    throw new Error('No base64 decoder available');
+  }
 }
 
 /**
@@ -1609,7 +1621,18 @@ function toUint8Array(hex: string): Uint8Array {
  * `uint8ArrayToBase64` converts the given Uint8Array to base64 string.
  */
 function uint8ArrayToBase64(bytes: Uint8Array): string {
-  return Buffer.from(bytes).toString('base64');
+  if (typeof window !== 'undefined' && typeof window.btoa === 'function') {
+    let binary = '';
+    for (let i = 0; i < bytes.byteLength; i++) {
+      binary += String.fromCharCode(bytes[i]);
+    }
+    return window.btoa(binary);
+  } else if (typeof Buffer !== 'undefined') {
+    // Node.js fallback
+    return Buffer.from(bytes).toString('base64');
+  } else {
+    throw new Error('No base64 encoder available');
+  }
 }
 /**
  * `bytesToChangeID` creates a ChangeID from the given bytes.

--- a/packages/sdk/src/api/converter.ts
+++ b/packages/sdk/src/api/converter.ts
@@ -1602,8 +1602,8 @@ function base64ToUint8Array(base64: string): Uint8Array {
       bytes[i] = binary.charCodeAt(i);
     }
     return bytes;
-  } else if (typeof Buffer !== 'undefined') {
-    // Node.js fallback
+  } else if (typeof globalThis !== 'undefined' && typeof (globalThis as any).Buffer !== 'undefined') {
+    const Buffer = (globalThis as any).Buffer;
     return new Uint8Array(Buffer.from(base64, 'base64'));
   } else {
     throw new Error('No base64 decoder available');
@@ -1627,8 +1627,8 @@ function uint8ArrayToBase64(bytes: Uint8Array): string {
       binary += String.fromCharCode(bytes[i]);
     }
     return window.btoa(binary);
-  } else if (typeof Buffer !== 'undefined') {
-    // Node.js fallback
+  } else if (typeof globalThis !== 'undefined' && typeof (globalThis as any).Buffer !== 'undefined') {
+    const Buffer = (globalThis as any).Buffer;
     return Buffer.from(bytes).toString('base64');
   } else {
     throw new Error('No base64 encoder available');


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
To reduce the size of serialized VersionVectors, the actorID encoding format has been changed from hex string to base64. Since actorIDs are used as keys in VersionVector objects and frequently transferred in network messages, reducing their length helps decrease payload size and improve performance. This change does not affect the semantics of the actorID, only its encoded representation.


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to https://github.com/yorkie-team/yorkie/pull/1388

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when handling version vector data by updating the encoding and decoding of actor IDs to use base64 format, ensuring consistent behavior across different environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->