### PR TITLE
Fix tree style divergence on concurrent split via End-token guard

### DIFF
--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -1020,6 +1020,11 @@ export class CRDTTree extends CRDTElement implements GCParent {
       return false;
     }
 
+    // NOTE: Unlike advancePastUnknownSplitSiblings, we intentionally omit
+    // the parent-equality check. In multi-level splits (splitLevel>=2),
+    // the split sibling may have been moved to a different parent by the
+    // recursive ancestor split. The End-token guard must still fire because
+    // the node WAS split — insNextID is only set by SplitElement.
     const actorID = next.id.getCreatedAt().getActorID();
     const knownLamport = versionVector.get(actorID);
 

--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -1002,6 +1002,34 @@ export class CRDTTree extends CRDTElement implements GCParent {
   }
 
   /**
+   * `hasUnknownSplitSibling` checks whether the given element node has a
+   * split sibling (via insNextID) whose creation the editor did not know
+   * about. Used to prevent styling via End tokens when a concurrent split
+   * extended the range into the split sibling.
+   */
+  private hasUnknownSplitSibling(
+    node: CRDTTreeNode,
+    versionVector: VersionVector,
+  ): boolean {
+    if (!node.insNextID) {
+      return false;
+    }
+
+    const next = this.findFloorNode(node.insNextID);
+    if (!next || next.isText) {
+      return false;
+    }
+
+    const actorID = next.id.getCreatedAt().getActorID();
+    const knownLamport = versionVector.get(actorID);
+
+    return (
+      knownLamport === undefined ||
+      knownLamport < next.id.getCreatedAt().getLamport()
+    );
+  }
+
+  /**
    * `registerNode` registers the given node to the tree.
    */
   public registerNode(node: CRDTTreeNode): void {
@@ -1142,6 +1170,17 @@ export class CRDTTree extends CRDTElement implements GCParent {
         }
 
         if (node.canStyle(editedAt, clientLamportAtChange) && attributes) {
+          // Skip styling via End token when the node has an unknown
+          // split sibling. The End token is in the range only because
+          // a concurrent split extended the range into the sibling.
+          if (
+            tokenType === TokenType.End &&
+            versionVector !== undefined &&
+            this.hasUnknownSplitSibling(node, versionVector)
+          ) {
+            return;
+          }
+
           const updatedAttrPairs = node.setAttrs(attributes, editedAt);
           const affectedAttrs = updatedAttrPairs.reduce(
             (acc: { [key: string]: string }, [, curr]) => {
@@ -1218,7 +1257,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
       fromLeft,
       toParent,
       toLeft,
-      ([node]) => {
+      ([node, tokenType]) => {
         const actorID = node.getCreatedAt().getActorID();
         let clientLamportAtChange = MaxLamport; // Local edit
         if (versionVector != undefined) {
@@ -1231,6 +1270,16 @@ export class CRDTTree extends CRDTElement implements GCParent {
           node.canStyle(editedAt, clientLamportAtChange) &&
           attributesToRemove
         ) {
+          // Skip styling via End token when the node has an unknown
+          // split sibling. The End token is in the range only because
+          // a concurrent split extended the range into the sibling.
+          if (
+            tokenType === TokenType.End &&
+            versionVector !== undefined &&
+            this.hasUnknownSplitSibling(node, versionVector)
+          ) {
+            return;
+          }
           if (!node.attrs) {
             node.attrs = new RHT();
           }


### PR DESCRIPTION
## Summary
- Port Fix 11 from Go SDK ([yorkie-team/yorkie#1731](https://github.com/yorkie-team/yorkie/pull/1731))
- Add `hasUnknownSplitSibling()` helper and End-token guard in `style()`/`removeStyle()` callbacks
- When processing an End token, skip styling if the node has a split sibling unknown to the editor's version vector

## Test plan
- [x] TypeScript type check passes (`tsc --noEmit`)
- [x] ESLint passes
- [x] Integration tests with Go server (CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented styling from being incorrectly applied or removed when collaborators concurrently split text nodes—range-end markers now ignore unknown concurrent splits so styles no longer leak or disappear unexpectedly.
  * Improved range traversal to better handle concurrent edits, reducing visual flicker and inconsistent styling during real-time collaboration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->