### PR TITLE
Simplify Counter interface and replace long with bigint

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -50,7 +50,6 @@
     "@bufbuild/protoc-gen-es": "^2.10.1",
     "@types/express": "^5.0.6",
     "@types/google-protobuf": "^3.15.12",
-    "@types/long": "^5.0.0",
     "@vitest/coverage-istanbul": "^4.0.15",
     "@vitest/coverage-v8": "^4.0.15",
     "axios": "^1.13.2",
@@ -70,7 +69,6 @@
     "@bufbuild/protobuf": "^2.10.1",
     "@connectrpc/connect": "^2.1.1",
     "@connectrpc/connect-web": "^2.1.1",
-    "@yorkie-js/schema": "workspace:*",
-    "long": "^5.3.2"
+    "@yorkie-js/schema": "workspace:*"
   }
 }

--- a/packages/sdk/public/counter.html
+++ b/packages/sdk/public/counter.html
@@ -58,7 +58,7 @@
           // 03. initialize document properties
           doc.update((root) => {
             if (!root.counter) {
-              root.counter = new yorkie.Counter(yorkie.IntType, 0);
+              root.counter = new yorkie.Counter(0);
             }
           }, 'create counter if not exists');
 

--- a/packages/sdk/public/multi.html
+++ b/packages/sdk/public/multi.html
@@ -115,7 +115,7 @@
 
           doc.update((root) => {
             if (!root.counter) {
-              root.counter = new yorkie.Counter(yorkie.IntType, 0);
+              root.counter = new yorkie.Counter(0);
               root.todos = [];
               root.content = new yorkie.Text();
               root.content.edit(0, 0, '\n');

--- a/packages/sdk/src/document/crdt/counter.ts
+++ b/packages/sdk/src/document/crdt/counter.ts
@@ -16,13 +16,17 @@
 
 import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
 import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
-import Long from 'long';
 import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 import {
   Primitive,
   PrimitiveType,
 } from '@yorkie-js/sdk/src/document/crdt/primitive';
-import { removeDecimal } from '@yorkie-js/sdk/src/util/number';
+import {
+  removeDecimal,
+  bigintFromBytesLE,
+  bigintToBytesLE,
+  bigintToInt32,
+} from '@yorkie-js/sdk/src/util/number';
 import type * as Devtools from '@yorkie-js/sdk/src/devtools/types';
 import { DataSize } from '@yorkie-js/sdk/src/util/resource';
 import { HLL } from '@yorkie-js/sdk/src/document/crdt/hll';
@@ -33,7 +37,7 @@ export enum CounterType {
   IntDedup,
 }
 
-export type CounterValue = number | Long;
+export type CounterValue = number | bigint;
 
 /**
  * `CRDTCounter` is a CRDT implementation of a counter. It is used to represent
@@ -58,17 +62,17 @@ export class CRDTCounter extends CRDTElement {
       case CounterType.Int:
         if (typeof value === 'number') {
           if (value > Math.pow(2, 31) - 1 || value < -Math.pow(2, 31)) {
-            this.value = Long.fromNumber(value).toInt();
+            this.value = bigintToInt32(BigInt(value));
           } else {
             this.value = removeDecimal(value);
           }
         } else {
-          this.value = value.toInt();
+          this.value = bigintToInt32(value);
         }
         break;
       case CounterType.Long:
         if (typeof value === 'number') {
-          this.value = Long.fromNumber(value);
+          this.value = BigInt(Math.trunc(value));
         } else {
           this.value = value;
         }
@@ -94,6 +98,7 @@ export class CRDTCounter extends CRDTElement {
   ): CRDTCounter {
     return new CRDTCounter(valueType, value, createdAt);
   }
+
   /**
    * `valueFromBytes` parses the given bytes into value.
    */
@@ -106,7 +111,7 @@ export class CRDTCounter extends CRDTElement {
       case CounterType.IntDedup:
         return bytes[0] | (bytes[1] << 8) | (bytes[2] << 16) | (bytes[3] << 24);
       case CounterType.Long:
-        return Long.fromBytesLE(Array.from(bytes));
+        return bigintFromBytesLE(bytes);
       default:
         throw new YorkieError(
           Code.ErrUnimplemented,
@@ -187,12 +192,8 @@ export class CRDTCounter extends CRDTElement {
    */
   public static getCounterType(value: CounterValue): CounterType | undefined {
     switch (typeof value) {
-      case 'object':
-        if (value instanceof Long) {
-          return CounterType.Long;
-        } else {
-          return;
-        }
+      case 'bigint':
+        return CounterType.Long;
       case 'number':
         if (value > Math.pow(2, 31) - 1 || value < -Math.pow(2, 31)) {
           return CounterType.Long;
@@ -203,6 +204,7 @@ export class CRDTCounter extends CRDTElement {
         return;
     }
   }
+
   /**
    * `isSupport` check if there is a counter type of given value.
    */
@@ -259,9 +261,7 @@ export class CRDTCounter extends CRDTElement {
         ]);
       }
       case CounterType.Long: {
-        const longVal = this.value as Long;
-        const longToBytes = longVal.toBytesLE();
-        return Uint8Array.from(longToBytes);
+        return bigintToBytesLE(this.value as bigint);
       }
       default:
         throw new YorkieError(
@@ -296,10 +296,7 @@ export class CRDTCounter extends CRDTElement {
       );
     }
     const val = v.getValue();
-    const isUnit =
-      v.getType() === PrimitiveType.Long
-        ? (val as Long).equals(Long.ONE)
-        : val === 1;
+    const isUnit = v.getType() === PrimitiveType.Long ? val === 1n : val === 1;
     if (!isUnit) {
       throw new YorkieError(
         Code.ErrInvalidArgument,
@@ -349,6 +346,7 @@ export class CRDTCounter extends CRDTElement {
         'dedup counter requires actor, use increaseDedup()',
       );
     }
+
     /**
      * `checkNumericType` checks if the given target is a numeric type.
      */
@@ -363,14 +361,21 @@ export class CRDTCounter extends CRDTElement {
     checkNumericType(v);
 
     if (this.valueType === CounterType.Long) {
-      this.value = (this.value as Long).add(v.getValue() as number | Long);
+      const delta =
+        typeof v.getValue() === 'bigint'
+          ? (v.getValue() as bigint)
+          : BigInt(Math.trunc(v.getValue() as number));
+      this.value = BigInt.asIntN(64, (this.value as bigint) + delta);
     } else {
       if (v.getType() === PrimitiveType.Long) {
-        this.value = (this.value as number) + (v.getValue() as Long).toInt();
+        this.value =
+          (this.value as number) + bigintToInt32(v.getValue() as bigint);
       } else {
-        this.value = Long.fromNumber(
-          (this.value as number) + removeDecimal(v.getValue() as number),
-        ).toInt();
+        this.value = bigintToInt32(
+          BigInt(
+            (this.value as number) + removeDecimal(v.getValue() as number),
+          ),
+        );
       }
     }
 

--- a/packages/sdk/src/document/crdt/counter.ts
+++ b/packages/sdk/src/document/crdt/counter.ts
@@ -72,9 +72,9 @@ export class CRDTCounter extends CRDTElement {
         break;
       case CounterType.Long:
         if (typeof value === 'number') {
-          this.value = BigInt(Math.trunc(value));
+          this.value = BigInt.asIntN(64, BigInt(Math.trunc(value)));
         } else {
-          this.value = value;
+          this.value = BigInt.asIntN(64, value);
         }
         break;
       default:

--- a/packages/sdk/src/document/crdt/primitive.ts
+++ b/packages/sdk/src/document/crdt/primitive.ts
@@ -14,13 +14,17 @@
  * limitations under the License.
  */
 
-import Long from 'long';
 import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
 import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
 import { escapeString } from '@yorkie-js/sdk/src/document/json/strings';
 import type * as Devtools from '@yorkie-js/sdk/src/devtools/types';
 import { DataSize } from '@yorkie-js/sdk/src/util/resource';
+import {
+  bigintToBytesLE,
+  bigintFromBytesLE,
+  bigintFromBytesLEUnsigned,
+} from '@yorkie-js/sdk/src/util/number';
 
 export enum PrimitiveType {
   Null,
@@ -39,7 +43,7 @@ export enum PrimitiveType {
  */
 export type PrimitiveValue =
   // eslint-disable-next-line @typescript-eslint/no-restricted-types
-  null | boolean | number | Long | string | Uint8Array | Date;
+  null | boolean | number | bigint | string | Uint8Array | Date;
 
 /**
  * `Primitive` represents primitive data type including logical clock.
@@ -86,11 +90,11 @@ export class Primitive extends CRDTElement {
       case PrimitiveType.String:
         return new TextDecoder('utf-8').decode(bytes);
       case PrimitiveType.Long:
-        return Long.fromBytesLE(Array.from(bytes));
+        return bigintFromBytesLE(bytes);
       case PrimitiveType.Bytes:
         return bytes;
       case PrimitiveType.Date:
-        return new Date(Long.fromBytesLE(Array.from(bytes), true).toNumber());
+        return new Date(Number(bigintFromBytesLEUnsigned(bytes)));
       default:
         throw new YorkieError(
           Code.ErrUnimplemented,
@@ -204,13 +208,13 @@ export class Primitive extends CRDTElement {
         } else {
           return PrimitiveType.Double;
         }
+      case 'bigint':
+        return PrimitiveType.Long;
       case 'string':
         return PrimitiveType.String;
       case 'object':
         if (value === null) {
           return PrimitiveType.Null;
-        } else if (value instanceof Long) {
-          return PrimitiveType.Long;
         } else if (value instanceof Uint8Array) {
           return PrimitiveType.Bytes;
         } else if (value instanceof Date) {
@@ -290,9 +294,7 @@ export class Primitive extends CRDTElement {
         return new TextEncoder().encode(this.value as string);
       }
       case PrimitiveType.Long: {
-        const longVal = this.value as Long;
-        const longToBytes = longVal.toBytesLE();
-        return Uint8Array.from(longToBytes);
+        return bigintToBytesLE(this.value as bigint);
       }
       case PrimitiveType.Bytes: {
         const bytesVal = this.value as Uint8Array;
@@ -300,11 +302,7 @@ export class Primitive extends CRDTElement {
       }
       case PrimitiveType.Date: {
         const dateVal = this.value as Date;
-        const dateToBytes = Long.fromNumber(
-          dateVal.getTime(),
-          true,
-        ).toBytesLE();
-        return Uint8Array.from(dateToBytes);
+        return bigintToBytesLE(BigInt(dateVal.getTime()));
       }
       default:
         throw new YorkieError(

--- a/packages/sdk/src/document/json/counter.ts
+++ b/packages/sdk/src/document/json/counter.ts
@@ -27,13 +27,14 @@ import type * as Devtools from '@yorkie-js/sdk/src/devtools/types';
 import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
 
 /**
- * `Counter` is a custom data type that is used to counter.
+ * `BaseCounter` is an internal base that holds the shared state and
+ * initialization logic for Counter and DedupCounter. Not exported.
  */
-export class Counter {
-  private valueType: CounterType;
-  private value: number | Long;
-  private context?: ChangeContext;
-  private counter?: CRDTCounter;
+class BaseCounter {
+  protected valueType: CounterType;
+  protected value: number | Long;
+  protected context?: ChangeContext;
+  protected counter?: CRDTCounter;
 
   constructor(valueType: CounterType, value: number | Long) {
     this.valueType = valueType;
@@ -41,7 +42,7 @@ export class Counter {
   }
 
   /**
-   * `initialize` initialize this text with context and internal text.
+   * `initialize` links this proxy to a ChangeContext and CRDTCounter.
    */
   public initialize(context: ChangeContext, counter: CRDTCounter): void {
     this.valueType = counter.getValueType();
@@ -51,17 +52,10 @@ export class Counter {
   }
 
   /**
-   * `getID` returns the ID of this text.
+   * `getID` returns the ID of this counter.
    */
   public getID(): TimeTicket {
     return this.counter!.getID();
-  }
-
-  /**
-   * `getValue` returns the value of this counter;
-   */
-  public getValue(): number | Long {
-    return this.value;
   }
 
   /**
@@ -69,82 +63,6 @@ export class Counter {
    */
   public getValueType(): CounterType {
     return this.valueType;
-  }
-
-  /**
-   * `increase` increases numeric data. Only valid for normal (non-dedup) counters.
-   */
-  public increase(v: number | Long): Counter {
-    if (!this.context || !this.counter) {
-      throw new YorkieError(
-        Code.ErrNotInitialized,
-        'Counter is not initialized yet',
-      );
-    }
-    if (this.counter.isDedup()) {
-      throw new YorkieError(
-        Code.ErrInvalidArgument,
-        'dedup counter does not support increase(), use add(actor)',
-      );
-    }
-
-    const ticket = this.context.issueTimeTicket();
-    const value = Primitive.of(v, ticket);
-    if (!value.isNumericType()) {
-      throw new TypeError(
-        `Unsupported type of value: ${typeof value.getValue()}`,
-      );
-    }
-
-    this.counter.increase(value);
-    this.context.push(
-      IncreaseOperation.create(this.counter.getCreatedAt(), value, ticket),
-    );
-
-    return this;
-  }
-
-  /**
-   * `add` records a unique actor in the dedup counter. If the actor has
-   * already been counted, the call is ignored. Only valid for dedup counters.
-   */
-  public add(actor: string): Counter {
-    if (!this.context || !this.counter) {
-      throw new YorkieError(
-        Code.ErrNotInitialized,
-        'Counter is not initialized yet',
-      );
-    }
-    if (!this.counter.isDedup()) {
-      throw new YorkieError(
-        Code.ErrInvalidArgument,
-        'add() is only supported on dedup counters',
-      );
-    }
-    if (!actor) {
-      throw new YorkieError(Code.ErrInvalidArgument, 'actor is required');
-    }
-
-    const ticket = this.context.issueTimeTicket();
-    const value = Primitive.of(1, ticket);
-    this.counter.increaseDedup(value, actor);
-    this.context.push(
-      IncreaseOperation.create(
-        this.counter.getCreatedAt(),
-        value,
-        ticket,
-        actor,
-      ),
-    );
-
-    return this;
-  }
-
-  /**
-   * `isDedup` returns whether this counter is a dedup counter.
-   */
-  public isDedup(): boolean {
-    return this.counter?.isDedup() ?? false;
   }
 
   /**
@@ -160,6 +78,64 @@ export class Counter {
 
     return this.counter.toJSForTest();
   }
+
+  /**
+   * `ensureInitialized` throws if this counter has not been initialized.
+   */
+  protected ensureInitialized(): void {
+    if (!this.context || !this.counter) {
+      throw new YorkieError(
+        Code.ErrNotInitialized,
+        'Counter is not initialized yet',
+      );
+    }
+  }
+}
+
+/**
+ * `Counter` is a numeric counter that supports `increase()`.
+ * For counting unique actors, use `DedupCounter` instead.
+ *
+ * ```typescript
+ * // Type is inferred from value:
+ * root.count = new Counter(0);           // Int
+ * root.count = new Counter(Long.ZERO);   // Long
+ * ```
+ */
+export class Counter extends BaseCounter {
+  constructor(value: number | Long) {
+    const type = value instanceof Long ? CounterType.Long : CounterType.Int;
+    super(type, value);
+  }
+
+  /**
+   * `getValue` returns the value of this counter.
+   */
+  public getValue(): number | Long {
+    return this.value;
+  }
+
+  /**
+   * `increase` increases numeric data.
+   */
+  public increase(v: number | Long): Counter {
+    this.ensureInitialized();
+
+    const ticket = this.context!.issueTimeTicket();
+    const value = Primitive.of(v, ticket);
+    if (!value.isNumericType()) {
+      throw new TypeError(
+        `Unsupported type of value: ${typeof value.getValue()}`,
+      );
+    }
+
+    this.counter!.increase(value);
+    this.context!.push(
+      IncreaseOperation.create(this.counter!.getCreatedAt(), value, ticket),
+    );
+
+    return this;
+  }
 }
 
 /**
@@ -174,8 +150,49 @@ export class Counter {
  * });
  * ```
  */
-export class DedupCounter extends Counter {
+export class DedupCounter extends BaseCounter {
   constructor() {
     super(CounterType.IntDedup, 0);
   }
+
+  /**
+   * `getValue` returns the value of this counter. Always a number since
+   * DedupCounter only supports IntDedup.
+   */
+  public getValue(): number {
+    return this.value as number;
+  }
+
+  /**
+   * `add` records a unique actor in the dedup counter. If the actor has
+   * already been counted, the call is ignored.
+   */
+  public add(actor: string): DedupCounter {
+    this.ensureInitialized();
+    if (!actor) {
+      throw new YorkieError(Code.ErrInvalidArgument, 'actor is required');
+    }
+
+    const ticket = this.context!.issueTimeTicket();
+    const value = Primitive.of(1, ticket);
+    this.counter!.increaseDedup(value, actor);
+    this.context!.push(
+      IncreaseOperation.create(
+        this.counter!.getCreatedAt(),
+        value,
+        ticket,
+        actor,
+      ),
+    );
+
+    return this;
+  }
+}
+
+/**
+ * `isCounter` returns true if the value is a Counter or DedupCounter.
+ * Used internally to detect counter instances during document updates.
+ */
+export function isCounter(value: unknown): value is Counter | DedupCounter {
+  return value instanceof Counter || value instanceof DedupCounter;
 }

--- a/packages/sdk/src/document/json/counter.ts
+++ b/packages/sdk/src/document/json/counter.ts
@@ -18,7 +18,6 @@ import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
 import { ChangeContext } from '@yorkie-js/sdk/src/document/change/context';
 import { Primitive } from '@yorkie-js/sdk/src/document/crdt/primitive';
 import { IncreaseOperation } from '@yorkie-js/sdk/src/document/operation/increase_operation';
-import Long from 'long';
 import {
   CounterType,
   CRDTCounter,
@@ -32,11 +31,11 @@ import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
  */
 class BaseCounter {
   protected valueType: CounterType;
-  protected value: number | Long;
+  protected value: number | bigint;
   protected context?: ChangeContext;
   protected counter?: CRDTCounter;
 
-  constructor(valueType: CounterType, value: number | Long) {
+  constructor(valueType: CounterType, value: number | bigint) {
     this.valueType = valueType;
     this.value = value;
   }
@@ -99,26 +98,26 @@ class BaseCounter {
  * ```typescript
  * // Type is inferred from value:
  * root.count = new Counter(0);           // Int
- * root.count = new Counter(Long.ZERO);   // Long
+ * root.count = new Counter(0n);           // Long
  * ```
  */
 export class Counter extends BaseCounter {
-  constructor(value: number | Long) {
-    const type = value instanceof Long ? CounterType.Long : CounterType.Int;
+  constructor(value: number | bigint) {
+    const type = typeof value === 'bigint' ? CounterType.Long : CounterType.Int;
     super(type, value);
   }
 
   /**
    * `getValue` returns the value of this counter.
    */
-  public getValue(): number | Long {
+  public getValue(): number | bigint {
     return this.value;
   }
 
   /**
    * `increase` increases numeric data.
    */
-  public increase(v: number | Long): Counter {
+  public increase(v: number | bigint): Counter {
     this.ensureInitialized();
 
     const ticket = this.context!.issueTimeTicket();

--- a/packages/sdk/src/document/json/element.ts
+++ b/packages/sdk/src/document/json/element.ts
@@ -23,10 +23,7 @@ import {
   PrimitiveValue,
 } from '@yorkie-js/sdk/src/document/crdt/primitive';
 import { CRDTText } from '@yorkie-js/sdk/src/document/crdt/text';
-import {
-  CounterType,
-  CRDTCounter,
-} from '@yorkie-js/sdk/src/document/crdt/counter';
+import { CRDTCounter } from '@yorkie-js/sdk/src/document/crdt/counter';
 import { CRDTTree } from '@yorkie-js/sdk/src/document/crdt/tree';
 import { RGATreeSplit } from '@yorkie-js/sdk/src/document/crdt/rga_tree_split';
 import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
@@ -42,7 +39,11 @@ import {
   ArrayProxy,
 } from '@yorkie-js/sdk/src/document/json/array';
 import { Text } from '@yorkie-js/sdk/src/document/json/text';
-import { Counter } from '@yorkie-js/sdk/src/document/json/counter';
+import {
+  Counter,
+  DedupCounter,
+  isCounter,
+} from '@yorkie-js/sdk/src/document/json/counter';
 import { Tree } from '@yorkie-js/sdk/src/document/json/tree';
 import { Indexable } from '../document';
 
@@ -65,6 +66,7 @@ export type WrappedElement<T = unknown, A extends Indexable = Indexable> =
   | JSONArray<T>
   | Text<A>
   | Counter
+  | DedupCounter
   | Tree;
 
 /**
@@ -77,6 +79,7 @@ export type JSONElement<T = unknown, A extends Indexable = Indexable> =
   | JSONArray<T>
   | Text<A>
   | Counter
+  | DedupCounter
   | Tree;
 
 /**
@@ -97,7 +100,12 @@ export function toWrappedElement(
   } else if (elem instanceof CRDTText) {
     return new Text(context, elem);
   } else if (elem instanceof CRDTCounter) {
-    const counter = new Counter(CounterType.Int, 0);
+    if (elem.isDedup()) {
+      const counter = new DedupCounter();
+      counter.initialize(context, elem);
+      return counter;
+    }
+    const counter = new Counter(0);
     counter.initialize(context, elem);
     return counter;
   } else if (elem instanceof CRDTTree) {
@@ -144,7 +152,7 @@ export function buildCRDTElement(
     if (value instanceof Text) {
       element = CRDTText.create(RGATreeSplit.create(), createdAt);
       value.initialize(context, element as CRDTText);
-    } else if (value instanceof Counter) {
+    } else if (isCounter(value)) {
       element = CRDTCounter.create(
         value.getValueType(),
         value.getValue(),

--- a/packages/sdk/src/document/operation/increase_operation.ts
+++ b/packages/sdk/src/document/operation/increase_operation.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import Long from 'long';
 import {
   ExecutionResult,
   Operation,
@@ -120,7 +119,7 @@ export class IncreaseOperation extends Operation {
     const valueType = primitiveValue.getType();
     const value =
       valueType === PrimitiveType.Long
-        ? (primitiveValue.getValue() as Long).multiply(-1)
+        ? -(primitiveValue.getValue() as bigint)
         : (primitiveValue.getValue() as number) * -1;
 
     const reverseOp = IncreaseOperation.create(

--- a/packages/sdk/src/util/number.ts
+++ b/packages/sdk/src/util/number.ts
@@ -15,7 +15,50 @@
  */
 
 /**
- `removeDecimal` returns a number with the decimal part removed.
+ * `removeDecimal` returns a number with the decimal part removed.
  */
 export const removeDecimal = (number: number) =>
   number < 0 ? Math.ceil(number) : Math.floor(number);
+
+/**
+ * `bigintToBytesLE` converts a signed 64-bit bigint to 8 bytes (little-endian).
+ */
+export function bigintToBytesLE(value: bigint): Uint8Array {
+  const buf = new Uint8Array(8);
+  // Interpret as unsigned 64-bit to handle negative values correctly.
+  let v = BigInt.asUintN(64, value);
+  for (let i = 0; i < 8; i++) {
+    buf[i] = Number(v & 0xffn);
+    v >>= 8n;
+  }
+  return buf;
+}
+
+/**
+ * `bigintFromBytesLE` reads a signed 64-bit bigint from 8 bytes (little-endian).
+ */
+export function bigintFromBytesLE(bytes: Uint8Array): bigint {
+  let v = 0n;
+  for (let i = 7; i >= 0; i--) {
+    v = (v << 8n) | BigInt(bytes[i]);
+  }
+  return BigInt.asIntN(64, v);
+}
+
+/**
+ * `bigintFromBytesLEUnsigned` reads an unsigned 64-bit bigint from 8 bytes (little-endian).
+ */
+export function bigintFromBytesLEUnsigned(bytes: Uint8Array): bigint {
+  let v = 0n;
+  for (let i = 7; i >= 0; i--) {
+    v = (v << 8n) | BigInt(bytes[i]);
+  }
+  return v;
+}
+
+/**
+ * `bigintToInt32` truncates a bigint to a signed 32-bit integer.
+ */
+export function bigintToInt32(value: bigint): number {
+  return Number(BigInt.asIntN(32, value));
+}

--- a/packages/sdk/src/yorkie.ts
+++ b/packages/sdk/src/yorkie.ts
@@ -22,7 +22,6 @@ import {
   Counter,
   DedupCounter,
 } from '@yorkie-js/sdk/src/document/json/counter';
-import { CounterType } from '@yorkie-js/sdk/src/document/crdt/counter';
 import * as Devtools from '@yorkie-js/sdk/src/devtools/types';
 import { Channel, ChannelEventType } from '@yorkie-js/sdk/src/channel/channel';
 import * as YSON from '@yorkie-js/sdk/src/document/yson';
@@ -171,8 +170,6 @@ export default {
   YSON,
   LogLevel,
   setLogLevel,
-  IntType: CounterType.Int,
-  LongType: CounterType.Long,
 };
 
 // TODO(hackerwins): Remove this when we have a better way to expose the API.
@@ -190,7 +187,5 @@ if (typeof globalThis !== 'undefined') {
     YSON,
     LogLevel,
     setLogLevel,
-    IntType: CounterType.Int,
-    LongType: CounterType.Long,
   };
 }

--- a/packages/sdk/test/bench/counter.bench.ts
+++ b/packages/sdk/test/bench/counter.bench.ts
@@ -1,5 +1,4 @@
 import { Document, Counter } from '@yorkie-js/sdk/src/yorkie';
-import Long from 'long';
 import { describe, bench, assert } from 'vitest';
 
 const benchmarkCounter = (size: number) => {
@@ -31,7 +30,7 @@ describe('Counter', () => {
     });
     assert.equal('{"age":128}', doc.toJSON());
     doc.update((root) => {
-      root.price = new Counter(Long.fromNumber(9000000000000000000));
+      root.price = new Counter(BigInt('9000000000000000000'));
       root.price.increase(long);
       root.price.increase(double);
       root.price.increase(float);

--- a/packages/sdk/test/bench/counter.bench.ts
+++ b/packages/sdk/test/bench/counter.bench.ts
@@ -1,12 +1,12 @@
 import { Document, Counter } from '@yorkie-js/sdk/src/yorkie';
-import { CounterType } from '@yorkie-js/sdk/src/document/crdt/counter';
+import Long from 'long';
 import { describe, bench, assert } from 'vitest';
 
 const benchmarkCounter = (size: number) => {
   const doc = new Document<{ counter: Counter }>('test-doc');
 
   doc.update((root) => {
-    root.counter = new Counter(CounterType.Int, 0);
+    root.counter = new Counter(0);
     for (let i = 0; i < size; i++) {
       root.counter.increase(i);
     }
@@ -22,7 +22,7 @@ describe('Counter', () => {
     const float = 3.14;
     const double = 5.66;
     doc.update((root) => {
-      root.age = new Counter(CounterType.Int, 5);
+      root.age = new Counter(5);
       root.age.increase(long);
       root.age.increase(double);
       root.age.increase(float);
@@ -31,7 +31,7 @@ describe('Counter', () => {
     });
     assert.equal('{"age":128}', doc.toJSON());
     doc.update((root) => {
-      root.price = new Counter(CounterType.Long, 9000000000000000000);
+      root.price = new Counter(Long.fromNumber(9000000000000000000));
       root.price.increase(long);
       root.price.increase(double);
       root.price.increase(float);

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -520,7 +520,7 @@ describe.sequential('Client', function () {
     // 02. cli update the document with creating a counter
     //     and sync with push-pull mode: CP(1, 1) -> CP(2, 2)
     d1.update((root) => {
-      root.counter = new yorkie.Counter(yorkie.IntType, 0);
+      root.counter = new yorkie.Counter(0);
     });
 
     let checkpoint = d1.getCheckpoint();
@@ -841,7 +841,7 @@ describe.sequential('Client', function () {
   }) => {
     type TestDoc = { counter: Counter };
     await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
-      d1.update((r) => (r.counter = new Counter(yorkie.IntType, 0)));
+      d1.update((r) => (r.counter = new Counter(0)));
       await c1.sync();
       await c2.sync();
 

--- a/packages/sdk/test/integration/counter_test.ts
+++ b/packages/sdk/test/integration/counter_test.ts
@@ -8,7 +8,6 @@ import {
   testRPCAddr,
 } from '@yorkie-js/sdk/test/integration/integration_helper';
 import yorkie, { Counter, SyncMode } from '@yorkie-js/sdk/src/yorkie';
-import Long from 'long';
 
 describe('Counter', function () {
   it('can be increased by Counter type', function ({ task }) {
@@ -115,13 +114,13 @@ describe('Counter', function () {
     assert.equal(`{"age":-2147483648}`, doc.toSortedJSON());
 
     doc.update((root) => {
-      root.age = new Counter(Long.fromString('9223372036854775807'));
+      root.age = new Counter(9223372036854775807n);
       root.age.increase(1);
     });
     assert.equal(`{"age":-9223372036854775808}`, doc.toSortedJSON());
 
     doc.update((root) => {
-      root.age = new Counter(Long.fromString('9223372036854775808'));
+      root.age = new Counter(9223372036854775808n);
     });
     assert.equal(`{"age":-9223372036854775808}`, doc.toSortedJSON());
   });
@@ -132,13 +131,13 @@ describe('Counter', function () {
 
     doc.update((root) => {
       root.cnt = new Counter(0);
-      root.longCnt = new Counter(Long.fromString('0'));
+      root.longCnt = new Counter(0n);
     });
     assert.equal(doc.toSortedJSON(), `{"cnt":0,"longCnt":0}`);
 
     doc.update((root) => {
       root.cnt.increase(1.5);
-      root.longCnt.increase(Long.fromString('9223372036854775807')); // 2^63-1
+      root.longCnt.increase(9223372036854775807n); // 2^63-1
     });
     assert.equal(doc.toSortedJSON(), `{"cnt":1,"longCnt":9223372036854775807}`);
 
@@ -186,14 +185,14 @@ describe('Counter', function () {
 
     doc.update((root) => {
       root.cnt = new Counter(0);
-      root.longCnt = new Counter(Long.fromString('0'));
+      root.longCnt = new Counter(0n);
     });
     assert.equal(doc.toSortedJSON(), `{"cnt":0,"longCnt":0}`);
     states.push(doc.toSortedJSON());
 
     doc.update((root) => {
       root.cnt.increase(2147483647); // 2^31-1
-      root.longCnt.increase(Long.fromString('9223372036854775807')); // 2^63-1
+      root.longCnt.increase(9223372036854775807n); // 2^63-1
     });
     assert.equal(
       doc.toSortedJSON(),
@@ -203,7 +202,7 @@ describe('Counter', function () {
 
     doc.update((root) => {
       root.cnt.increase(1); // overflow
-      root.longCnt.increase(Long.fromString('1')); // overflow
+      root.longCnt.increase(1n); // overflow
     });
     assert.equal(
       doc.toSortedJSON(),

--- a/packages/sdk/test/integration/counter_test.ts
+++ b/packages/sdk/test/integration/counter_test.ts
@@ -7,11 +7,7 @@ import {
   toDocKey,
   testRPCAddr,
 } from '@yorkie-js/sdk/test/integration/integration_helper';
-import yorkie, {
-  Counter,
-  CounterType,
-  SyncMode,
-} from '@yorkie-js/sdk/src/yorkie';
+import yorkie, { Counter, SyncMode } from '@yorkie-js/sdk/src/yorkie';
 import Long from 'long';
 
 describe('Counter', function () {
@@ -24,8 +20,8 @@ describe('Counter', function () {
 
     doc.update((root) => {
       root.k1 = {};
-      root.k1.age = new Counter(CounterType.Int, 1);
-      root.k1.length = new Counter(CounterType.Int, 10.5);
+      root.k1.age = new Counter(1);
+      root.k1.length = new Counter(10.5);
       root.k1.age.increase(5);
       root.k1.length.increase(3.5);
     });
@@ -60,11 +56,11 @@ describe('Counter', function () {
     type TestDoc = { age: Counter; length: Counter };
     await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
-        root.age = new Counter(CounterType.Int, 0);
+        root.age = new Counter(0);
       });
       d1.update((root) => {
         root.age.increase(1).increase(2);
-        root.length = new Counter(CounterType.Int, 10);
+        root.length = new Counter(10);
       });
 
       await c1.sync();
@@ -80,9 +76,9 @@ describe('Counter', function () {
       height: Counter;
     }>(async (c1, d1, c2, d2) => {
       d1.update((root) => {
-        root.age = new Counter(CounterType.Int, 0);
-        root.width = new Counter(CounterType.Int, 0);
-        root.height = new Counter(CounterType.Int, 0);
+        root.age = new Counter(0);
+        root.width = new Counter(0);
+        root.height = new Counter(0);
       });
       await c1.sync();
       await c2.sync();
@@ -94,7 +90,7 @@ describe('Counter', function () {
       });
       d2.update((root) => {
         root.age.increase(3.14).increase(2);
-        root.width = new Counter(CounterType.Int, 2.5);
+        root.width = new Counter(2.5);
       });
       await c1.sync();
       await c2.sync();
@@ -108,30 +104,24 @@ describe('Counter', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc = new Document<{ age: Counter }>(docKey);
     doc.update((root) => {
-      root.age = new Counter(CounterType.Int, 2147483647);
+      root.age = new Counter(2147483647);
       root.age.increase(1);
     });
     assert.equal(`{"age":-2147483648}`, doc.toSortedJSON());
 
     doc.update((root) => {
-      root.age = new Counter(CounterType.Int, 2147483648);
+      root.age = new Counter(2147483648);
     });
     assert.equal(`{"age":-2147483648}`, doc.toSortedJSON());
 
     doc.update((root) => {
-      root.age = new Counter(
-        CounterType.Long,
-        Long.fromString('9223372036854775807'),
-      );
+      root.age = new Counter(Long.fromString('9223372036854775807'));
       root.age.increase(1);
     });
     assert.equal(`{"age":-9223372036854775808}`, doc.toSortedJSON());
 
     doc.update((root) => {
-      root.age = new Counter(
-        CounterType.Long,
-        Long.fromString('9223372036854775808'),
-      );
+      root.age = new Counter(Long.fromString('9223372036854775808'));
     });
     assert.equal(`{"age":-9223372036854775808}`, doc.toSortedJSON());
   });
@@ -141,8 +131,8 @@ describe('Counter', function () {
     const doc = new Document<{ cnt: Counter; longCnt: Counter }>(docKey);
 
     doc.update((root) => {
-      root.cnt = new Counter(CounterType.Int, 0);
-      root.longCnt = new Counter(CounterType.Long, Long.fromString('0'));
+      root.cnt = new Counter(0);
+      root.longCnt = new Counter(Long.fromString('0'));
     });
     assert.equal(doc.toSortedJSON(), `{"cnt":0,"longCnt":0}`);
 
@@ -170,7 +160,7 @@ describe('Counter', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc = new Document<TestDoc>(docKey);
     doc.update((root) => {
-      root.counter = new Counter(CounterType.Int, 100);
+      root.counter = new Counter(100);
     }, 'init counter');
     assert.equal(doc.toSortedJSON(), '{"counter":100}');
 
@@ -195,8 +185,8 @@ describe('Counter', function () {
     const states: Array<string> = [];
 
     doc.update((root) => {
-      root.cnt = new Counter(CounterType.Int, 0);
-      root.longCnt = new Counter(CounterType.Long, Long.fromString('0'));
+      root.cnt = new Counter(0);
+      root.longCnt = new Counter(Long.fromString('0'));
     });
     assert.equal(doc.toSortedJSON(), `{"cnt":0,"longCnt":0}`);
     states.push(doc.toSortedJSON());
@@ -237,7 +227,7 @@ describe('Counter', function () {
 
     await client1.attach(doc1, { syncMode: SyncMode.Manual });
     doc1.update((root) => {
-      root.counter = new Counter(yorkie.IntType, 100);
+      root.counter = new Counter(100);
     }, 'init counter');
     await client1.sync();
     assert.equal(doc1.toSortedJSON(), '{"counter":100}');

--- a/packages/sdk/test/integration/doc_presence_test.ts
+++ b/packages/sdk/test/integration/doc_presence_test.ts
@@ -611,7 +611,7 @@ describe('Undo/Redo', function () {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc = new yorkie.Document<TestDoc, Presence>(docKey);
     doc.update((root) => {
-      root.counter = new Counter(yorkie.IntType, 100);
+      root.counter = new Counter(100);
     }, 'init counter');
 
     const client = new yorkie.Client({ rpcAddr: testRPCAddr });

--- a/packages/sdk/test/integration/document_test.ts
+++ b/packages/sdk/test/integration/document_test.ts
@@ -24,7 +24,6 @@ import {
 } from '@yorkie-js/sdk/src/document/document';
 import { OpInfo } from '@yorkie-js/sdk/src/document/operation/operation';
 import { YorkieError } from '@yorkie-js/sdk/src/util/error';
-import Long from 'long';
 
 describe('Document', function () {
   afterEach(() => {
@@ -1172,7 +1171,7 @@ describe('Document', function () {
         },
         {
           name: 'long',
-          input: Long.MAX_VALUE,
+          input: 9223372036854775807n,
           expectedJSON: `{"long":9223372036854775807}`,
         },
         {
@@ -1214,7 +1213,7 @@ describe('Document', function () {
             null?: null;
             boolean?: boolean;
             number?: number;
-            long?: Long;
+            long?: bigint;
             object?: { k: string };
             array?: Array<JSONElement>;
             bytes?: Uint8Array;

--- a/packages/sdk/test/integration/document_test.ts
+++ b/packages/sdk/test/integration/document_test.ts
@@ -6,7 +6,6 @@ import yorkie, {
   SyncMode,
   Tree,
   JSONElement,
-  CounterType,
 } from '@yorkie-js/sdk/src/yorkie';
 import {
   testRPCAddr,
@@ -143,7 +142,7 @@ describe('Document', function () {
     });
 
     d1.update((root) => {
-      root.counter = new yorkie.Counter(yorkie.IntType, 100);
+      root.counter = new yorkie.Counter(100);
       root.todos = ['todo1', 'todo2', 'todo3'] as JSONArray<string>;
       root.content = new yorkie.Text();
       root.content.edit(0, 0, 'hello world', {
@@ -262,7 +261,7 @@ describe('Document', function () {
     });
 
     d2.update((root) => {
-      root.counter = new yorkie.Counter(yorkie.IntType, 0);
+      root.counter = new yorkie.Counter(0);
       root.todos = ['todo1', 'todo2'];
     });
     await eventCollector.waitAndVerifyNthEvent(1, [
@@ -875,7 +874,7 @@ describe('Document', function () {
       const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
       const doc = new yorkie.Document<TestDoc>(docKey);
       doc.update((root) => {
-        root.counter = new Counter(yorkie.IntType, 100);
+        root.counter = new Counter(100);
       }, 'init counter');
       assert.equal(doc.toSortedJSON(), '{"counter":100}');
 
@@ -909,7 +908,7 @@ describe('Document', function () {
       const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
       const doc = new yorkie.Document<TestDoc>(docKey);
       doc.update((root) => {
-        root.counter = new Counter(yorkie.IntType, 100);
+        root.counter = new Counter(100);
       }, 'init counter');
       assert.equal(doc.toSortedJSON(), '{"counter":100}');
 
@@ -969,7 +968,7 @@ describe('Document', function () {
       const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
       const doc = new yorkie.Document<TestDoc>(docKey);
       doc.update((root) => {
-        root.counter = new Counter(yorkie.IntType, 100);
+        root.counter = new Counter(100);
       }, 'init counter');
       assert.equal(doc.toSortedJSON(), '{"counter":100}');
 
@@ -1002,7 +1001,7 @@ describe('Document', function () {
       const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
       const doc = new yorkie.Document<TestDoc>(docKey);
       doc.update((root) => {
-        root.counter = new Counter(yorkie.IntType, 0);
+        root.counter = new Counter(0);
       }, 'init counter');
       assert.equal(doc.toSortedJSON(), '{"counter":0}');
 
@@ -1060,7 +1059,7 @@ describe('Document', function () {
       const doc1 = new yorkie.Document(docKey);
       await c1.attach(doc1, {
         initialRoot: {
-          counter: new Counter(CounterType.Int, 0),
+          counter: new Counter(0),
           content: { x: 1, y: 1 },
         },
       });
@@ -1074,7 +1073,7 @@ describe('Document', function () {
       const doc2 = new yorkie.Document(docKey);
       await c2.attach(doc2, {
         initialRoot: {
-          counter: new Counter(CounterType.Int, 1),
+          counter: new Counter(1),
           content: { x: 1, y: 2 },
           new: { k: 'v' },
         },
@@ -1153,7 +1152,7 @@ describe('Document', function () {
         },
         {
           name: 'counter',
-          input: new Counter(CounterType.Int, 1),
+          input: new Counter(1),
           expectedJSON: `{"counter":1}`,
         },
         {

--- a/packages/sdk/test/integration/primitive_test.ts
+++ b/packages/sdk/test/integration/primitive_test.ts
@@ -1,5 +1,4 @@
 import { describe, it, assert } from 'vitest';
-import Long from 'long';
 import { Document } from '@yorkie-js/sdk/src/document/document';
 import { InitialCheckpoint } from '@yorkie-js/sdk/src/document/change/checkpoint';
 import { withTwoClientsAndDocuments } from '@yorkie-js/sdk/test/integration/integration_helper';
@@ -50,7 +49,7 @@ describe('Primitive', function () {
       k0: null;
       k1: boolean;
       k2: number;
-      k3: Long;
+      k3: bigint;
       k4: number;
       k5: string;
       k6: Uint8Array;
@@ -61,7 +60,7 @@ describe('Primitive', function () {
         root['k0'] = null;
         root['k1'] = true;
         root['k2'] = 2147483647;
-        root['k3'] = Long.MAX_VALUE;
+        root['k3'] = 9223372036854775807n;
         root['k4'] = 1.79;
         root['k5'] = '4';
         root['k6'] = new Uint8Array([65, 66]);

--- a/packages/sdk/test/unit/api/converter_test.ts
+++ b/packages/sdk/test/unit/api/converter_test.ts
@@ -18,7 +18,6 @@ import { describe, it, assert } from 'vitest';
 import { Document } from '@yorkie-js/sdk/src/document/document';
 import { converter } from '@yorkie-js/sdk/src/api/converter';
 import { Counter, Primitive, Text, Tree } from '@yorkie-js/sdk/src/yorkie';
-import { CounterType } from '@yorkie-js/sdk/src/document/crdt/counter';
 import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
 import { CRDTTree, CRDTTreeNode } from '@yorkie-js/sdk/src/document/crdt/tree';
 
@@ -74,7 +73,7 @@ describe('Converter', function () {
         italic: false,
         color: 'red',
       });
-      root.k4 = new Counter(CounterType.Int, 0);
+      root.k4 = new Counter(0);
       root.k4.increase(1).increase(2).increase(3);
     });
 

--- a/packages/sdk/test/unit/document/crdt/counter_test.ts
+++ b/packages/sdk/test/unit/document/crdt/counter_test.ts
@@ -16,7 +16,6 @@
 
 import { describe, it, assert } from 'vitest';
 import { InitialTimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
-import Long from 'long';
 import {
   CounterType,
   CRDTCounter,
@@ -26,14 +25,10 @@ import { Primitive } from '@yorkie-js/sdk/src/document/crdt/primitive';
 describe('Counter', function () {
   it('Can increase numeric data of Counter', function () {
     const double = CRDTCounter.create(CounterType.Int, 10, InitialTimeTicket);
-    const long = CRDTCounter.create(
-      CounterType.Long,
-      Long.fromString('100'),
-      InitialTimeTicket,
-    );
+    const long = CRDTCounter.create(CounterType.Long, 100n, InitialTimeTicket);
 
     const doubleOperand = Primitive.of(10, InitialTimeTicket);
-    const longOperand = Primitive.of(Long.fromString('100'), InitialTimeTicket);
+    const longOperand = Primitive.of(100n, InitialTimeTicket);
 
     double.increase(doubleOperand);
     double.increase(longOperand);
@@ -41,7 +36,7 @@ describe('Counter', function () {
 
     long.increase(doubleOperand);
     long.increase(longOperand);
-    assert.equal((long.getValue() as Long).toNumber(), 210);
+    assert.equal(Number(long.getValue() as bigint), 210);
 
     // error process test
     function errorTest(counter: CRDTCounter, operand: Primitive): void {
@@ -68,11 +63,11 @@ describe('Counter', function () {
     errorTest(double, date);
 
     assert.equal(double.getValue(), 120);
-    assert.equal((long.getValue() as Long).toNumber(), 210);
+    assert.equal(Number(long.getValue() as bigint), 210);
 
     // subtraction test
     const negative = Primitive.of(-50, InitialTimeTicket);
-    const negativeLong = Primitive.of(Long.fromNumber(-100), InitialTimeTicket);
+    const negativeLong = Primitive.of(BigInt(-100), InitialTimeTicket);
     double.increase(negative);
     double.increase(negativeLong);
     assert.equal(double.getValue(), -30);

--- a/packages/sdk/test/unit/document/crdt/primitive_test.ts
+++ b/packages/sdk/test/unit/document/crdt/primitive_test.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import Long from 'long';
 import { describe, it, assert } from 'vitest';
 import { InitialTimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
 import {
@@ -46,7 +45,7 @@ describe('Primitive', function () {
     },
     {
       type: PrimitiveType.Long,
-      value: Long.MAX_VALUE,
+      value: 9223372036854775807n,
     },
     {
       type: PrimitiveType.Bytes,

--- a/packages/sdk/test/unit/document/document_size_test.ts
+++ b/packages/sdk/test/unit/document/document_size_test.ts
@@ -2,7 +2,6 @@ import { describe, it, assert } from 'vitest';
 import Long from 'long';
 import {
   Counter,
-  CounterType,
   Document,
   JSONObject,
   Text,
@@ -116,7 +115,7 @@ describe('Document Size', () => {
 
   it('counter test', function () {
     const doc = new Document<{ counter: Counter }>('test-doc');
-    doc.update((root) => (root.counter = new Counter(CounterType.Int, 0)));
+    doc.update((root) => (root.counter = new Counter(0)));
     assert.deepEqual(doc.getDocSize().live, { data: 4, meta: 72 });
   });
 
@@ -243,7 +242,7 @@ describe('Document Size', () => {
 
   it('deep copy test', function () {
     const doc = new Document<{ counter: Counter }>('test-doc');
-    doc.update((root) => (root.counter = new Counter(CounterType.Int, 0)));
+    doc.update((root) => (root.counter = new Counter(0)));
     const clone = doc.getClone()!.root.deepcopy();
     assert.deepEqual(doc.getDocSize(), clone.getDocSize());
   });
@@ -252,7 +251,7 @@ describe('Document Size', () => {
     const doc = new Document<{ arr: Array<Counter> }>('test-doc');
 
     doc.update((root) => (root['arr'] = []));
-    doc.update((root) => root['arr'].push(new Counter(CounterType.Int, 0)));
+    doc.update((root) => root['arr'].push(new Counter(0)));
 
     const clone = doc.getClone()!.root.deepcopy();
     assert.deepEqual(clone.getDocSize(), doc.getDocSize());

--- a/packages/sdk/test/unit/document/document_size_test.ts
+++ b/packages/sdk/test/unit/document/document_size_test.ts
@@ -1,5 +1,4 @@
 import { describe, it, assert } from 'vitest';
-import Long from 'long';
 import {
   Counter,
   Document,
@@ -60,7 +59,7 @@ describe('Document Size', () => {
       k0: null;
       k1: boolean;
       k2: number;
-      k3: Long;
+      k3: bigint;
       k4: number;
       k5: string;
       k6: Uint8Array;
@@ -79,7 +78,7 @@ describe('Document Size', () => {
     doc.update((root) => (root['k2'] = 2147483647));
     assert.deepEqual(doc.getDocSize().live, { data: 16, meta: 168 });
 
-    doc.update((root) => (root['k3'] = Long.MAX_VALUE));
+    doc.update((root) => (root['k3'] = 9223372036854775807n));
     assert.deepEqual(doc.getDocSize().live, { data: 24, meta: 216 });
 
     doc.update((root) => (root['k4'] = 1.79));

--- a/packages/sdk/test/unit/document/document_test.ts
+++ b/packages/sdk/test/unit/document/document_test.ts
@@ -24,13 +24,7 @@ import {
 import { Document, DocEventType } from '@yorkie-js/sdk/src/document/document';
 import { DocEventType as PbDocEventType } from '@yorkie-js/sdk/src/api/yorkie/v1/resources_pb';
 import { OpInfo } from '@yorkie-js/sdk/src/document/operation/operation';
-import yorkie, {
-  JSONArray,
-  Text,
-  Counter,
-  CounterType,
-  Tree,
-} from '@yorkie-js/sdk/src/yorkie';
+import { JSONArray, Text, Counter, Tree } from '@yorkie-js/sdk/src/yorkie';
 import { withTwoClientsAndDocuments } from '@yorkie-js/sdk/test/integration/integration_helper';
 
 describe.sequential('Document', function () {
@@ -1058,7 +1052,7 @@ describe.sequential('Document', function () {
     });
 
     doc.update((root) => {
-      root.cnt = new Counter(CounterType.Int, 0);
+      root.cnt = new Counter(0);
     });
     await eventCollector.waitAndVerifyNthEvent(1, [
       { type: 'set', path: '$', key: 'cnt' },
@@ -1324,7 +1318,7 @@ describe.sequential('Document', function () {
   it('gets the value of the counter', function () {
     const doc = new Document<{ counter: Counter }>('test-doc');
     doc.update((root) => {
-      root.counter = new Counter(CounterType.Int, 155);
+      root.counter = new Counter(155);
     });
     assert.equal(155, doc.getRoot().counter.getValue());
   });
@@ -1417,7 +1411,7 @@ describe.sequential('Document', function () {
     });
 
     doc.update((root) => {
-      root.counter = new Counter(CounterType.Int, 0);
+      root.counter = new Counter(0);
       root.counter.increase(1);
     });
 
@@ -1500,7 +1494,7 @@ describe.sequential('Document', function () {
         }
       });
 
-      d1.update((r) => (r.counter = new Counter(yorkie.IntType, 0)));
+      d1.update((r) => (r.counter = new Counter(0)));
       await c1.sync();
       await c2.sync();
 

--- a/packages/sdk/test/unit/schema/ruleset_validator_test.ts
+++ b/packages/sdk/test/unit/schema/ruleset_validator_test.ts
@@ -266,7 +266,7 @@ describe('ruleset-validator', () => {
     doc.update((root) => {
       root.text = new yorkie.Text();
       root.tree = new yorkie.Tree({ type: 'doc', children: [] });
-      root.counter = new yorkie.Counter(yorkie.IntType, 0);
+      root.counter = new yorkie.Counter(0);
     });
     let result = validateYorkieRuleset(doc.getRootObject(), ruleset);
     expect(result.valid).to.eq(true);

--- a/packages/sdk/test/unit/schema/ruleset_validator_test.ts
+++ b/packages/sdk/test/unit/schema/ruleset_validator_test.ts
@@ -14,7 +14,6 @@
  * limitations under the License.
  */
 
-import Long from 'long';
 import { describe, it, expect } from 'vitest';
 import yorkie from '@yorkie-js/sdk/src/yorkie';
 import { validateYorkieRuleset } from '@yorkie-js/sdk/src/document/schema/ruleset_validator';
@@ -55,7 +54,7 @@ describe('ruleset-validator', () => {
       root.field2 = true;
       root.field3 = 123;
       root.field4 = 123.456;
-      root.field5 = Long.MAX_VALUE;
+      root.field5 = 9223372036854775807n;
       root.field6 = 'test';
       root.field7 = new Date();
       root.field8 = new Uint8Array([1, 2, 3]);
@@ -67,7 +66,7 @@ describe('ruleset-validator', () => {
       root.field1 = false;
       root.field2 = 123;
       root.field3 = 123.456;
-      root.field4 = Long.MAX_VALUE;
+      root.field4 = 9223372036854775807n;
       root.field5 = 'test';
       root.field6 = new Date();
       root.field7 = new Uint8Array([1, 2, 3]);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -736,9 +736,6 @@ importers:
       '@yorkie-js/schema':
         specifier: workspace:*
         version: link:../schema
-      long:
-        specifier: ^5.3.2
-        version: 5.3.2
     devDependencies:
       '@buf/googleapis_googleapis.bufbuild_es':
         specifier: 2.10.1-20251126203132-004180b77378.1
@@ -755,9 +752,6 @@ importers:
       '@types/google-protobuf':
         specifier: ^3.15.12
         version: 3.15.12
-      '@types/long':
-        specifier: ^5.0.0
-        version: 5.0.0
       '@vitest/coverage-istanbul':
         specifier: ^4.0.15
         version: 4.0.15(vitest@4.0.15(@types/node@24.10.1)(jiti@2.6.1)(jsdom@27.2.0)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(yaml@2.8.2))
@@ -3768,10 +3762,6 @@ packages:
   '@types/lodash@4.17.21':
     resolution: {integrity: sha512-FOvQ0YPD5NOfPgMzJihoT+Za5pdkDJWcbpuj1DjaKZIr/gxodQjY/uWEFlTNqW2ugXHUiL8lRQgw63dzKHZdeQ==}
 
-  '@types/long@5.0.0':
-    resolution: {integrity: sha512-eQs9RsucA/LNjnMoJvWG/nXa7Pot/RbBzilF/QRIU/xRl+0ApxrSUFsV5lmf01SvSlqMzJ7Zwxe440wmz2SJGA==}
-    deprecated: This is a stub types definition. long provides its own type definitions, so you do not need this installed.
-
   '@types/node@24.10.1':
     resolution: {integrity: sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==}
 
@@ -6157,9 +6147,6 @@ packages:
   log-update@6.1.0:
     resolution: {integrity: sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==}
     engines: {node: '>=18'}
-
-  long@5.3.2:
-    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
@@ -11288,10 +11275,6 @@ snapshots:
 
   '@types/lodash@4.17.21': {}
 
-  '@types/long@5.0.0':
-    dependencies:
-      long: 5.3.2
-
   '@types/node@24.10.1':
     dependencies:
       undici-types: 7.16.0
@@ -14029,8 +14012,6 @@ snapshots:
       slice-ansi: 7.1.2
       strip-ansi: 7.1.2
       wrap-ansi: 9.0.2
-
-  long@5.3.2: {}
 
   loose-envify@1.4.0:
     dependencies:


### PR DESCRIPTION
## Summary

- Separate `Counter` and `DedupCounter` into independent types so invalid method calls (e.g. `increase()` on DedupCounter) are caught at **compile time**
- Counter constructor infers type from value: `new Counter(0)` → Int, `new Counter(0n)` → Long
- Replace `long` npm package with native `bigint` (~25KB bundle reduction)
- Remove `IntType`/`LongType` aliases and `CounterType` from user-facing API

## Breaking Changes

| Before | After |
|--------|-------|
| `new Counter(CounterType.Int, 0)` | `new Counter(0)` |
| `new Counter(CounterType.Long, Long.ZERO)` | `new Counter(0n)` |
| `counter.increase(Long.fromString('1'))` | `counter.increase(1n)` |
| `DedupCounter` has `increase()` (runtime error) | `DedupCounter` has no `increase()` (compile error) |
| `Counter` has `add()` (runtime error) | `Counter` has no `add()` (compile error) |
| `yorkie.IntType` / `yorkie.LongType` | Removed — type inferred from value |

## Related

- Go server counterpart: yorkie-team/yorkie#improve-counter-interface
- Context: [#765](https://github.com/yorkie-team/yorkie/issues/765) — Counter generics discussion

## Test plan

- [x] All 238 unit tests pass
- [x] Build succeeds with ~25KB bundle reduction
- [x] Lint passes with zero warnings
- [x] Integration tests with running Yorkie server

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  - Simplified `Counter` constructor—now infers type from value (e.g., `new Counter(0)` for integers, `new Counter(100n)` for large numbers). Removed explicit type parameter requirement.
  - Removed exported `IntType` and `LongType` constants.

* **Chores**
  - Eliminated `long` library dependency; now uses native JavaScript `bigint` for large number handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->