### PR TITLE
Remove deprecated SelectOperation

### DIFF
--- a/packages/sdk/src/api/converter.ts
+++ b/packages/sdk/src/api/converter.ts
@@ -1218,9 +1218,6 @@ function fromOperation(pbOperation: PbOperation): Operation | undefined {
       attributes,
       fromTimeTicket(pbStyleOperation!.executedAt)!,
     );
-  } else if (pbOperation.body.case === 'select') {
-    // TODO(hackerwins): Select is deprecated.
-    return;
   } else if (pbOperation.body.case === 'increase') {
     const pbIncreaseOperation = pbOperation.body.value;
     return IncreaseOperation.create(
@@ -1602,7 +1599,10 @@ function base64ToUint8Array(base64: string): Uint8Array {
       bytes[i] = binary.charCodeAt(i);
     }
     return bytes;
-  } else if (typeof globalThis !== 'undefined' && typeof (globalThis as any).Buffer !== 'undefined') {
+  } else if (
+    typeof globalThis !== 'undefined' &&
+    typeof (globalThis as any).Buffer !== 'undefined'
+  ) {
     const Buffer = (globalThis as any).Buffer;
     return new Uint8Array(Buffer.from(base64, 'base64'));
   } else {
@@ -1627,7 +1627,10 @@ function uint8ArrayToBase64(bytes: Uint8Array): string {
       binary += String.fromCharCode(bytes[i]);
     }
     return window.btoa(binary);
-  } else if (typeof globalThis !== 'undefined' && typeof (globalThis as any).Buffer !== 'undefined') {
+  } else if (
+    typeof globalThis !== 'undefined' &&
+    typeof (globalThis as any).Buffer !== 'undefined'
+  ) {
     const Buffer = (globalThis as any).Buffer;
     return Buffer.from(bytes).toString('base64');
   } else {

--- a/packages/sdk/src/api/yorkie/v1/resources.proto
+++ b/packages/sdk/src/api/yorkie/v1/resources.proto
@@ -101,16 +101,6 @@ message Operation {
     TimeTicket executed_at = 6;
     map<string, string> attributes = 7;
   }
-  // NOTE(hackerwins): Select Operation is not used in the current version.
-  // In the previous version, it was used to represent selection of Text.
-  // However, it has been replaced by Presence now. It is retained for backward
-  // compatibility purposes.
-  message Select {
-    TimeTicket parent_created_at = 1;
-    TextNodePos from = 2;
-    TextNodePos to = 3;
-    TimeTicket executed_at = 4;
-  }
   message Style {
     TimeTicket parent_created_at = 1;
     TextNodePos from = 2;
@@ -155,7 +145,6 @@ message Operation {
     Move move = 3;
     Remove remove = 4;
     Edit edit = 5;
-    Select select = 6;
     Style style = 7;
     Increase increase = 8;
     TreeEdit tree_edit = 9;
@@ -342,10 +331,11 @@ message UpdatableProjectFields {
 message DocumentSummary {
   string id = 1;
   string key = 2;
-  string snapshot = 3;
+  string root = 3;
   int32 attached_clients = 7;
   DocSize document_size = 8;
   string schema_key = 9;
+  map<string, Presence> presences = 10;
   google.protobuf.Timestamp created_at = 4;
   google.protobuf.Timestamp accessed_at = 5;
   google.protobuf.Timestamp updated_at = 6;

--- a/packages/sdk/src/api/yorkie/v1/resources_pb.ts
+++ b/packages/sdk/src/api/yorkie/v1/resources_pb.ts
@@ -462,12 +462,6 @@ export class Operation extends Message<Operation> {
     case: "edit";
   } | {
     /**
-     * @generated from field: yorkie.v1.Operation.Select select = 6;
-     */
-    value: Operation_Select;
-    case: "select";
-  } | {
-    /**
      * @generated from field: yorkie.v1.Operation.Style style = 7;
      */
     value: Operation_Style;
@@ -511,7 +505,6 @@ export class Operation extends Message<Operation> {
     { no: 3, name: "move", kind: "message", T: Operation_Move, oneof: "body" },
     { no: 4, name: "remove", kind: "message", T: Operation_Remove, oneof: "body" },
     { no: 5, name: "edit", kind: "message", T: Operation_Edit, oneof: "body" },
-    { no: 6, name: "select", kind: "message", T: Operation_Select, oneof: "body" },
     { no: 7, name: "style", kind: "message", T: Operation_Style, oneof: "body" },
     { no: 8, name: "increase", kind: "message", T: Operation_Increase, oneof: "body" },
     { no: 9, name: "tree_edit", kind: "message", T: Operation_TreeEdit, oneof: "body" },
@@ -822,66 +815,6 @@ export class Operation_Edit extends Message<Operation_Edit> {
 
   static equals(a: Operation_Edit | PlainMessage<Operation_Edit> | undefined, b: Operation_Edit | PlainMessage<Operation_Edit> | undefined): boolean {
     return proto3.util.equals(Operation_Edit, a, b);
-  }
-}
-
-/**
- * NOTE(hackerwins): Select Operation is not used in the current version.
- * In the previous version, it was used to represent selection of Text.
- * However, it has been replaced by Presence now. It is retained for backward
- * compatibility purposes.
- *
- * @generated from message yorkie.v1.Operation.Select
- */
-export class Operation_Select extends Message<Operation_Select> {
-  /**
-   * @generated from field: yorkie.v1.TimeTicket parent_created_at = 1;
-   */
-  parentCreatedAt?: TimeTicket;
-
-  /**
-   * @generated from field: yorkie.v1.TextNodePos from = 2;
-   */
-  from?: TextNodePos;
-
-  /**
-   * @generated from field: yorkie.v1.TextNodePos to = 3;
-   */
-  to?: TextNodePos;
-
-  /**
-   * @generated from field: yorkie.v1.TimeTicket executed_at = 4;
-   */
-  executedAt?: TimeTicket;
-
-  constructor(data?: PartialMessage<Operation_Select>) {
-    super();
-    proto3.util.initPartial(data, this);
-  }
-
-  static readonly runtime: typeof proto3 = proto3;
-  static readonly typeName = "yorkie.v1.Operation.Select";
-  static readonly fields: FieldList = proto3.util.newFieldList(() => [
-    { no: 1, name: "parent_created_at", kind: "message", T: TimeTicket },
-    { no: 2, name: "from", kind: "message", T: TextNodePos },
-    { no: 3, name: "to", kind: "message", T: TextNodePos },
-    { no: 4, name: "executed_at", kind: "message", T: TimeTicket },
-  ]);
-
-  static fromBinary(bytes: Uint8Array, options?: Partial<BinaryReadOptions>): Operation_Select {
-    return new Operation_Select().fromBinary(bytes, options);
-  }
-
-  static fromJson(jsonValue: JsonValue, options?: Partial<JsonReadOptions>): Operation_Select {
-    return new Operation_Select().fromJson(jsonValue, options);
-  }
-
-  static fromJsonString(jsonString: string, options?: Partial<JsonReadOptions>): Operation_Select {
-    return new Operation_Select().fromJsonString(jsonString, options);
-  }
-
-  static equals(a: Operation_Select | PlainMessage<Operation_Select> | undefined, b: Operation_Select | PlainMessage<Operation_Select> | undefined): boolean {
-    return proto3.util.equals(Operation_Select, a, b);
   }
 }
 
@@ -2566,9 +2499,9 @@ export class DocumentSummary extends Message<DocumentSummary> {
   key = "";
 
   /**
-   * @generated from field: string snapshot = 3;
+   * @generated from field: string root = 3;
    */
-  snapshot = "";
+  root = "";
 
   /**
    * @generated from field: int32 attached_clients = 7;
@@ -2584,6 +2517,11 @@ export class DocumentSummary extends Message<DocumentSummary> {
    * @generated from field: string schema_key = 9;
    */
   schemaKey = "";
+
+  /**
+   * @generated from field: map<string, yorkie.v1.Presence> presences = 10;
+   */
+  presences: { [key: string]: Presence } = {};
 
   /**
    * @generated from field: google.protobuf.Timestamp created_at = 4;
@@ -2610,10 +2548,11 @@ export class DocumentSummary extends Message<DocumentSummary> {
   static readonly fields: FieldList = proto3.util.newFieldList(() => [
     { no: 1, name: "id", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 2, name: "key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
-    { no: 3, name: "snapshot", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 3, name: "root", kind: "scalar", T: 9 /* ScalarType.STRING */ },
     { no: 7, name: "attached_clients", kind: "scalar", T: 5 /* ScalarType.INT32 */ },
     { no: 8, name: "document_size", kind: "message", T: DocSize },
     { no: 9, name: "schema_key", kind: "scalar", T: 9 /* ScalarType.STRING */ },
+    { no: 10, name: "presences", kind: "map", K: 9 /* ScalarType.STRING */, V: {kind: "message", T: Presence} },
     { no: 4, name: "created_at", kind: "message", T: Timestamp },
     { no: 5, name: "accessed_at", kind: "message", T: Timestamp },
     { no: 6, name: "updated_at", kind: "message", T: Timestamp },


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

SelectOperation in Text is no longer needed since presence is now
handled via Change. It was kept for backward compatibility, but has
become obsolete after document compaction. This commit removes it
completely.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to https://github.com/yorkie-team/yorkie/pull/1417

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced presence tracking within document summaries, allowing for real-time user presence information.

* **Refactor**
  * Renamed the "snapshot" field in document summaries to "root" for improved clarity.

* **Chores**
  * Removed deprecated selection operation support, including related fields and messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->