### PR TITLE
Fix SplitElement divergence on concurrent split inside merge range

### DIFF
--- a/packages/sdk/src/util/index_tree.ts
+++ b/packages/sdk/src/util/index_tree.ts
@@ -511,31 +511,34 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
     const left = this._children.slice(0, offset);
     const right = this._children.slice(offset);
 
-    // Fix 8: Keep merge-moved children in the original node when the
-    // merge is concurrent and the split boundary is not itself within
-    // merged content. If the boundary node has mergedFrom, the split
-    // is operating within merged content and all children move normally.
-    const boundaryIsMerged =
-      left.length > 0 &&
-      'mergedFrom' in left[left.length - 1] &&
-      (left[left.length - 1] as any).mergedFrom != null;
+    // Fix 8: Handle concurrent merge-moved children during split.
+    // When a child was merge-moved from a source that is itself a child
+    // of the node being split, the content was local to this level and
+    // should stay in the original (left) node. When the source is
+    // external (e.g., a sibling element that was merged), the content
+    // should flow naturally to the split (right) node.
+    const allChildren = [...left, ...right];
     const actualRight: Array<T> = [];
     for (const child of right) {
       if (
-        !boundaryIsMerged &&
         'mergedFrom' in child &&
         (child as any).mergedFrom != null &&
         'mergedAt' in child &&
         (child as any).mergedAt != null
       ) {
-        // Only veto for remote operations (with versionVector) when the
-        // merge is concurrent. Local edits (no versionVector) always know
-        // about all prior operations, so never veto.
         if (versionVector) {
           const mergedAt = (child as any).mergedAt as TimeTicket;
           if (!versionVector.afterOrEqual(mergedAt)) {
-            left.push(child);
-            continue;
+            // Check if the merge source is a child of this node.
+            const mergedFrom = (child as any).mergedFrom;
+            const sourceIsChild = allChildren.some(
+              (sibling) =>
+                'id' in sibling && (sibling as any).id.equals(mergedFrom),
+            );
+            if (sourceIsChild) {
+              left.push(child);
+              continue;
+            }
           }
         }
       }

--- a/packages/sdk/test/integration/tree_test.ts
+++ b/packages/sdk/test/integration/tree_test.ts
@@ -4201,6 +4201,44 @@ describe('Tree.edit(concurrent, side by side range)', () => {
     }, task.name);
   });
 
+  // Regression test for https://github.com/yorkie-team/yorkie/issues/1726
+  // When one client splits inside a block that the other client merges,
+  // replicas must converge.
+  it('contained-split-and-merge-same-block', async function ({ task }) {
+    await withTwoClientsAndDocuments<{ t: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.t = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+      assert.equal(
+        d1.getRoot().t.toXML(),
+        /*html*/ `<r><p>ab</p><p>cd</p></r>`,
+      );
+
+      // d1: split first paragraph at a|b
+      d1.update((r) => r.t.edit(2, 2, undefined, 1));
+      // d2: merge both paragraphs
+      d2.update((r) => r.t.edit(3, 5));
+      assert.equal(
+        d1.getRoot().t.toXML(),
+        /*html*/ `<r><p>a</p><p>b</p><p>cd</p></r>`,
+      );
+      assert.equal(d2.getRoot().t.toXML(), /*html*/ `<r><p>abcd</p></r>`);
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+      assert.equal(d1.getRoot().t.toXML(), d2.getRoot().t.toXML());
+    }, task.name);
+  });
+
   it('side-by-side-merge-and-insert', async function ({ task }) {
     await withTwoClientsAndDocuments<{ t: Tree }>(async (c1, d1, c2, d2) => {
       d1.update((root) => {


### PR DESCRIPTION
## Summary

- Port the server-side fix from yorkie-team/yorkie#1727 to the JS SDK
- Replace `boundaryIsMerged` heuristic in `splitElement` with `sourceIsChild` check: merge-moved children from external sources flow to the split (right) node, while locally-sourced children stay in the original (left) node
- Add `contained-split-and-merge-same-block` convergence test

## Test plan

- [ ] `pnpm sdk test test/integration/tree_test.ts` passes with updated server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added an integration test for concurrent split-and-merge edits to verify consistent convergence across replicas.
* **Bug Fixes**
  * Improved handling of concurrent split/merge scenarios so document structure and merges are resolved correctly, reducing divergence and improving convergence after syncing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->