### PR TITLE
Text undo: add functionality that can undo edit operation, which comtain replace operation, insert operation and remove operation.

### DIFF
--- a/examples/vanilla-codemirror6/package.json
+++ b/examples/vanilla-codemirror6/package.json
@@ -13,6 +13,7 @@
     "vite": "^5.0.12"
   },
   "dependencies": {
+    "@codemirror/view": "^6.4.1",
     "@codemirror/state": "^6.4.1",
     "codemirror": "^6.0.1",
     "@yorkie-js/sdk": "workspace:*"

--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -332,6 +332,71 @@
           yorkie.setLogLevel(yorkie.LogLevel.Debug);
           devtool.setCodeMirror(codemirror);
 
+          // Intercept keyboard undo/redo and route through Yorkie's history.
+          // This ensures multi-user undo/redo is coordinated by Yorkie.
+          codemirror.addKeyMap({
+            'Ctrl-Z': function (cm) {
+              if (
+                doc &&
+                doc.history &&
+                doc.history.canUndo &&
+                doc.history.canUndo()
+              ) {
+                doc.history.undo();
+                return true;
+              }
+              return CodeMirror.commands.undo(cm);
+            },
+            'Cmd-Z': function (cm) {
+              if (
+                doc &&
+                doc.history &&
+                doc.history.canUndo &&
+                doc.history.canUndo()
+              ) {
+                doc.history.undo();
+                return true;
+              }
+              return CodeMirror.commands.undo(cm);
+            },
+            'Ctrl-Y': function (cm) {
+              if (
+                doc &&
+                doc.history &&
+                doc.history.canRedo &&
+                doc.history.canRedo()
+              ) {
+                doc.history.redo();
+                return true;
+              }
+              return CodeMirror.commands.redo(cm);
+            },
+            'Shift-Ctrl-Z': function (cm) {
+              if (
+                doc &&
+                doc.history &&
+                doc.history.canRedo &&
+                doc.history.canRedo()
+              ) {
+                doc.history.redo();
+                return true;
+              }
+              return CodeMirror.commands.redo(cm);
+            },
+            'Shift-Cmd-Z': function (cm) {
+              if (
+                doc &&
+                doc.history &&
+                doc.history.canRedo &&
+                doc.history.canRedo()
+              ) {
+                doc.history.redo();
+                return true;
+              }
+              return CodeMirror.commands.redo(cm);
+            },
+          });
+
           // 02-1. create client with RPCAddr.
           const client = new yorkie.Client({
             rpcAddr: 'http://localhost:8080',
@@ -383,7 +448,8 @@
           });
 
           doc.subscribe('$.content', (event) => {
-            if (event.type === 'remote-change') {
+            // Handle both remote changes and undo/redo-applied changes.
+            if (event.type === 'remote-change' || event.source === 'undoredo') {
               const { actor, operations } = event.value;
               handleOperations(operations, actor);
 
@@ -401,7 +467,15 @@
           // 04. bind the document with the codemirror.
           // 04-1. codemirror to document(applying local).
           codemirror.on('beforeChange', (cm, change) => {
-            if (change.origin === 'yorkie' || change.origin === 'setValue') {
+            // Ignore changes that originated from Yorkie sync or programmatic setValue.
+            // Also ignore CodeMirror's undo/redo origins as those are routed
+            // through Yorkie's history to keep multi-user history consistent.
+            if (
+              change.origin === 'yorkie' ||
+              change.origin === 'setValue' ||
+              change.origin === 'undo' ||
+              change.origin === 'redo'
+            ) {
               return;
             }
 

--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -492,7 +492,12 @@
             console.log(`%c local: ${from}-${to}: ${content}`, 'color: green');
           });
           codemirror.on('change', (cm, change) => {
-            if (change.origin === 'yorkie' || change.origin === 'setValue') {
+            if (
+              change.origin === 'yorkie' ||
+              change.origin === 'setValue' ||
+              change.origin === 'undo' ||
+              change.origin === 'redo'
+            ) {
               return;
             }
 

--- a/packages/sdk/src/document/crdt/rga_tree_split.ts
+++ b/packages/sdk/src/document/crdt/rga_tree_split.ts
@@ -588,7 +588,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
    * @param range - range of RGATreeSplitNode
    * @param editedAt - edited time
    * @param value - value
-   * @returns `[RGATreeSplitPos, Array<GCPair>, Array<Change>]`
+   * @returns `[RGATreeSplitPos, Array<GCPair>, DataSize, Array<ValueChange<T>>, Array<T>]`
    */
   public edit(
     range: RGATreeSplitPosRange,

--- a/packages/sdk/src/document/crdt/rga_tree_split.ts
+++ b/packages/sdk/src/document/crdt/rga_tree_split.ts
@@ -761,7 +761,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
     }
 
     let offsetInPart = pos.getRelativeOffset();
-    let partLen = node.getLength();
+    let partLen = node.getContentLength();
     while (offsetInPart > partLen) {
       offsetInPart -= partLen;
       const next: RGATreeSplitNode<T> | undefined = node!.getNext();

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -788,6 +788,7 @@ export class Document<R, P extends Indexable = Indexable> {
         this.root,
         this.presences,
         OpSource.Local,
+        this.clone?.root,
       );
 
       // NOTE(hackerwins): In update(Set), the element is replaced with a new value.

--- a/packages/sdk/src/document/operation/edit_operation.ts
+++ b/packages/sdk/src/document/operation/edit_operation.ts
@@ -120,6 +120,8 @@ export class EditOperation extends Operation {
       root.registerGCPair(pair);
     }
 
+    console.log(`gcLock: ${this.fromPos.getID().getCreatedAt().toIDString()}`);
+
     return {
       opInfos: changes.map(({ from, to, value }) => {
         return {
@@ -131,6 +133,7 @@ export class EditOperation extends Operation {
         } as OperationInfo;
       }),
       reverseOp,
+      gcLock: this.fromPos.getID().toIDString(),
     };
   }
   /**

--- a/packages/sdk/src/document/operation/operation.ts
+++ b/packages/sdk/src/document/operation/operation.ts
@@ -193,6 +193,7 @@ export type ExecutionResult = {
   // TODO(chacha912): After implementing all of the reverseOperation,
   // we change the type to non-optional.
   reverseOp?: Operation;
+  gcLock?: string;
 };
 
 /**

--- a/packages/sdk/src/util/gclock.ts
+++ b/packages/sdk/src/util/gclock.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2025 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * GCLock
+ *
+ * A bidirectional lock registry to prevent premature GC of timeTicket–referenced
+ * data while undo operations may still need it.
+ *
+ * Why this is needed:
+ * In an undo/redo system, an UndoOperation can reference a timeTicket that
+ * points to data which might be collected by GC before the actual undo `execute`
+ * runs. If that happens, executing the undo would fail. This class lets you
+ * "lock" GC for specific timeTickets as long as there are operations referencing
+ * them. When the operations are done, you "unlock" and allow GC again.
+ *
+ * Design:
+ * - forward index: Map<timeTicketKey: string, Set<operation>>
+ * - reverse index: WeakMap<operation, Set<timeTicketKey: string>>
+ *
+ * We support multi-lock: a single operation may be locked
+ * against multiple timeTickets simultaneously. `unlock(operation)` removes the
+ * operation from all its associated timeTickets, deleting those keys if no
+ * other operations remain.
+ *
+ * Notes:
+ * - Uses a WeakMap for the reverse index so operations can be GC’d naturally
+ *   when the outside world drops references to them.
+ * - The caller must provide canonical `timeTicketKey` strings.
+ */
+export class GCLock<OP extends object> {
+  private forward = new Map<string, Set<OP>>();
+  private reverse = new WeakMap<OP, Set<string>>();
+
+  /**
+   * Lock GC for the given `timeTicketKey` on behalf of `operation`.
+   * If the key does not exist yet, it will be created and initialized with `[operation]`.
+   * If it exists, the operation is added to its Set (idempotent).
+   *
+   * @param timeTicketKey - stable string key of the resource to protect
+   * @param operation     - the operation that requires the protection
+   */
+  lock(timeTicketKey: string, operation: OP): void {
+    // forward
+    let fset = this.forward.get(timeTicketKey);
+    if (!fset) {
+      fset = new Set<OP>();
+      this.forward.set(timeTicketKey, fset);
+    }
+    if (!fset.has(operation)) fset.add(operation);
+
+    // reverse
+    let rset = this.reverse.get(operation);
+    if (!rset) {
+      rset = new Set<string>();
+      this.reverse.set(operation, rset);
+    }
+    rset.add(timeTicketKey);
+  }
+
+  /**
+   * Unlock GC for all timeTickets currently held by `operation`.
+   * For each affected timeTicketKey:
+   *  - If the Set contains only this operation, the key is deleted.
+   *  - Otherwise, only this operation is removed from the Set.
+   *
+   * Returns the number of distinct timeTicketKeys that were affected
+   * for this operation.
+   *
+   * @param operation - the operation to release from all locks
+   * @returns number of timeTicketKeys touched by this unlock
+   */
+  unlock(operation: OP): number {
+    const rset = this.reverse.get(operation);
+    if (!rset || rset.size === 0) return 0;
+
+    let touched = 0;
+    for (const key of rset) {
+      const fset = this.forward.get(key);
+      if (!fset) continue;
+
+      if (fset.delete(operation)) {
+        touched++;
+        if (fset.size === 0) this.forward.delete(key);
+      }
+    }
+
+    // remove reverse mapping entirely for this operation
+    this.reverse.delete(operation);
+    return touched;
+  }
+
+  /**
+   * Check if the given `timeTicketKey` currently has any active locks.
+   *
+   * @param timeTicketKey - the key to check
+   * @returns true if locked, false otherwise
+   */
+  isLocked(timeTicketKey: string): boolean {
+    return this.forward.has(timeTicketKey);
+  }
+
+  /**
+   * Get number of operations locking the given `timeTicketKey`.
+   * Useful for diagnostics/metrics.
+   *
+   * @param timeTicketKey - the key to inspect
+   * @returns count of operations currently locking it
+   */
+  size(timeTicketKey: string): number {
+    return this.forward.get(timeTicketKey)?.size ?? 0;
+  }
+
+  /**
+   * Returns a human-readable snapshot of the current locks, e.g.:
+   *   GCLock{ tt#1: [op#A, op#B], tt#2: [op#C] }
+   *
+   * Notes:
+   * - Only the forward index (timeTicketKey -> Set<operation>) is included.
+   * - The reverse index is a WeakMap and cannot be enumerated by design.
+   *
+   * @param opLabeler Optional function to stringify each operation.
+   *                  Defaults to returning "[op]".
+   */
+  public toString(opLabeler?: (op: OP) => string): string {
+    const label = opLabeler ?? (() => '[op]');
+    const chunks: Array<string> = [];
+    for (const [k, set] of this.forward) {
+      const ops = [...set].map(label).join(', ');
+      chunks.push(`${k}: [${ops}]`);
+    }
+    return `GCLock{ ${chunks.join(', ')} }`;
+  }
+
+  /**
+   * Return a lightweight snapshot of lock counts per key
+   * for debugging/telemetry (no operation identities are exposed).
+   */
+  debugSnapshot(): Record<string, number> {
+    const out: Record<string, number> = {};
+    for (const [k, set] of this.forward) out[k] = set.size;
+    return out;
+  }
+
+  /**
+   * Create a structural deep copy of this GCLock.
+   *
+   * Containers (Map/Set) are fully recreated so the returned instance is
+   * independent of the original. Operation objects (OP) themselves are NOT
+   * cloned; their references are preserved to keep identity semantics.
+   *
+   * Implementation detail:
+   * - WeakMap cannot be enumerated, so we rebuild the reverse index from
+   *   the forward Map during the copy.
+   *
+   * @returns a new GCLock whose forward/reverse indexes mirror the current state
+   */
+  deepcopy(): GCLock<OP> {
+    const copy = new GCLock<OP>();
+
+    // Rebuild forward map and reverse index from current forward map.
+    for (const [key, set] of this.forward) {
+      const newSet = new Set<OP>();
+      for (const op of set) {
+        newSet.add(op);
+
+        // reconstruct reverse: op -> keys
+        let rset = copy.reverse.get(op);
+        if (!rset) {
+          rset = new Set<string>();
+          copy.reverse.set(op, rset);
+        }
+        rset.add(key);
+      }
+      copy.forward.set(key, newSet);
+    }
+
+    return copy;
+  }
+}

--- a/packages/sdk/test/integration/history_text_test.ts
+++ b/packages/sdk/test/integration/history_text_test.ts
@@ -1,0 +1,251 @@
+import { describe, it, assert } from 'vitest';
+import { Document, Text } from '@yorkie-js/sdk/src/yorkie';
+import { withTwoClientsAndDocuments } from '@yorkie-js/sdk/test/integration/integration_helper';
+
+type TextOp = 'insert' | 'delete' | 'replace' | 'style';
+const ops: Array<TextOp> = ['insert', 'delete', 'replace', 'style'];
+
+/**
+ * 단일 클라이언트용: root.t에 op1 세트를 적용
+ * 문서는 항상 초기 콘텐츠를 충분히 갖도록 설정해서 인덱스 안전하게 씁니다.
+ */
+function applyTextOp1(doc: Document<{ t: Text }>, op: TextOp) {
+  doc.update((root) => {
+    const t = root.t;
+
+    switch (op) {
+      case 'insert': {
+        // 끝에 삽입
+        const len = t.length ?? t.toString().length;
+        t.edit(len, len, 'X');
+        break;
+      }
+      case 'delete': {
+        // 중간 한 글자 삭제 (가능하면)
+        const len = t.length ?? t.toString().length;
+        if (len >= 3) {
+          t.edit(1, 2, ''); // [1,2) 삭제
+        } else if (len > 0) {
+          t.edit(0, 1, '');
+        }
+        break;
+      }
+      case 'replace': {
+        // [1,3) → '12' 로 치환 (가능하면)
+        const len = t.length ?? t.toString().length;
+        if (len >= 3) {
+          t.edit(1, 3, '12');
+        } else {
+          // 길이가 짧으면 앞에서 가능한 범위를 치환
+          const to = Math.min(1, len);
+          t.edit(0, to, 'R');
+        }
+        break;
+      }
+      case 'style': {
+        // 전체 또는 가능한 범위에 스타일 부여
+        const len = t.length ?? t.toString().length;
+        if (len === 0) {
+          t.edit(0, 0, 'A');
+        }
+        const end = t.length ?? t.toString().length;
+        t.setStyle(0, end, { bold: true } as any);
+        break;
+      }
+    }
+  }, op);
+}
+
+/**
+ * 두 번째 클라이언트용: op2 세트를 적용
+ * 인덱스를 다르게 잡아서 충돌/병합 시나리오를 만들어봄.
+ */
+function applyTextOp2(doc: Document<{ t: Text }>, op: TextOp) {
+  doc.update((root) => {
+    const t = root.t;
+
+    switch (op) {
+      case 'insert': {
+        // 앞쪽에 삽입
+        t.edit(0, 0, 'Q');
+        break;
+      }
+      case 'delete': {
+        // 뒤쪽 한 글자 삭제 (가능하면)
+        const len = t.length ?? t.toString().length;
+        if (len > 0) t.edit(len - 1, len, '');
+        break;
+      }
+      case 'replace': {
+        // [0,1) → 'Z' 로 치환 (가능하면)
+        const len = t.length ?? t.toString().length;
+        if (len > 0) t.edit(0, 1, 'Z');
+        else t.edit(0, 0, 'Z');
+        break;
+      }
+    }
+  }, op);
+}
+
+describe('Text Undo - single op', () => {
+  for (const op of ['insert', 'delete', 'replace'] as Array<TextOp>) {
+    it(`should undo ${op}`, () => {
+      const doc = new Document<{ t: Text }>('test-doc');
+      // 초기화
+      doc.update((root) => {
+        root.t = new Text();
+        root.t.edit(0, 0, 'The fox jumped.');
+      }, 'init');
+
+      // op 적용 후 undo
+      applyTextOp1(doc, op);
+      doc.history.undo();
+
+      assert.equal(
+        doc.getRoot().t.toString(),
+        'The fox jumped.',
+        `undo ${op} should restore text content`,
+      );
+    });
+  }
+});
+
+describe('Text Undo - chained ops', () => {
+  // 텍스트 내용만 읽는 헬퍼
+  const contentOf = (doc: Document<{ t: Text }>) => doc.getRoot().t.toString();
+
+  for (const op1 of ['replace'] as Array<TextOp>) {
+    for (const op2 of ['delete'] as Array<TextOp>) {
+      for (const op3 of ['delete'] as Array<TextOp>) {
+        const caseName = `${op1}-${op2}-${op3}`;
+
+        it(`should step back correctly: ${caseName}`, () => {
+          const doc = new Document<{ t: Text }>('test-doc');
+
+          doc.update((root) => {
+            root.t = new Text();
+            root.t.edit(0, 0, 'ABCD');
+          }, 'init');
+
+          // 텍스트 스냅샷 저장
+          const S: Array<string> = [];
+          S.push(contentOf(doc)); // S0
+
+          applyTextOp1(doc, op1);
+          S.push(contentOf(doc)); // S1
+
+          applyTextOp1(doc, op2);
+          S.push(contentOf(doc)); // S2
+
+          applyTextOp1(doc, op3);
+          S.push(contentOf(doc)); // S3
+
+          // S3 -> S2 -> S1 -> S0 순으로 되돌아가는지 확인
+          for (let i = 3; i >= 1; i--) {
+            doc.history.undo();
+            const back = contentOf(doc);
+            assert.equal(
+              back,
+              S[i - 1],
+              `undo back to S${i - 1} failed on ${caseName}`,
+            );
+          }
+        });
+      }
+    }
+  }
+});
+
+describe('Text Undo - multi client', () => {
+  for (const op1 of ops) {
+    for (const op2 of ops) {
+      const caseName = `${op1}-${op2}`;
+
+      it(`should converge after both undo: ${caseName}`, async function ({
+        task,
+      }) {
+        type TestDoc = { t: Text };
+        await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
+          // 초기 동기화
+          d1.update((root) => {
+            root.t = new Text();
+            root.t.edit(0, 0, 'The fox jumped.');
+          }, 'init');
+          await c1.sync();
+          await c2.sync();
+          assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+
+          // 각자 op 적용
+          applyTextOp1(d1, op1);
+          applyTextOp2(d2, op2);
+
+          // 수렴 확인
+          await c1.sync();
+          await c2.sync();
+          await c1.sync();
+          assert.equal(
+            d1.toSortedJSON(),
+            d2.toSortedJSON(),
+            'Mismatch after both ops',
+          );
+
+          // 둘 다 undo
+          d1.history.undo();
+          d2.history.undo();
+
+          await c1.sync();
+          await c2.sync();
+          await c1.sync();
+
+          assert.equal(
+            d1.toSortedJSON(),
+            d2.toSortedJSON(),
+            'Mismatch after both undos',
+          );
+        }, task.name);
+      });
+    }
+  }
+});
+
+/**
+ * 특수 케이스: 복합 치환/스타일 섞인 시나리오에 대한 빠른 회귀 테스트
+ */
+describe('Text Undo - mixed scenario smoke test', () => {
+  it('should undo replace+style+insert in order', () => {
+    const doc = new Document<{ t: Text }>('test-doc');
+    doc.update((root) => {
+      root.t = new Text();
+      root.t.edit(0, 0, 'Hello World');
+    }, 'init');
+
+    const S0 = doc.toSortedJSON();
+
+    // replace
+    doc.update((root) => root.t.edit(6, 11, 'Yorkie'), 'replace');
+    const S1 = doc.toSortedJSON();
+
+    // style
+    doc.update(
+      (root) => root.t.setStyle(0, 11, { bold: true } as any),
+      'style',
+    );
+    const S2 = doc.toSortedJSON();
+
+    // insert
+    doc.update((root) => root.t.edit(11, 11, '!'), 'insert');
+    // const S3 = doc.toSortedJSON();
+
+    // undo insert
+    doc.history.undo();
+    assert.equal(doc.toSortedJSON(), S2, 'undo insert');
+
+    // undo style
+    doc.history.undo();
+    assert.equal(doc.toSortedJSON(), S1, 'undo style');
+
+    // undo replace
+    doc.history.undo();
+    assert.equal(doc.toSortedJSON(), S0, 'undo replace');
+  });
+});

--- a/packages/sdk/test/integration/history_text_test.ts
+++ b/packages/sdk/test/integration/history_text_test.ts
@@ -114,9 +114,9 @@ describe('Text Undo - chained ops', () => {
   // 텍스트 내용만 읽는 헬퍼
   const contentOf = (doc: Document<{ t: Text }>) => doc.getRoot().t.toString();
 
-  for (const op1 of ['replace'] as Array<TextOp>) {
-    for (const op2 of ['delete'] as Array<TextOp>) {
-      for (const op3 of ['delete'] as Array<TextOp>) {
+  for (const op1 of ['insert', 'delete', 'replace'] as Array<TextOp>) {
+    for (const op2 of ['insert', 'delete', 'replace'] as Array<TextOp>) {
+      for (const op3 of ['insert', 'delete', 'replace'] as Array<TextOp>) {
         const caseName = `${op1}-${op2}-${op3}`;
 
         it(`should step back correctly: ${caseName}`, () => {

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -20,8 +20,8 @@ export default defineConfig({
     benchmark: {
       exclude: ['**/lib/**', '**/node_modules/**'],
     },
-    // setupFiles: ['./test/vitest.setup.ts'],
-    setupFiles: ['../../test/vitest.setup.ts'],
+    setupFiles: ['./test/vitest.setup.ts'],
+    // setupFiles: ['../../test/vitest.setup.ts'],
   },
   plugins: [
     tsconfigPaths({

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -21,7 +21,6 @@ export default defineConfig({
       exclude: ['**/lib/**', '**/node_modules/**'],
     },
     setupFiles: ['./test/vitest.setup.ts'],
-    // setupFiles: ['../../test/vitest.setup.ts'],
   },
   plugins: [
     tsconfigPaths({

--- a/packages/sdk/vitest.config.ts
+++ b/packages/sdk/vitest.config.ts
@@ -20,7 +20,8 @@ export default defineConfig({
     benchmark: {
       exclude: ['**/lib/**', '**/node_modules/**'],
     },
-    setupFiles: ['./test/vitest.setup.ts'],
+    // setupFiles: ['./test/vitest.setup.ts'],
+    setupFiles: ['../../test/vitest.setup.ts'],
   },
   plugins: [
     tsconfigPaths({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,10 +131,6 @@ importers:
         specifier: 5.3.3
         version: 5.3.3
 
-  examples/nextjs-scheduler/dist: {}
-
-  examples/nextjs-scheduler/dist/types: {}
-
   examples/nextjs-todolist:
     dependencies:
       '@radix-ui/react-slot':
@@ -426,6 +422,9 @@ importers:
       '@codemirror/state':
         specifier: ^6.4.1
         version: 6.5.2
+      '@codemirror/view':
+        specifier: ^6.4.1
+        version: 6.38.1
       '@yorkie-js/sdk':
         specifier: workspace:*
         version: link:../../packages/sdk


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Undo about Raw Text. note that undo does not consider style.

Any background context you want to provide?

#### What are the relevant tickets?
Fixes #

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [ ] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [ ] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multi-user undo/redo for text edits with reverse-op generation and preserved convergence.
  * Edit APIs now return removed text values and offer position refinement for stable cursor/selection.
  * GC lock mechanism added to prevent premature garbage collection during undo.
  * Editor example intercepts undo/redo to route through shared history for consistent local/remote behavior.
  * Example dependency updated for editor integration.

* **Tests**
  * Added integration tests covering single, chained, and multi-client undo scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->