### PR TITLE
Support `array[idx] = val` via Proxy.set trap

### DIFF
--- a/packages/sdk/src/document/json/array.ts
+++ b/packages/sdk/src/document/json/array.ts
@@ -60,9 +60,9 @@ export type JSONArray<T> = {
   getLast?(): WrappedElement<T>;
 
   /**
-   * `setInteger` sets the element of the given index.
+   * `setValue` sets the given value at the given index.
    */
-  setInteger?(index: number, value: unknown): WrappedElement<T>;
+  setValue?(index: number, value: unknown): WrappedElement<T>;
 
   /**
    * `delete` deletes the element of the given index.
@@ -265,9 +265,9 @@ export class ArrayProxy {
             );
             return toWrappedElement(context, inserted);
           };
-        } else if (method === 'setInteger') {
+        } else if (method === 'setValue') {
           return (index: number, value: number): WrappedElement | undefined => {
-            const array = ArrayProxy.setIntegerInternal(
+            const array = ArrayProxy.setValueInternal(
               context,
               target,
               index,
@@ -379,7 +379,7 @@ export class ArrayProxy {
       set: (target: CRDTArray, key: string, value: any): boolean => {
         if (isNumericString(key)) {
           const index = Number(key);
-          ArrayProxy.setIntegerInternal(context, target, index, value);
+          ArrayProxy.setValueInternal(context, target, index, value);
           return true;
         }
         return Reflect.set(target, key, value);
@@ -623,9 +623,9 @@ export class ArrayProxy {
   }
 
   /**
-   * `setIntegerInternal` sets the given integer at the given index.
+   * `setValueInternal` sets the given value at the given index.
    */
-  public static setIntegerInternal(
+  public static setValueInternal(
     context: ChangeContext,
     target: CRDTArray,
     index: number,

--- a/packages/sdk/test/integration/array_test.ts
+++ b/packages/sdk/test/integration/array_test.ts
@@ -811,7 +811,7 @@ describe('Array Concurrency Table Tests', function () {
     {
       opName: 'set.target',
       executor: (arr: JSONArray<number>, cid: number) => {
-        arr.setInteger!(oneIdx, newValues[cid]);
+        arr.setValue!(oneIdx, newValues[cid]);
       },
     },
 
@@ -997,12 +997,12 @@ describe('Array Set By Index Tests', function () {
       assert.equal(d1.toJSON!(), d2.toJSON!());
 
       d2.update((root) => {
-        root.k1.setInteger!(1, -4);
+        root.k1.setValue!(1, -4);
         assert.equal('{"k1":[-1,-4,-3]}', root.toJSON!());
       });
 
       d1.update((root) => {
-        root.k1.setInteger!(0, -5);
+        root.k1.setValue!(0, -5);
         assert.equal('{"k1":[-5,-2,-3]}', root.toJSON!());
       });
 
@@ -1014,7 +1014,7 @@ describe('Array Set By Index Tests', function () {
     }, task.name);
   });
 
-    it('can handle array set operation by Proxy', () => {
+  it('can handle array set operation by Proxy', () => {
     const doc = new Document<{ list: JSONArray<any> }>('test-doc');
 
     doc.update((root) => {
@@ -1043,13 +1043,19 @@ describe('Array Set By Index Tests', function () {
       const idx = root.list.findIndex((v) => v === 'setV');
       if (idx >= 0) root.list[idx] = 'setV2';
     }, 'set #2');
-    assert.equal(doc.toSortedJSON(), '{"list":["setV2","newV","newV","b","c"]}');
-    
+    assert.equal(
+      doc.toSortedJSON(),
+      '{"list":["setV2","newV","newV","b","c"]}',
+    );
+
     doc.update((root) => {
       const idx = root.list.findIndex((v) => v === 'setV2');
       if (idx >= 0) root.list[idx] = ['s', 'e', 't', 'V', '3'];
     }, 'set #2');
-    assert.equal(doc.toSortedJSON(), '{"list":[["s","e","t","V","3"],"newV","newV","b","c"]}');
+    assert.equal(
+      doc.toSortedJSON(),
+      '{"list":[["s","e","t","V","3"],"newV","newV","b","c"]}',
+    );
   });
 });
 

--- a/packages/sdk/test/integration/array_test.ts
+++ b/packages/sdk/test/integration/array_test.ts
@@ -1013,6 +1013,44 @@ describe('Array Set By Index Tests', function () {
       assert.isTrue(result);
     }, task.name);
   });
+
+    it('can handle array set operation by Proxy', () => {
+    const doc = new Document<{ list: JSONArray<any> }>('test-doc');
+
+    doc.update((root) => {
+      root.list = ['a', 'b', 'c'];
+    }, 'init');
+    assert.equal(doc.toSortedJSON(), '{"list":["a","b","c"]}');
+
+    doc.update((root) => {
+      const prev = root.list.getElementByIndex!(0);
+      root.list.insertAfter!(prev.getID!(), 'newV');
+    }, 'insertAfter #1');
+    assert.equal(doc.toSortedJSON(), '{"list":["a","newV","b","c"]}');
+
+    doc.update((root) => {
+      const prev = root.list.getElementByIndex!(0);
+      root.list.insertAfter!(prev.getID!(), 'newV');
+    }, 'insertAfter #2');
+    assert.equal(doc.toSortedJSON(), '{"list":["a","newV","newV","b","c"]}');
+
+    doc.update((root) => {
+      root.list[0] = 'setV';
+    }, 'set #1');
+    assert.equal(doc.toSortedJSON(), '{"list":["setV","newV","newV","b","c"]}');
+
+    doc.update((root) => {
+      const idx = root.list.findIndex((v) => v === 'setV');
+      if (idx >= 0) root.list[idx] = 'setV2';
+    }, 'set #2');
+    assert.equal(doc.toSortedJSON(), '{"list":["setV2","newV","newV","b","c"]}');
+    
+    doc.update((root) => {
+      const idx = root.list.findIndex((v) => v === 'setV2');
+      if (idx >= 0) root.list[idx] = ['s', 'e', 't', 'V', '3'];
+    }, 'set #2');
+    assert.equal(doc.toSortedJSON(), '{"list":[["s","e","t","V","3"],"newV","newV","b","c"]}');
+  });
 });
 
 interface ClientAndDocPair<T extends Indexable> {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This PR adds a `set` operation to `ArrayProxy`, allowing users to use the array in the form of `array[idx] = val;`.

#### Any background context you want to provide?

For reference, see [MDN](https://developer.mozilla.org/ko/docs/Web/JavaScript/Reference/Global_Objects/Proxy/Proxy/set) on the `Proxy.set` trap.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1015 
Relevant to #1037

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled direct assignment to array elements by index, allowing users to update array values using standard bracket notation.
* **Tests**
  * Added tests to verify correct behavior of array element assignment and updates using both direct index assignment and array methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->