### PR TITLE
Prevent document attachment before component mount

### DIFF
--- a/packages/react/src/DocumentProvider.tsx
+++ b/packages/react/src/DocumentProvider.tsx
@@ -14,7 +14,13 @@
  * limitations under the License.
  */
 
-import React, { createContext, useContext, useEffect, useRef } from 'react';
+import React, {
+  createContext,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {
   Document,
   Presence,
@@ -49,6 +55,14 @@ export function useYorkieDocument<R, P extends Indexable = Indexable>(
 ) {
   const initialRootRef = useRef(initialRoot);
   const initialPresenceRef = useRef(initialPresence);
+  const [didMount, setDidMount] = useState(false);
+
+  // NOTE(hackerwins): In StrictMode, the component will call twice
+  // useEffect in development mode. To prevent attaching a document
+  // twice, attach a document after the mounting.
+  useEffect(() => {
+    setDidMount(true);
+  }, []);
 
   useEffect(() => {
     if (clientError) {
@@ -60,7 +74,7 @@ export function useYorkieDocument<R, P extends Indexable = Indexable>(
       return;
     }
 
-    if (!client || clientLoading) {
+    if (!client || clientLoading || !didMount) {
       documentStore.setState((state) => ({
         ...state,
         loading: true,
@@ -160,7 +174,7 @@ export function useYorkieDocument<R, P extends Indexable = Indexable>(
         unsub();
       }
     };
-  }, [client, clientLoading, clientError, docKey, documentStore]);
+  }, [client, clientLoading, clientError, docKey, documentStore, didMount]);
 }
 
 export type DocumentContextType<R, P extends Indexable = Indexable> = {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Prevent document attachment before component mount

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Addresses some of #1047

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document handling to prevent issues caused by premature attachment during component mounting, especially in React StrictMode. This enhances stability and reliability when using the document provider.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->