### PR TITLE
Rename OperationInfo to OpInfo across the codebase

### DIFF
--- a/examples/nextjs-quill/components/Editor.tsx
+++ b/examples/nextjs-quill/components/Editor.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useDocument } from '@yorkie-js/react';
-import { Indexable, OperationInfo, Text } from '@yorkie-js/sdk';
+import { Indexable, Text } from '@yorkie-js/sdk';
 import Quill, { Delta, QuillOptions } from 'quill';
 import 'quill/dist/quill.snow.css';
 import { useCallback, useEffect, useRef } from 'react';
@@ -39,7 +39,7 @@ const Editor = () => {
   const { doc, update, loading, error } = useDocument<YorkieDoc>();
 
   // Handle remote operations and apply them to Quill editor
-  const handleOperations = useCallback((ops: OperationInfo[]) => {
+  const handleOperations = useCallback((ops) => {
     if (!quillRef.current) return;
 
     const deltaOperations = getDeltaOperations(ops);

--- a/examples/nextjs-quill/lib/utils.ts
+++ b/examples/nextjs-quill/lib/utils.ts
@@ -1,4 +1,4 @@
-import { OperationInfo } from '@yorkie-js/sdk';
+import { OpInfo } from '@yorkie-js/sdk';
 import { clsx, type ClassValue } from 'clsx';
 import { Op } from 'quill';
 import { twMerge } from 'tailwind-merge';
@@ -21,8 +21,8 @@ export const toDeltaOperation = <T extends TextValueType>(textValue: T): Op => {
   };
 };
 
-// Convert array of Yorkie OperationInfo to array of Quill Delta Operations
-export const getDeltaOperations = (ops: Array<OperationInfo>): Array<Op> => {
+// Convert array of Yorkie OpInfo to array of Quill Delta Operations
+export const getDeltaOperations = (ops: Array<OpInfo>): Array<Op> => {
   const operations: Array<Op> = [];
   let prevTo = 0;
 

--- a/examples/vanilla-codemirror6/src/main.ts
+++ b/examples/vanilla-codemirror6/src/main.ts
@@ -1,4 +1,4 @@
-import type { EditOpInfo, OperationInfo } from '@yorkie-js/sdk';
+import type { EditOpInfo, OpInfo } from '@yorkie-js/sdk';
 import yorkie, { DocEventType } from '@yorkie-js/sdk';
 import { basicSetup, EditorView } from 'codemirror';
 import { Transaction, TransactionSpec } from '@codemirror/state';
@@ -145,7 +145,7 @@ async function main() {
   });
 
   // 03-3. define event handler that apply remote changes to local
-  function handleOperations(operations: Array<OperationInfo>) {
+  function handleOperations(operations: Array<OpInfo>) {
     for (const op of operations) {
       if (op.type === 'edit') {
         handleEditOp(op);

--- a/examples/vanilla-quill/src/main.ts
+++ b/examples/vanilla-quill/src/main.ts
@@ -1,4 +1,4 @@
-import yorkie, { DocEventType, Indexable, OperationInfo } from '@yorkie-js/sdk';
+import yorkie, { DocEventType, Indexable, OpInfo } from '@yorkie-js/sdk';
 import ColorHash from 'color-hash';
 import Quill, { Delta, type Op } from 'quill';
 import QuillCursors from 'quill-cursors';
@@ -242,7 +242,7 @@ async function main() {
     });
 
   // 04-2. document to Quill(remote).
-  function handleOperations(ops: Array<OperationInfo>) {
+  function handleOperations(ops: Array<OpInfo>) {
     const deltaOperations = [];
     let prevTo = 0;
     for (const op of ops) {

--- a/packages/sdk/src/devtools/types.ts
+++ b/packages/sdk/src/devtools/types.ts
@@ -31,7 +31,7 @@ import {
   type UnwatchedEvent,
   type PresenceChangedEvent,
 } from '@yorkie-js/sdk/src/document/document';
-import type { OperationInfo } from '@yorkie-js/sdk/src/document/operation/operation';
+import type { OpInfo } from '@yorkie-js/sdk/src/document/operation/operation';
 
 /**
  * `Client` represents a client value in devtools.
@@ -103,10 +103,7 @@ export type TreeNodeInfo = {
 /**
  * `DocEventForReplay` is an event used to replay a document.
  */
-export type DocEventForReplay<
-  P extends Indexable = Indexable,
-  T = OperationInfo,
-> =
+export type DocEventForReplay<P extends Indexable = Indexable, T = OpInfo> =
   | StatusChangedEvent
   | SnapshotEvent
   | LocalChangeEvent<T, P>

--- a/packages/sdk/src/document/change/change.ts
+++ b/packages/sdk/src/document/change/change.ts
@@ -18,7 +18,7 @@ import { ActorID } from '@yorkie-js/sdk/src/document/time/actor_id';
 import {
   OpSource,
   Operation,
-  OperationInfo,
+  OpInfo,
 } from '@yorkie-js/sdk/src/document/operation/operation';
 import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
 import { ChangeID } from '@yorkie-js/sdk/src/document/change/change_id';
@@ -155,10 +155,10 @@ export class Change<P extends Indexable> {
     presences: Map<ActorID, P>,
     source: OpSource,
   ): {
-    opInfos: Array<OperationInfo>;
+    opInfos: Array<OpInfo>;
     reverseOps: Array<HistoryOperation<P>>;
   } {
-    const changeOpInfos: Array<OperationInfo> = [];
+    const changeOpInfos: Array<OpInfo> = [];
     const reverseOps: Array<HistoryOperation<P>> = [];
 
     for (const operation of this.operations) {

--- a/packages/sdk/src/document/operation/edit_operation.ts
+++ b/packages/sdk/src/document/operation/edit_operation.ts
@@ -21,7 +21,7 @@ import { RGATreeSplitPos } from '@yorkie-js/sdk/src/document/crdt/rga_tree_split
 import { CRDTText } from '@yorkie-js/sdk/src/document/crdt/text';
 import {
   Operation,
-  OperationInfo,
+  OpInfo,
   ExecutionResult,
   OpSource,
 } from '@yorkie-js/sdk/src/document/operation/operation';
@@ -119,7 +119,7 @@ export class EditOperation extends Operation {
           to,
           value,
           path: root.createPath(this.getParentCreatedAt()),
-        } as OperationInfo;
+        } as OpInfo;
       }),
     };
   }

--- a/packages/sdk/src/document/operation/operation.ts
+++ b/packages/sdk/src/document/operation/operation.ts
@@ -34,44 +34,44 @@ export enum OpSource {
 }
 
 /**
- * `OperationInfo` represents the information of an operation.
+ * `OpInfo` represents the information of an operation.
  * It is used to inform to the user what kind of operation was executed.
  */
-export type OperationInfo =
-  | TextOperationInfo
-  | CounterOperationInfo
-  | ArrayOperationInfo
-  | ObjectOperationInfo
-  | TreeOperationInfo;
+export type OpInfo =
+  | TextOpInfo
+  | CounterOpInfo
+  | ArrayOpInfo
+  | ObjectOpInfo
+  | TreeOpInfo;
 
 /**
- * `TextOperationInfo` represents the OperationInfo for the yorkie.Text.
+ * `TextOpInfo` represents the OperationInfo for the yorkie.Text.
  */
-export type TextOperationInfo = EditOpInfo | StyleOpInfo;
+export type TextOpInfo = EditOpInfo | StyleOpInfo;
 
 /**
- * `CounterOperationInfo` represents the OperationInfo for the yorkie.Counter.
+ * `CounterOpInfo` represents the OperationInfo for the yorkie.Counter.
  */
-export type CounterOperationInfo = IncreaseOpInfo;
+export type CounterOpInfo = IncreaseOpInfo;
 
 /**
- * `ArrayOperationInfo` represents the OperationInfo for the JSONArray.
+ * `ArrayOpInfo` represents the OperationInfo for the JSONArray.
  */
-export type ArrayOperationInfo =
+export type ArrayOpInfo =
   | AddOpInfo
   | RemoveOpInfo
   | MoveOpInfo
   | ArraySetOpInfo;
 
 /**
- * `ObjectOperationInfo` represents the OperationInfo for the JSONObject.
+ * `ObjectOpInfo` represents the OperationInfo for the JSONObject.
  */
-export type ObjectOperationInfo = SetOpInfo | RemoveOpInfo;
+export type ObjectOpInfo = SetOpInfo | RemoveOpInfo;
 
 /**
- * `TreeOperationInfo` represents the OperationInfo for the yorkie.Tree.
+ * `TreeOpInfo` represents the OperationInfo for the yorkie.Tree.
  */
-export type TreeOperationInfo = TreeEditOpInfo | TreeStyleOpInfo;
+export type TreeOpInfo = TreeEditOpInfo | TreeStyleOpInfo;
 
 /**
  * `AddOpInfo` represents the information of the add operation.
@@ -189,7 +189,7 @@ export type TreeStyleOpInfo = {
  * `ExecutionResult` represents the result of operation execution.
  */
 export type ExecutionResult = {
-  opInfos: Array<OperationInfo>;
+  opInfos: Array<OpInfo>;
   // TODO(chacha912): After implementing all of the reverseOperation,
   // we change the type to non-optional.
   reverseOp?: Operation;

--- a/packages/sdk/src/document/operation/remove_operation.ts
+++ b/packages/sdk/src/document/operation/remove_operation.ts
@@ -19,7 +19,7 @@ import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
 import {
   OpSource,
   Operation,
-  OperationInfo,
+  OpInfo,
   ExecutionResult,
 } from '@yorkie-js/sdk/src/document/operation/operation';
 import {
@@ -99,7 +99,7 @@ export class RemoveOperation extends Operation {
     const elem = container.delete(this.createdAt, this.getExecutedAt());
     root.registerRemovedElement(elem);
 
-    const opInfos: Array<OperationInfo> =
+    const opInfos: Array<OpInfo> =
       container instanceof CRDTArray
         ? [
             {

--- a/packages/sdk/src/document/operation/style_operation.ts
+++ b/packages/sdk/src/document/operation/style_operation.ts
@@ -21,7 +21,7 @@ import { RGATreeSplitPos } from '@yorkie-js/sdk/src/document/crdt/rga_tree_split
 import { CRDTText } from '@yorkie-js/sdk/src/document/crdt/text';
 import {
   Operation,
-  OperationInfo,
+  OpInfo,
   ExecutionResult,
   OpSource,
 } from '@yorkie-js/sdk/src/document/operation/operation';
@@ -111,7 +111,7 @@ export class StyleOperation extends Operation {
           to,
           value,
           path: root.createPath(this.getParentCreatedAt()),
-        } as OperationInfo;
+        } as OpInfo;
       }),
     };
   }

--- a/packages/sdk/src/document/operation/tree_edit_operation.ts
+++ b/packages/sdk/src/document/operation/tree_edit_operation.ts
@@ -25,7 +25,7 @@ import {
 } from '@yorkie-js/sdk/src/document/crdt/tree';
 import {
   Operation,
-  OperationInfo,
+  OpInfo,
   ExecutionResult,
   OpSource,
 } from '@yorkie-js/sdk/src/document/operation/operation';
@@ -145,7 +145,7 @@ export class TreeEditOperation extends Operation {
             splitLevel,
             fromPath,
             toPath,
-          } as OperationInfo;
+          } as OpInfo;
         },
       ),
     };

--- a/packages/sdk/src/document/operation/tree_style_operation.ts
+++ b/packages/sdk/src/document/operation/tree_style_operation.ts
@@ -24,7 +24,7 @@ import {
 } from '@yorkie-js/sdk/src/document/crdt/tree';
 import {
   Operation,
-  OperationInfo,
+  OpInfo,
   ExecutionResult,
   OpSource,
 } from '@yorkie-js/sdk/src/document/operation/operation';
@@ -161,7 +161,7 @@ export class TreeStyleOperation extends Operation {
           fromPath,
           toPath,
           path: root.createPath(this.getParentCreatedAt()),
-        } as OperationInfo;
+        } as OpInfo;
       }),
     };
   }

