### PR TITLE
fix: attachment constructor arg typo

### DIFF
--- a/packages/sdk/src/client/attachment.ts
+++ b/packages/sdk/src/client/attachment.ts
@@ -30,7 +30,7 @@ export class Attachment<T, P extends Indexable> {
     doc: Document<T, P>,
     docID: string,
     syncMode: SyncMode,
-    unsubscribeBroacastEvent: Unsubscribe,
+    unsubscribeBroadcastEvent: Unsubscribe,
   ) {
     this.reconnectStreamDelay = reconnectStreamDelay;
     this.doc = doc;
@@ -38,7 +38,7 @@ export class Attachment<T, P extends Indexable> {
     this.syncMode = syncMode;
     this.remoteChangeEventReceived = false;
     this.cancelled = false;
-    this.unsubscribeBroadcastEvent = unsubscribeBroacastEvent;
+    this.unsubscribeBroadcastEvent = unsubscribeBroadcastEvent;
   }
 
   /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
unsubscribeBroacastEvent -> unsubscribeBroadcastEvent

#### Any background context you want to provide?
None

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Corrected a typo in the SDK’s Attachment constructor parameter name, aligning it with the documented property. If you reference this parameter directly, update your integration to use the corrected name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->