### PR TITLE
Fix removedAt timestamp handling in text deletions

### DIFF
--- a/packages/sdk/src/api/converter.ts
+++ b/packages/sdk/src/api/converter.ts
@@ -1057,7 +1057,7 @@ function fromTextNode(pbTextNode: PbTextNode): RGATreeSplitNode<CRDTTextValue> {
     fromTextNodeID(pbTextNode.id!),
     textValue,
   );
-  textNode.remove(fromTimeTicket(pbTextNode.removedAt));
+  textNode.setRemovedAt(fromTimeTicket(pbTextNode.removedAt));
   return textNode;
 }
 

--- a/packages/sdk/src/document/crdt/element_rht.ts
+++ b/packages/sdk/src/document/crdt/element_rht.ts
@@ -96,13 +96,13 @@ export class ElementRHT {
   ): CRDTElement | undefined {
     let removed;
     const node = this.nodeMapByKey.get(key);
-    if (node != null && !node.isRemoved() && node.remove(executedAt)) {
+    if (!!node && !node.isRemoved() && node.remove(executedAt)) {
       removed = node.getValue();
     }
 
     const newNode = ElementRHTNode.of(key, value);
     this.nodeMapByCreatedAt.set(value.getCreatedAt().toIDString(), newNode);
-    if (node == null || executedAt.after(node.getValue().getPositionedAt())) {
+    if (!node || executedAt.after(node.getValue().getPositionedAt())) {
       this.nodeMapByKey.set(key, newNode);
       value.setMovedAt(executedAt);
     }
@@ -167,7 +167,7 @@ export class ElementRHT {
     removedAt: TimeTicket,
   ): CRDTElement | undefined {
     const node = this.nodeMapByKey.get(key);
-    if (node == null) {
+    if (!node) {
       return;
     }
 
@@ -183,7 +183,7 @@ export class ElementRHT {
    */
   public has(key: string): boolean {
     const node = this.nodeMapByKey.get(key);
-    if (node == null) {
+    if (!node) {
       return false;
     }
     return !node.isRemoved();

--- a/packages/sdk/src/document/crdt/rga_tree_split.ts
+++ b/packages/sdk/src/document/crdt/rga_tree_split.ts
@@ -452,7 +452,7 @@ export class RGATreeSplitNode<T extends RGATreeSplitValue>
       return false;
     }
 
-    if (this.removedAt == null) {
+    if (!this.removedAt) {
       return true;
     }
 
@@ -483,7 +483,7 @@ export class RGATreeSplitNode<T extends RGATreeSplitValue>
    * `remove` removes the node of the given edited time.
    */
   public remove(removedAt: TimeTicket, tombstoneKnown: boolean) {
-    if (this.removedAt == null) {
+    if (!this.removedAt) {
       this.removedAt = removedAt;
       return;
     }

--- a/packages/sdk/src/document/crdt/rga_tree_split.ts
+++ b/packages/sdk/src/document/crdt/rga_tree_split.ts
@@ -20,7 +20,6 @@ import { SplayNode, SplayTree } from '@yorkie-js/sdk/src/util/splay_tree';
 import { LLRBTree } from '@yorkie-js/sdk/src/util/llrb_tree';
 import {
   InitialTimeTicket,
-  MaxLamport,
   TimeTicket,
   TimeTicketSize,
   TimeTicketStruct,
@@ -446,16 +445,15 @@ export class RGATreeSplitNode<T extends RGATreeSplitValue>
   /**
    * `canDelete` checks if node is able to delete.
    */
-  public canDelete(
-    editedAt: TimeTicket,
-    clientLamportAtChange: bigint,
-  ): boolean {
-    const justRemoved = !this.removedAt;
-    const nodeExisted =
-      this.getCreatedAt().getLamport() <= clientLamportAtChange;
+  public canRemove(creationKnown: boolean): boolean {
+    // NOTE(hackerwins): Skip if the node's creation was not visible to this
+    // operation.
+    if (!creationKnown) {
+      return false;
+    }
 
-    if (nodeExisted && (!this.removedAt || editedAt.after(this.removedAt))) {
-      return justRemoved;
+    if (this.removedAt == null) {
+      return true;
     }
 
     return false;
@@ -475,10 +473,26 @@ export class RGATreeSplitNode<T extends RGATreeSplitValue>
   }
 
   /**
-   * `remove` removes node of given edited time.
+   * `setRemovedAt` sets the remove time of this node.
    */
-  public remove(editedAt?: TimeTicket): void {
-    this.removedAt = editedAt;
+  public setRemovedAt(removedAt?: TimeTicket): void {
+    this.removedAt = removedAt;
+  }
+
+  /**
+   * `remove` removes the node of the given edited time.
+   */
+  public remove(removedAt: TimeTicket, tombstoneKnown: boolean) {
+    if (this.removedAt == null) {
+      this.removedAt = removedAt;
+      return;
+    }
+
+    // NOTE(hackerwins): Overwrite only if prior tombstone was not known
+    // (concurrent or unseen) and newer.
+    if (!tombstoneKnown && removedAt.after(this.removedAt)) {
+      this.removedAt = removedAt;
+    }
   }
 
   /**
@@ -923,64 +937,46 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
   private deleteNodes(
     candidates: Array<RGATreeSplitNode<T>>,
     editedAt: TimeTicket,
-    versionVector?: VersionVector,
+    vector?: VersionVector,
   ): [Array<ValueChange<T>>, Map<string, RGATreeSplitNode<T>>] {
     if (!candidates.length) {
       return [[], new Map()];
     }
 
-    // There are 2 types of nodes in `candidates`: should delete, should not delete.
-    // `nodesToKeep` contains nodes should not delete,
-    // then is used to find the boundary of the range to be deleted.
-    const [nodesToDelete, nodesToKeep] = this.filterNodes(
-      candidates,
-      editedAt,
-      versionVector,
-    );
+    const isLocal = vector === undefined;
 
-    const removedNodes = new Map();
-    // First we need to collect indexes for change.
-    const changes = this.makeChanges(nodesToKeep, editedAt);
-    for (const node of nodesToDelete) {
-      // Then make nodes be tombstones and map that.
-      removedNodes.set(node.getID().toIDString(), node);
-      node.remove(editedAt);
-    }
-    // Finally remove index nodes of tombstones.
-    this.deleteIndexNodes(nodesToKeep);
-
-    return [changes, removedNodes];
-  }
-
-  private filterNodes(
-    candidates: Array<RGATreeSplitNode<T>>,
-    editedAt: TimeTicket,
-    versionVector?: VersionVector,
-  ): [Array<RGATreeSplitNode<T>>, Array<RGATreeSplitNode<T> | undefined>] {
-    const nodesToDelete: Array<RGATreeSplitNode<T>> = [];
+    // 01. Collect nodes to remove and keep.
+    const nodesToRemove: Array<RGATreeSplitNode<T>> = [];
     const nodesToKeep: Array<RGATreeSplitNode<T> | undefined> = [];
-
     const [leftEdge, rightEdge] = this.findEdgesOfCandidates(candidates);
     nodesToKeep.push(leftEdge);
-
     for (const node of candidates) {
-      const actorID = node.getCreatedAt().getActorID();
-      let clientLamportAtChange = MaxLamport; // Local edit
-      if (versionVector != undefined) {
-        clientLamportAtChange = versionVector!.get(actorID)
-          ? versionVector!.get(actorID)!
-          : 0n;
-      }
-
-      if (node.canDelete(editedAt, clientLamportAtChange)) {
-        nodesToDelete.push(node);
+      if (node.canRemove(isLocal || vector.afterOrEqual(node.getCreatedAt()))) {
+        nodesToRemove.push(node);
       } else {
         nodesToKeep.push(node);
       }
     }
     nodesToKeep.push(rightEdge);
 
-    return [nodesToDelete, nodesToKeep];
+    // 02. Create value changes with previous indexes before deletion.
+    const changes = this.makeChanges(nodesToKeep, editedAt);
+
+    // 03. Mark tombstones for removal.
+    const removedNodes = new Map();
+    for (const node of nodesToRemove) {
+      removedNodes.set(node.getID().toIDString(), node);
+      node.remove(
+        editedAt,
+        node.isRemoved() &&
+          (isLocal || vector.afterOrEqual(node.getRemovedAt()!)),
+      );
+    }
+
+    // 04. Clear the index tree of the given deletion boundaries.
+    this.deleteIndexNodes(nodesToKeep);
+
+    return [changes, removedNodes];
   }
 
   /**

--- a/packages/sdk/src/document/time/version_vector.ts
+++ b/packages/sdk/src/document/time/version_vector.ts
@@ -51,6 +51,13 @@ export class VersionVector {
   }
 
   /**
+   * `has` checks if the given actor exists in the VersionVector.
+   */
+  public has(actorID: string): boolean {
+    return this.vector.has(actorID);
+  }
+
+  /**
    * `maxLamport` returns max lamport value from vector
    */
   public maxLamport() {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Fix removedAt timestamp handling in text deletions

Previously, during range deletions, nodes already marked as deleted (tombstones) could have their `removedAt` timestamp incorrectly overwritten. This broke CRDT semantics by losing causal deletion information and causing incorrect conflict resolution or undo/redo.

Changes:
- Distinguish causal vs concurrent deletions and return true only for newly removed nodes.
- Added `SetRemovedAt` for deserialization without triggering deletion logic.

Now:
- Causal deletions preserve original timestamps.
- Concurrent deletions resolve with LWW.
- GC only registers newly removed nodes, while boundaries are preserved.


#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Addresses #821
Related to https://github.com/yorkie-team/yorkie/pull/1447

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  - More reliable/dead-character-free text deletions; reduces rare undeletion/resurrection after sync.
  - Better handling of concurrent deletions to avoid inconsistent remnants.

* **Improvements**
  - Deletion behavior now respects creation visibility and tombstones, improving cross-device consistency.
  - More predictable offline edit sync and tombstone handling for stability.

* **Tests**
  - Added integration tests verifying causal and concurrent deletion behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->