### PR TITLE
Fix garbage size accounting for Text nodes

### DIFF
--- a/packages/sdk/index.html
+++ b/packages/sdk/index.html
@@ -74,7 +74,7 @@
           </svg>
           <div><span id="network-status"></span></div>
           <div style="margin-left: 8px; font-family: monospace">
-            <span id="memory-usage-text">Memory: -</span>
+            <span id="doc-size"></span>
           </div>
         </div>
         <div class="center-tools tools">
@@ -238,12 +238,11 @@
       }
 
       function updateMemoryUsageDisplay(doc) {
-        const docSize = doc.getDocSize();
-        if (!docSize) return;
-
-        document.getElementById('memory-usage-text').textContent =
-          `Memory: live=${docSize.live.data + docSize.live.meta}B, ` +
-          `gc=${docSize.gc.data + docSize.gc.meta}B`;
+        const size = doc.getDocSize();
+        document.getElementById('doc-size').textContent =
+          `Live=${size.live.data + size.live.meta}B, ` +
+          `GC=${size.gc.data + size.gc.meta}B, ` +
+          `Garbage=${doc.getGarbageLen()}`;
       }
 
       // https://github.com/codemirror/CodeMirror/pull/5619

--- a/packages/sdk/src/document/crdt/root.ts
+++ b/packages/sdk/src/document/crdt/root.ts
@@ -354,6 +354,7 @@ export class CRDTRoot {
       if (removedAt && minSyncedVersionVector?.afterOrEqual(removedAt)) {
         pair.parent.purge(pair.child);
 
+        subDataSize(this.docSize.gc, pair.child.getDataSize());
         this.gcPairMap.delete(pair.child.toIDString());
         count += 1;
       }


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

This commit fixes an issue where garbage size updates were missing for
Text nodes, since the accounting logic was previously applied only at
the Element level.

To address this, GC size accounting is now properly updated for Text
nodes as well, ensuring that the displayed totals are reliable.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Header memory indicator now shows a clearer summary with Live, GC, and Garbage metrics and improved formatting.
- Bug Fixes
  - Corrected memory accounting so GC sizes decrease accurately after garbage collection, ensuring displayed totals are reliable.
- Tests
  - Added unit tests covering GC size accounting across common text-edit scenarios to ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->