### PR TITLE
Switch default transport from gRPC-Web to Connect Protocol

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -21,7 +21,10 @@ import {
   ConnectError,
   Code as ConnectCode,
 } from '@connectrpc/connect';
-import { createGrpcWebTransport } from '@connectrpc/connect-web';
+import {
+  createConnectTransport,
+  createGrpcWebTransport,
+} from '@connectrpc/connect-web';
 import {
   YorkieService,
   WatchResponse,
@@ -194,6 +197,13 @@ export interface ClientOptions {
    * client.
    */
   userAgent?: string;
+
+  /**
+   * `useGrpcWebTransport` determines the transport protocol.
+   * If true, uses gRPC-Web transport for backward compatibility.
+   * If false (default), uses Connect Protocol transport.
+   */
+  useGrpcWebTransport?: boolean;
 }
 
 /**
@@ -336,23 +346,24 @@ export class Client {
     const { authInterceptor, setToken } = createAuthInterceptor(this.apiKey);
     this.setAuthToken = setToken;
 
+    const transportOptions = {
+      baseUrl: rpcAddr,
+      interceptors: [authInterceptor, createMetricInterceptor(opts?.userAgent)],
+      fetch: (input: RequestInfo | URL, init?: RequestInit) => {
+        return fetch(input as RequestInfo, {
+          ...init,
+          keepalive: this.keepalive,
+        });
+      },
+    };
+
     // Here we make the client itself, combining the service
     // definition with the transport.
     this.rpcClient = createConnectClient(
       YorkieService,
-      createGrpcWebTransport({
-        baseUrl: rpcAddr,
-        interceptors: [
-          authInterceptor,
-          createMetricInterceptor(opts?.userAgent),
-        ],
-        fetch: (input, init) => {
-          return fetch(input as RequestInfo, {
-            ...init,
-            keepalive: this.keepalive,
-          });
-        },
-      }),
+      opts.useGrpcWebTransport
+        ? createGrpcWebTransport(transportOptions)
+        : createConnectTransport(transportOptions),
     );
     this.taskQueue = [];
   }

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -67,6 +67,20 @@ describe.sequential('Client', function () {
     assert.isFalse(clientWithoutKey.isActive());
   });
 
+  it('Can activate with gRPC-Web transport', async function ({ task }) {
+    const clientKey = `${task.name}-${new Date().getTime()}`;
+    const client = new yorkie.Client({
+      rpcAddr: testRPCAddr,
+      key: clientKey,
+      useGrpcWebTransport: true,
+    });
+    assert.isFalse(client.isActive());
+    await client.activate();
+    assert.isTrue(client.isActive());
+    await client.deactivate();
+    assert.isFalse(client.isActive());
+  });
+
   it('Can attach/detach document', async function ({ task }) {
     const cli = new yorkie.Client({ rpcAddr: testRPCAddr });
     await cli.activate();


### PR DESCRIPTION
## Summary

- Switch the default RPC transport from `createGrpcWebTransport` to `createConnectTransport`
- Add `useGrpcWebTransport` option to `ClientOptions` for backward compatibility
- Add integration test verifying gRPC-Web transport fallback still works

## Motivation

The server already supports Connect, gRPC, and gRPC-Web protocols automatically via the Connect RPC framework. There is no technical reason to keep gRPC-Web as the default client transport. Connect Protocol offers better debugging (JSON serialization support) and standard HTTP semantics.

## Changes

**`packages/sdk/src/client/client.ts`**
- Import `createConnectTransport` alongside `createGrpcWebTransport`
- Add `useGrpcWebTransport?: boolean` option to `ClientOptions` (default: `false`)
- Extract `transportOptions` and select transport via ternary

**`packages/sdk/test/integration/client_test.ts`**
- Add `Can activate with gRPC-Web transport` test

## Test plan

- [x] `pnpm lint` — 0 warnings
- [x] `pnpm sdk build` — success
- [x] `pnpm sdk test test/integration/client_test.ts` — 17/17 pass (Connect Protocol default)
- [x] `pnpm sdk test test/integration/doc_presence_test.ts` — 14/14 pass (SSE streaming)
- [ ] `pnpm sdk test` — full suite

## Design doc

`03_projects/docs/design/connect-protocol-migration.md` in [second-brain](https://github.com/yorkie-team/second-brain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `useGrpcWebTransport` option to client configuration, allowing selection between gRPC-Web and Connect transport protocols.

* **Tests**
  * Added integration test for gRPC-Web transport activation and deactivation flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->