### PR TITLE
Ensure LWW concurrent deletions collapse to single tombstone timestamp

### DIFF
--- a/packages/sdk/test/integration/text_test.ts
+++ b/packages/sdk/test/integration/text_test.ts
@@ -909,6 +909,23 @@ describe('peri-text example: text concurrent edit', function () {
       for (const n of [...getAllNodes(d1), ...getAllNodes(d2)]) {
         assert.ok(n.getRemovedAt(), 'node should be deleted');
       }
+
+      await c2.sync();
+      await c1.sync();
+      
+      const timestampSet = new Set<string>();
+      for (const n of [...getAllNodes(d1), ...getAllNodes(d2)]) {
+          if (n.getRemovedAt()) {
+            const timestamp = n.getRemovedAt().toIDString();
+            timestampSet.add(timestamp);
+          }
+        }
+  
+        assert.equal(
+          timestampSet.size,
+          1,
+          'Should have 1 timestamp in concurrent deletion',
+        );
     }, task.name);
   });
 });


### PR DESCRIPTION
제목:
**test: verify LWW concurrent deletion with single tombstone timestamp**

---

<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

* Adds an additional check in the concurrent deletion test (LWW behavior).
* Uses `Set` to confirm that all `removedAt` timestamps collapse into **size = 1**.
* Ensures correctness of LWW semantics: concurrent deletions should resolve to a single consistent tombstone timestamp.

#### Any background context you want to provide?

* The **previous test only verified** that all nodes were tombstoned (`removedAt` exists).
* It did **not** validate that all tombstoned nodes shared the same timestamp.
* This PR closes that gap by explicitly asserting `timestampSet.size === 1`.

#### What are the relevant tickets?

Fixes #

### Checklist

* [x] Added relevant tests
* [ ] Addressed and resolved all CodeRabbit review comments
* [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an integration test for concurrent deletions to verify that, after synchronization, all tombstoned nodes share a single removal timestamp.
  * Ensures consistent post-deletion synchronization behavior across replicas, improving reliability and guarding against timestamp divergence.
  * Increases confidence in edge-case handling without altering public APIs or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->