### PR TITLE
feat (test) : Casual and Concurrent situtaion about update removeAt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -145,3 +145,5 @@ packages/sdk/lib/
 
 # npm
 **/package-lock.json
+**/pnpm-lock.yaml
+

--- a/packages/sdk/src/document/crdt/text.ts
+++ b/packages/sdk/src/document/crdt/text.ts
@@ -528,4 +528,30 @@ export class CRDTText<A extends Indexable = Indexable> extends CRDTElement {
 
     return pairs;
   }
+
+  /**
+   * `canDeleteForTest` returns whether the node at the given index can be deleted for testing purpose.
+   * This method checks the deletion state of nodes regardless of their current index position.
+   */
+  public canDeleteForTest(index: number): boolean {
+    let currentIndex = 0;
+    for (const rgaNode of this.rgaTreeSplit) {
+      const originalLength = rgaNode.getValue().getContent().length;
+
+      if (currentIndex <= index && index < currentIndex + originalLength) {
+        if (rgaNode.getRemovedAt()) {
+          return false;
+        }
+
+        return rgaNode.canDelete(
+          this.getCreatedAt(),
+          this.getCreatedAt().getLamport(),
+        );
+      }
+
+      currentIndex += originalLength;
+    }
+
+    return false;
+  }
 }

--- a/packages/sdk/src/document/json/text.ts
+++ b/packages/sdk/src/document/json/text.ts
@@ -348,4 +348,18 @@ export class Text<A extends Indexable = Indexable> {
 
     return this.text.indexRangeToPosRange(fromIdx, toIdx);
   }
+
+  /**
+   * `canDeleteForTest` returns whether the node at the given index can be deleted for testing purpose.
+   */
+  public canDeleteForTest(index: number): boolean {
+    if (!this.text) {
+      throw new YorkieError(
+        Code.ErrNotInitialized,
+        'Text is not initialized yet',
+      );
+    }
+
+    return this.text.canDeleteForTest(index);
+  }
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Implements new test cases covering both **causal** and **concurrent** scenarios for the `update removeAt` behavior in CRDT text operations.  
These tests specifically target a concurrency issue where `removeAt` updates were not applying **Last-Write-Wins (LWW)** logic correctly in concurrent editing situations.  
By adding these tests, we can verify correct handling of deletion conflicts and ensure that the latest timestamp always prevails in concurrent updates.

#### Any background context you want to provide?
Currently, in concurrent editing scenarios, the `removeAt` update does not consistently apply the LWW rule, which can lead to incorrect tombstone state or unexpected document content.  
This PR focuses solely on reproducing this issue through tests so that it can be reliably addressed in subsequent fixes.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #821

### Checklist
- [x] Added relevant tests
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything