### PR TITLE
Prevent watch stream re-creation after detachment

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -940,6 +940,18 @@ export class Client {
           );
         }
 
+        // NOTE(hackerwins): Check if the document is still attached to prevent
+        // watch stream creation after detachment.
+        if (!this.attachmentMap.has(docKey)) {
+          this.conditions[ClientCondition.WatchLoop] = false;
+          return Promise.reject(
+            new YorkieError(
+              Code.ErrDocumentNotAttached,
+              `${docKey} is not attached`,
+            ),
+          );
+        }
+
         const ac = new AbortController();
         const stream = this.rpcClient.watchDocument(
           {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This commit fixes an issue where watchDocument could be called again
after the document is detached.

When navigating away from a page, DocumentProvider calls detach, which
cancels the watch stream via detachInternal. However, runWatchLoop's
onDisconnect callback may already be scheduled. This callback
re-schedules doLoop via setTimeout, which then calls watchDocument
again.

This commit adds a check to ensure the document is still attached
before starting a new watch stream.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document handling to prevent watch streams from being created for detached documents, enhancing reliability and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->