### PR TITLE
Fix incorrect deletion of compacted documents

### DIFF
--- a/packages/sdk/src/document/change/change_id.ts
+++ b/packages/sdk/src/document/change/change_id.ts
@@ -137,15 +137,6 @@ export class ChangeID {
     const lamport =
       otherLamport > this.lamport ? otherLamport + 1n : this.lamport + 1n;
 
-    // NOTE(chacha912): Documents created by server may have an InitialActorID
-    // in their version vector. Although server is not an actual client, it
-    // generates document snapshots from changes by participating with an
-    // InitialActorID during document instance creation and accumulating stored
-    // changes in DB.
-    // Semantically, including a non-client actor in version vector is
-    // problematic. To address this, we remove the InitialActorID from snapshots.
-    vector.unset(InitialActorID);
-
     const maxVersionVector = this.versionVector.max(vector);
     maxVersionVector.set(this.actor, lamport);
 

--- a/packages/sdk/test/integration/gc_test.ts
+++ b/packages/sdk/test/integration/gc_test.ts
@@ -9,6 +9,7 @@ import {
   vectorOf,
   DefaultSnapshotThreshold,
 } from '../helper/helper';
+import { InitialActorID } from '@yorkie-js/sdk/src/document/time/actor_id';
 
 describe('Garbage Collection', function () {
   it('getGarbageLen should return the actual number of elements garbage-collected', async function ({
@@ -1993,6 +1994,7 @@ describe('Garbage Collection', function () {
       vectorOf([
         { c: c1.getID()!, l: 998n },
         { c: c2.getID()!, l: 1000n },
+        { c: InitialActorID, l: 1002n },
         { c: c3.getID()!, l: 1003n },
       ]),
       d3.getVersionVector(),


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fix incorrect deletion of compacted documents

During compaction, existing changes are removed and a single
CompactedChange is created by the housekeeping server(InitialActorID).

The InitialActorID is then removed(unset) from the document’s
VersionVector via Document.ChangeID.SetClocks.

When deleting content, the canDelete condition checks for tombstone
marking. Since the InitialActorID entry is missing from VersionVector,
it is treated as “not existed” and excluded from deletion.

This commit removes the code that unsets InitialActorID in
VersionVector so that deletion works as expected.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Related to https://github.com/yorkie-team/yorkie/pull/1437

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Preserves server-provided version vectors when applying snapshots, improving synchronization consistency and conflict resolution.

- Bug Fixes
  - Fixed an issue where an entry in the version vector could be unintentionally pruned during snapshot processing.

- Tests
  - Updated integration tests to reflect the preserved version vector behavior.

- Chores
  - No changes to public APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->