### PR TITLE
Prevent event loss by ensuring sync loop resumes after reconnect

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -607,11 +607,11 @@ export class Client {
       return doc;
     }
 
+    // NOTE(hackerwins): In non-pushpull mode, the client does not receive change events
+    // from the server. Therefore, we need to set `remoteChangeEventReceived` to true
+    // to sync the local and remote changes. This has limitations in that unnecessary
+    // syncs occur if the client and server do not have any changes.
     if (syncMode === SyncMode.Realtime) {
-      // NOTE(hackerwins): In non-pushpull mode, the client does not receive change events
-      // from the server. Therefore, we need to set `remoteChangeEventReceived` to true
-      // to sync the local and remote changes. This has limitations in that unnecessary
-      // syncs occur if the client and server do not have any changes.
       attachment.remoteChangeEventReceived = true;
     }
 
@@ -971,6 +971,11 @@ export class Client {
           },
         ]);
         logger.info(`[WD] c:"${this.getKey()}" watches d:"${docKey}"`);
+
+        // NOTE(hackerwins): Set remoteChangeEventReceived to true to prevent
+        // event stream gap issues. This ensures sync loop continues even when
+        // no remote change events are received immediately after watch stream starts.
+        attachment.remoteChangeEventReceived = true;
 
         return new Promise((resolve, reject) => {
           const handleStream = async () => {

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -767,7 +767,7 @@ describe.sequential('Client', function () {
       root.t = new Text();
       root.t.edit(0, 0, 'a');
     });
-    await eventCollectorD2.waitAndVerifyNthEvent(1, DocSyncStatus.Synced);
+    await eventCollectorD2.waitAndVerifyNthEvent(2, DocSyncStatus.Synced);
 
     assert.equal(d1.getRoot().t.toString(), 'a');
     assert.equal(d2.getRoot().t.toString(), 'a');

--- a/packages/sdk/test/integration/webhook_test.ts
+++ b/packages/sdk/test/integration/webhook_test.ts
@@ -476,11 +476,6 @@ describe('Auth Webhook', () => {
       root.k1 = 'v1';
     });
 
-    await syncEventCollector.waitFor(DocSyncStatus.Synced);
-    await authErrorEventCollector.waitFor({
-      reason: ExpiredTokenErrorMessage,
-      method: 'PushPull',
-    });
     expect(authTokenInjector).toBeCalledTimes(2);
     expect(authTokenInjector).nthCalledWith(1);
     expect(authTokenInjector).nthCalledWith(2, ExpiredTokenErrorMessage);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Prevent event loss by ensuring sync loop resumes after reconnect

When a new event stream is established (e.g., due to network or timeout),
there may be a gap where no remote change events are received.
By preemptively setting remoteChangeEventReceived = true,
we ensure the sync loop continues, avoiding stale state.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved synchronization handling to prevent event stream gaps and ensure sync loops continue as expected in realtime mode.
  * Adjusted test expectations to accurately reflect synchronization event timing in push-only mode.
  * Simplified a test case by removing unnecessary event waits during token refresh and realtime sync scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->