--- a/packages/sdk/src/yorkie.ts
+++ b/packages/sdk/src/yorkie.ts
@@ -66,19 +66,19 @@ export {
 export { type ActorID } from '@yorkie-js/sdk/src/document/time/actor_id';
 export { VersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
 export type {
-  OperationInfo,
-  TextOperationInfo,
-  CounterOperationInfo,
-  ArrayOperationInfo,
-  ObjectOperationInfo,
-  TreeOperationInfo,
-  AddOpInfo,
+  OpInfo,
+  CounterOpInfo,
   IncreaseOpInfo,
-  RemoveOpInfo,
+  ObjectOpInfo,
   SetOpInfo,
+  RemoveOpInfo,
+  ArrayOpInfo,
+  AddOpInfo,
   MoveOpInfo,
+  TextOpInfo,
   EditOpInfo,
   StyleOpInfo,
+  TreeOpInfo,
   TreeEditOpInfo,
   TreeStyleOpInfo,
 } from '@yorkie-js/sdk/src/document/operation/operation';

--- a/packages/sdk/test/helper/helper.ts
+++ b/packages/sdk/test/helper/helper.ts
@@ -23,7 +23,7 @@ import {
   CRDTTreeNodeID,
 } from '@yorkie-js/sdk/src/document/crdt/tree';
 import {
-  OperationInfo,
+  OpInfo,
   Operation,
 } from '@yorkie-js/sdk/src/document/operation/operation';
 import {
@@ -213,10 +213,7 @@ export class TextView {
     this.value = '';
   }
 
-  public applyOperations(
-    operations: Array<OperationInfo>,
-    enableLog = false,
-  ): void {
+  public applyOperations(operations: Array<OpInfo>, enableLog = false): void {
     const oldValue = this.value;
     const changeLogs = [];
     for (const op of operations) {

--- a/packages/sdk/test/integration/document_test.ts
+++ b/packages/sdk/test/integration/document_test.ts
@@ -23,7 +23,7 @@ import {
   DocEventType,
   StatusChangedEvent,
 } from '@yorkie-js/sdk/src/document/document';
-import { OperationInfo } from '@yorkie-js/sdk/src/document/operation/operation';
+import { OpInfo } from '@yorkie-js/sdk/src/document/operation/operation';
 import { YorkieError } from '@yorkie-js/sdk/src/util/error';
 import Long from 'long';
 
@@ -174,9 +174,9 @@ describe('Document', function () {
 
     type EventForTest = {
       type: DocEventType;
-      value: Array<OperationInfo>;
+      value: Array<OpInfo>;
     };
-    let expectedEventValue: Array<OperationInfo>;
+    let expectedEventValue: Array<OpInfo>;
     const eventCollectorD1 = new EventCollector<EventForTest>();
     const eventCollectorD2 = new EventCollector<EventForTest>();
     const unsub1 = d1.subscribe((event) => {
@@ -295,10 +295,9 @@ describe('Document', function () {
     await c1.attach(d1);
     await c2.attach(d2);
 
-    type EventForTest = Array<OperationInfo>;
-    const eventCollector = new EventCollector<EventForTest>();
-    const eventCollectorForTodos = new EventCollector<EventForTest>();
-    const eventCollectorForCounter = new EventCollector<EventForTest>();
+    const eventCollector = new EventCollector<Array<OpInfo>>();
+    const eventCollectorForTodos = new EventCollector<Array<OpInfo>>();
+    const eventCollectorForCounter = new EventCollector<Array<OpInfo>>();
     const unsub = d1.subscribe((event) => {
       if (event.type === DocEventType.Snapshot) {
         return;
@@ -385,10 +384,9 @@ describe('Document', function () {
     await c1.attach(d1);
     await c2.attach(d2);
 
-    type EventForTest = Array<OperationInfo>;
-    const eventCollector = new EventCollector<EventForTest>();
-    const eventCollectorForTodos0 = new EventCollector<EventForTest>();
-    const eventCollectorForObjC1 = new EventCollector<EventForTest>();
+    const eventCollector = new EventCollector<Array<OpInfo>>();
+    const eventCollectorForTodos0 = new EventCollector<Array<OpInfo>>();
+    const eventCollectorForObjC1 = new EventCollector<Array<OpInfo>>();
     const unsub = d1.subscribe((event) => {
       if (event.type === DocEventType.Snapshot) {
         return;

--- a/packages/sdk/test/integration/text_test.ts
+++ b/packages/sdk/test/integration/text_test.ts
@@ -912,20 +912,20 @@ describe('peri-text example: text concurrent edit', function () {
 
       await c2.sync();
       await c1.sync();
-      
+
       const timestampSet = new Set<string>();
       for (const n of [...getAllNodes(d1), ...getAllNodes(d2)]) {
-          if (n.getRemovedAt()) {
-            const timestamp = n.getRemovedAt().toIDString();
-            timestampSet.add(timestamp);
-          }
+        if (n.getRemovedAt()) {
+          const timestamp = n.getRemovedAt().toIDString();
+          timestampSet.add(timestamp);
         }
-  
-        assert.equal(
-          timestampSet.size,
-          1,
-          'Should have 1 timestamp in concurrent deletion',
-        );
+      }
+
+      assert.equal(
+        timestampSet.size,
+        1,
+        'Should have 1 timestamp in concurrent deletion',
+      );
     }, task.name);
   });
 });

--- a/packages/sdk/test/unit/document/document_test.ts
+++ b/packages/sdk/test/unit/document/document_test.ts
@@ -22,7 +22,7 @@ import {
 } from '@yorkie-js/sdk/test/helper/helper';
 
 import { Document, DocEventType } from '@yorkie-js/sdk/src/document/document';
-import { OperationInfo } from '@yorkie-js/sdk/src/document/operation/operation';
+import { OpInfo } from '@yorkie-js/sdk/src/document/operation/operation';
 import yorkie, {
   JSONArray,
   Text,
@@ -972,8 +972,7 @@ describe.sequential('Document', function () {
   it('changeInfo test for object', async function () {
     const doc = new Document<any>('test-doc');
 
-    type EventForTest = Array<OperationInfo>;
-    const eventCollector = new EventCollector<EventForTest>();
+    const eventCollector = new EventCollector<Array<OpInfo>>();
     const unsub = doc.subscribe((event) => {
       if (event.type === DocEventType.Snapshot) {
         return;
@@ -1017,8 +1016,7 @@ describe.sequential('Document', function () {
 
   it('changeInfo test for array', async function () {
     const doc = new Document<any>('test-doc');
-    type EventForTest = Array<OperationInfo>;
-    const eventCollector = new EventCollector<EventForTest>();
+    const eventCollector = new EventCollector<Array<OpInfo>>();
     const unsub = doc.subscribe((event) => {
       if (event.type === DocEventType.Snapshot) {
         return;
@@ -1050,8 +1048,7 @@ describe.sequential('Document', function () {
   it('changeInfo test for counter', async function () {
     type TestDoc = { cnt: Counter };
     const doc = new Document<TestDoc>('test-doc');
-    type EventForTest = Array<OperationInfo>;
-    const eventCollector = new EventCollector<EventForTest>();
+    const eventCollector = new EventCollector<Array<OpInfo>>();
     const unsub = doc.subscribe((event) => {
       if (event.type === DocEventType.Snapshot) {
         return;
@@ -1104,8 +1101,7 @@ describe.sequential('Document', function () {
   it('changeInfo test for text', async function () {
     type TestDoc = { text: Text };
     const doc = new Document<TestDoc>('test-doc');
-    type EventForTest = Array<OperationInfo>;
-    const eventCollector = new EventCollector<EventForTest>();
+    const eventCollector = new EventCollector<Array<OpInfo>>();
     const unsub = doc.subscribe((event) => {
       if (event.type === DocEventType.Snapshot) {
         return;
@@ -1135,8 +1131,7 @@ describe.sequential('Document', function () {
   it('changeInfo test for text with attributes', async function () {
     type TestDoc = { textWithAttr: Text };
     const doc = new Document<TestDoc>('test-doc');
-    type EventForTest = Array<OperationInfo>;
-    const eventCollector = new EventCollector<EventForTest>();
+    const eventCollector = new EventCollector<Array<OpInfo>>();
     const unsub = doc.subscribe((event) => {
       if (event.type === DocEventType.Snapshot) {
         return;
@@ -1358,7 +1353,7 @@ describe.sequential('Document', function () {
     });
   });
 
-  it('check OperationInfo type for subscribe path', function () {
+  it('check OpInfo type for subscribe path', function () {
     const doc = new Document<{
       num?: number;
       b: { c: Array<number>; d: { e: { fname: Array<number> } } };
@@ -1404,11 +1399,7 @@ describe.sequential('Document', function () {
     doc.update((root) => {
       root.b = {
         c: [],
-        d: {
-          e: {
-            fname: [],
-          },
-        },
+        d: { e: { fname: [] } },
       };
 
       root.b.d.e.fname.push(1);


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

Rename OperationInfo to OpInfo across the codebase

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Public operation type names shortened (OperationInfo → OpInfo and related Op* renames); SDK type exports and event typings updated accordingly.
  - Document subscribe overloads and event payload generics now reference OpInfo variants; no runtime behavior changes.

- Tests
  - Tests and helpers updated to use OpInfo; a minor assertion timing tweak in a text concurrency test.

- Examples
  - Example projects updated to follow OpInfo typings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->