### PR TITLE
Enable splitLevel=1 concurrent tests and add split undo/redo

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -7,6 +7,7 @@ New design documents should be based on [TEMPLATE.md](TEMPLATE.md).
 - [Devtools Extension](devtools.md): Message flow between devtools extension and yorkie-js-sdk
 - [ProseMirror Binding](prosemirror.md): Bidirectional sync between ProseMirror and Yorkie Tree CRDT
 - [ProseMirror Native Split/Merge](prosemirror-native-split-merge.md): Use Tree.Edit splitLevel and boundary deletion for splits and merges instead of block replacement
+- [Tree Split Undo/Redo](tree-split-undo-redo.md): Undo/redo support for Tree.Edit splitLevel=1 via boundary deletion reverse ops
 
 ## Guidelines
 

--- a/docs/design/tree-split-undo-redo.md
+++ b/docs/design/tree-split-undo-redo.md
@@ -1,0 +1,141 @@
+---
+created: 2026-04-15
+updated: 2026-04-15
+tags: [tree, undo-redo, split]
+---
+
+# Tree Split Undo/Redo (splitLevel=1)
+
+## Problem
+
+`TreeEditOperation` with `splitLevel > 0` does not generate a reverse
+operation, so undo/redo is silently skipped for split operations. This
+blocks ProseMirror binding and Wafflebase from using Yorkie-native
+undo/redo for paragraph splitting (Enter key).
+
+The guard at `tree_edit_operation.ts:187-189` explicitly returns
+`undefined` for `splitLevel !== 0`:
+
+```typescript
+const reverseOp =
+  this.splitLevel === 0
+    ? this.toReverseOperation(tree, removedNodes, preEditFromIdx)
+    : undefined;
+```
+
+### Goals
+
+- Generate reverse operations for `splitLevel=1` split edits.
+- Support single-client undo/redo cycle: split → undo → redo.
+- Support 2-client concurrent scenarios where remote edits do not
+  overlap with the split boundary (reconciliation Cases 1-2).
+
+### Non-Goals
+
+- `splitLevel >= 2` undo/redo — forward convergence fails for L2
+  concurrent operations (68/320 tests fail). Deferred until L2 forward
+  convergence is fixed.
+- Overlapping range reconciliation Cases 3-6 — existing Phase 2 scope,
+  unchanged by this work.
+- New operation types or protocol changes.
+
+## Design
+
+### Reverse Operation: Boundary Deletion
+
+A split creates new element boundaries without removing any nodes:
+
+```
+splitLevel=1: <p>ab|cd</p>  →  <p>ab</p><p>cd</p>   (2 boundary tokens)
+```
+
+The reverse is a boundary deletion — a `splitLevel=0` edit that removes
+the boundary tokens, merging the split elements back:
+
+```
+reverse: edit(fromIdx, fromIdx + 2, undefined, 0)   // delete 2 boundary tokens
+```
+
+The reverse op is a standard `TreeEditOperation` with `isUndoOp=true`,
+`splitLevel=0`, and integer indices for reconciliation. This means:
+
+1. **No new operation types.** The reverse reuses the existing
+   `TreeEditOperation` infrastructure.
+2. **Reconciliation unchanged.** The reverse op is `splitLevel=0`, so
+   the existing 6-case overlap logic in `reconcileOperation` applies
+   directly.
+3. **Redo works automatically.** When the boundary deletion (undo)
+   executes, it removes nodes and produces its own reverse op via the
+   existing `toReverseOperation` path — a `splitLevel=0` re-insertion
+   of the boundary nodes.
+
+### Undo/Redo Cycle
+
+```
+split(L1)
+  → undo: boundary delete (splitLevel=0, removes 2 tokens)
+    → redo: re-insert boundary nodes (splitLevel=0, deep-copied nodes)
+      → undo again: boundary delete (same as first undo)
+```
+
+Each step produces a standard `splitLevel=0` reverse op, so the entire
+cycle uses existing infrastructure after the initial reverse op
+generation.
+
+### Code Changes
+
+Only `tree_edit_operation.ts` is modified:
+
+1. **Remove the `splitLevel === 0` guard** in `execute()` and replace
+   with a branch: call `toReverseOperation` for `splitLevel=0`, call a
+   new `toSplitReverseOperation` for `splitLevel > 0`.
+
+2. **Add `toSplitReverseOperation` method** that:
+   - Computes `boundarySize = 2 * this.splitLevel` (for L1, this is 2)
+   - Guards against `fromIdx + boundarySize > tree.getSize()` (concurrent
+     parent deletion → no-op)
+   - Returns `TreeEditOperation.create(parentCreatedAt, fromPos,
+     tree.findPos(fromIdx + boundarySize), undefined, 0, executedAt,
+     isUndoOp=true, fromIdx, fromIdx + boundarySize)`
+
+3. **No changes to**: `history.ts`, `document.ts`, `reconcileOperation`,
+   or any other file.
+
+### Edge Cases
+
+| Case | Behavior |
+|------|----------|
+| Front split (`<p>\|ab</p>` → `<p></p><p>ab</p>`) | Undo deletes 2 boundary tokens, merges empty element back |
+| Back split (`<p>ab\|</p>` → `<p>ab</p><p></p>`) | Same — boundary deletion merges trailing empty element |
+| Concurrent parent deletion | `fromIdx + boundarySize > tree.getSize()` guard → undo is no-op |
+| Concurrent insert into split result (non-overlapping) | Reconciliation Cases 1-2 shift indices correctly |
+| Concurrent insert into split boundary (overlapping) | Out of scope — Cases 3-6, existing Phase 2 skip |
+
+### Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| Boundary size assumption (`2 * splitLevel`) may be wrong if concurrent edits insert nodes between split boundaries | Only L1 is in scope; L1 concurrent split already converges (152 tests passing). Reconciliation Cases 1-2 handle non-overlapping shifts. |
+| Merge semantics on undo may differ from original pre-split state (e.g., `mergedFrom`/`mergedAt` metadata) | Boundary deletion triggers standard CRDTTree merge path, same as user-initiated merge. Verify in tests. |
+| Redo re-inserts deep-copied boundary nodes — node IDs may conflict with GC | Existing `splitLevel=0` redo path already handles this. No new risk. |
+
+### Design Decisions
+
+| Decision | Reason |
+|----------|--------|
+| Boundary deletion as reverse | Reverse op is `splitLevel=0`, reuses all existing reconciliation and redo infrastructure. Simplest approach. |
+| `splitLevel=1` only | L2 forward convergence is broken (68 test failures). Enabling undo on broken forward ops adds risk. |
+| Single file change | Split reverse is a small extension to `toReverseOperation`. No architectural changes needed. |
+| `boundarySize = 2 * splitLevel` | Each split level creates one close tag + one open tag = 2 tree index tokens per level. |
+
+## Alternatives Considered
+
+| Alternative | Why not |
+|-------------|---------|
+| **Content-based reverse** (deep-copy original node, delete split result, re-insert original) | Concurrent edits to split result would be lost. Dangerous in collaborative environment. |
+| **Split-aware reverse** (store splitLevel in reverse, execute merge on undo) | Merge is just boundary deletion. Same result as approach A but adds a new reverse op variant for no benefit. |
+| **Support splitLevel=2 simultaneously** | Forward convergence fails for L2 concurrent splits. Fix forward first, then add undo. |
+
+## Tasks
+
+Implementation plan to be created separately.

--- a/docs/design/tree-split-undo-redo.md
+++ b/docs/design/tree-split-undo-redo.md
@@ -136,6 +136,79 @@ Only `tree_edit_operation.ts` is modified:
 | **Split-aware reverse** (store splitLevel in reverse, execute merge on undo) | Merge is just boundary deletion. Same result as approach A but adds a new reverse op variant for no benefit. |
 | **Support splitLevel=2 simultaneously** | Forward convergence fails for L2 concurrent splits. Fix forward first, then add undo. |
 
+### Test Strategy: Table-Driven
+
+Follow the existing `history_tree_test.ts` pattern of declaring a test
+state space and iterating over combinations.
+
+#### Test State Space
+
+```
+┌─────────────────┬─────────────────────────────────────────────────┐
+│ Variable        │ Domain                                          │
+├─────────────────┼─────────────────────────────────────────────────┤
+│ SplitPosition   │ {front, middle, back}                           │
+│ Action          │ {undo, undo-redo, undo-redo-undo}               │
+│ ClientCount     │ {1, 2}                                          │
+│ ChainOp         │ {split-only, split+insert-text, split+delete,   │
+│                 │  insert-text+split}                              │
+│ RemoteOp        │ {insert-text, delete-text, insert-element}      │
+│ RemotePosition  │ {before-split, after-split, different-element}  │
+└─────────────────┴─────────────────────────────────────────────────┘
+```
+
+#### Test Sections
+
+**Section A: Single-client split undo/redo (table-driven)**
+
+```typescript
+type SplitPos = 'front' | 'middle' | 'back';
+const splitPositions: SplitPos[] = ['front', 'middle', 'back'];
+
+for (const pos of splitPositions) {
+  it(`should undo split at ${pos}`, ...);
+  it(`should redo split at ${pos}`, ...);
+  it(`should undo-redo-undo split at ${pos}`, ...);
+}
+```
+
+- Initial tree: `<doc><p>ABCD</p></doc>`
+- front: `edit(1, 1, undefined, 1)` → `<doc><p></p><p>ABCD</p></doc>`
+- middle: `edit(3, 3, undefined, 1)` → `<doc><p>AB</p><p>CD</p></doc>`
+- back: `edit(5, 5, undefined, 1)` → `<doc><p>ABCD</p><p></p></doc>`
+
+**Section B: Single-client chained ops (table-driven)**
+
+```typescript
+type SplitChainOp = 'split' | 'insert-text' | 'delete-text';
+for (const op1 of splitChainOps) {
+  for (const op2 of splitChainOps) {
+    it(`should undo chain: ${op1} → ${op2}`, ...);
+  }
+}
+```
+
+Snapshot-based verification: record XML after each op, undo in reverse
+order checking each snapshot, redo forward checking each snapshot.
+
+**Section C: Multi-client convergence (table-driven)**
+
+```typescript
+for (const remoteOp of ['insert-text', 'delete-text', 'insert-element']) {
+  for (const remotePos of ['before-split', 'after-split', 'different-element']) {
+    it(`should converge: split + remote ${remoteOp} at ${remotePos}`, ...);
+  }
+}
+```
+
+Uses `withTwoClientsAndDocuments`. d1 splits, d2 does remote op,
+sync, d1 undoes, sync again, assert convergence.
+
+**Section D: Edge cases (explicit)**
+
+- Empty paragraph undo (front/back split)
+- Concurrent parent deletion → undo is no-op
+
 ## Tasks
 
 Implementation plan to be created separately.

--- a/docs/tasks/active/20260415-tree-split-undo-redo-todo.md
+++ b/docs/tasks/active/20260415-tree-split-undo-redo-todo.md
@@ -1,0 +1,656 @@
+# Tree Split Undo/Redo (splitLevel=1) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable undo/redo for Tree.Edit splitLevel=1 operations by generating boundary-deletion reverse ops.
+
+**Architecture:** When a splitLevel>0 edit executes, generate a splitLevel=0 boundary-deletion reverse op (2 tokens per split level). This reverse op reuses all existing reconciliation and redo infrastructure unchanged.
+
+**Tech Stack:** TypeScript, Vitest, yorkie-js-sdk CRDT internals
+
+**Design doc:** `docs/design/tree-split-undo-redo.md`
+
+---
+
+### Task 1: Table-driven single-client split undo tests (Section A)
+
+**Files:**
+- Modify: `packages/sdk/test/integration/history_tree_test.ts`
+
+- [ ] **Step 1: Add the split undo/redo test section**
+
+Append after the existing "Tree History - single client split/merge" describe block (line ~481):
+
+```typescript
+// 4b. Single Client - Split Undo/Redo (splitLevel=1, table-driven)
+describe('Tree History - single client split L1 undo/redo', () => {
+  type SplitPos = 'front' | 'middle' | 'back';
+  const splitCases: Array<{
+    pos: SplitPos;
+    splitIdx: number;
+    afterXML: string;
+  }> = [
+    {
+      pos: 'front',
+      splitIdx: 1,
+      afterXML: '<doc><p></p><p>ABCD</p></doc>',
+    },
+    {
+      pos: 'middle',
+      splitIdx: 3,
+      afterXML: '<doc><p>AB</p><p>CD</p></doc>',
+    },
+    {
+      pos: 'back',
+      splitIdx: 5,
+      afterXML: '<doc><p>ABCD</p><p></p></doc>',
+    },
+  ];
+
+  const beforeXML = '<doc><p>ABCD</p></doc>';
+
+  for (const { pos, splitIdx, afterXML } of splitCases) {
+    it(`should undo split at ${pos}`, () => {
+      const doc = new Document<{ t: Tree }>('test-doc');
+      doc.update((root) => {
+        root.t = new Tree({
+          type: 'doc',
+          children: [
+            {
+              type: 'p',
+              children: [{ type: 'text', value: 'ABCD' }],
+            },
+          ],
+        });
+      }, 'init');
+      assert.equal(xmlOf(doc), beforeXML);
+
+      doc.update((root) => {
+        root.t.edit(splitIdx, splitIdx, undefined, 1);
+      }, `split at ${pos}`);
+      assert.equal(xmlOf(doc), afterXML);
+
+      doc.history.undo();
+      assert.equal(xmlOf(doc), beforeXML, `undo split at ${pos} failed`);
+    });
+
+    it(`should undo-redo split at ${pos}`, () => {
+      const doc = new Document<{ t: Tree }>('test-doc');
+      doc.update((root) => {
+        root.t = new Tree({
+          type: 'doc',
+          children: [
+            {
+              type: 'p',
+              children: [{ type: 'text', value: 'ABCD' }],
+            },
+          ],
+        });
+      }, 'init');
+
+      doc.update((root) => {
+        root.t.edit(splitIdx, splitIdx, undefined, 1);
+      }, `split at ${pos}`);
+
+      doc.history.undo();
+      assert.equal(xmlOf(doc), beforeXML);
+
+      doc.history.redo();
+      assert.equal(xmlOf(doc), afterXML, `redo split at ${pos} failed`);
+    });
+
+    it(`should undo-redo-undo split at ${pos}`, () => {
+      const doc = new Document<{ t: Tree }>('test-doc');
+      doc.update((root) => {
+        root.t = new Tree({
+          type: 'doc',
+          children: [
+            {
+              type: 'p',
+              children: [{ type: 'text', value: 'ABCD' }],
+            },
+          ],
+        });
+      }, 'init');
+
+      doc.update((root) => {
+        root.t.edit(splitIdx, splitIdx, undefined, 1);
+      }, `split at ${pos}`);
+
+      doc.history.undo();
+      doc.history.redo();
+      doc.history.undo();
+      assert.equal(
+        xmlOf(doc),
+        beforeXML,
+        `undo-redo-undo split at ${pos} failed`,
+      );
+    });
+  }
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm sdk test test/integration/history_tree_test.ts`
+
+Expected: 9 new tests fail (3 positions × 3 actions). The `undo` call
+has no effect because `reverseOp` is `undefined` for splitLevel=1, so
+`afterXML` persists instead of reverting to `beforeXML`.
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+git add packages/sdk/test/integration/history_tree_test.ts
+git commit -m "Add failing tests for splitLevel=1 split undo/redo
+
+Table-driven tests covering front/middle/back split positions with
+undo, undo-redo, and undo-redo-undo actions. All 9 tests fail
+because reverse ops are not generated for splitLevel > 0."
+```
+
+---
+
+### Task 2: Implement `toSplitReverseOperation` and enable reverse ops
+
+**Files:**
+- Modify: `packages/sdk/src/document/operation/tree_edit_operation.ts`
+
+- [ ] **Step 1: Add `toSplitReverseOperation` method**
+
+Add this method after the existing `toReverseOperation` method (after line ~288):
+
+```typescript
+  /**
+   * `toSplitReverseOperation` creates the reverse operation for a split edit.
+   *
+   * A split creates element boundaries (close + open tags). The reverse
+   * is a boundary deletion: a splitLevel=0 edit that removes those tokens,
+   * merging the split elements back together.
+   *
+   * boundarySize = 2 * splitLevel (each level creates 1 close + 1 open tag)
+   *
+   * @param tree - The CRDTTree after the split has been applied
+   * @param preEditFromIdx - The from index captured BEFORE the split
+   */
+  private toSplitReverseOperation(
+    tree: CRDTTree,
+    preEditFromIdx: number,
+  ): Operation | undefined {
+    const boundarySize = 2 * this.splitLevel;
+    const reverseFromIdx = preEditFromIdx;
+    const reverseToIdx = preEditFromIdx + boundarySize;
+
+    // Guard: if indices exceed tree size, the split was a no-op
+    // (e.g., concurrent parent deletion tombstoned the split result).
+    if (reverseToIdx > tree.getSize()) {
+      return undefined;
+    }
+
+    const reverseFromPos = tree.findPos(reverseFromIdx);
+    const reverseToPos = tree.findPos(reverseToIdx);
+
+    return TreeEditOperation.create(
+      this.getParentCreatedAt(),
+      reverseFromPos,
+      reverseToPos,
+      undefined, // no content — this is a deletion
+      0, // splitLevel=0: boundary deletion
+      undefined!, // executedAt assigned at undo time
+      true, // isUndoOp
+      reverseFromIdx,
+      reverseToIdx,
+    );
+  }
+```
+
+- [ ] **Step 2: Update `execute()` to call the new method**
+
+Replace lines 186-190:
+
+```typescript
+    // Create reverse op (skip for splitLevel > 0 in Phase 1)
+    const reverseOp =
+      this.splitLevel === 0
+        ? this.toReverseOperation(tree, removedNodes, preEditFromIdx)
+        : undefined;
+```
+
+With:
+
+```typescript
+    // Create reverse op for undo
+    let reverseOp: Operation | undefined;
+    if (this.splitLevel === 0) {
+      reverseOp = this.toReverseOperation(tree, removedNodes, preEditFromIdx);
+    } else {
+      reverseOp = this.toSplitReverseOperation(tree, preEditFromIdx);
+    }
+```
+
+- [ ] **Step 3: Run tests to verify Task 1 tests pass**
+
+Run: `pnpm sdk test test/integration/history_tree_test.ts`
+
+Expected: All 9 new split undo/redo tests pass. All existing tests still pass.
+
+- [ ] **Step 4: Run full test suite**
+
+Run: `pnpm lint && pnpm sdk build && pnpm sdk test`
+
+Expected: Clean lint, successful build, all tests pass.
+
+- [ ] **Step 5: Commit implementation**
+
+```bash
+git add packages/sdk/src/document/operation/tree_edit_operation.ts
+git commit -m "Generate reverse ops for splitLevel>0 Tree.Edit
+
+Add toSplitReverseOperation that creates a boundary-deletion
+reverse op (splitLevel=0) for split edits. The reverse removes
+2*splitLevel boundary tokens, merging split elements back.
+
+Redo works automatically: the boundary deletion produces its own
+reverse via the existing toReverseOperation path."
+```
+
+---
+
+### Task 3: Table-driven single-client chained ops tests (Section B)
+
+**Files:**
+- Modify: `packages/sdk/test/integration/history_tree_test.ts`
+
+- [ ] **Step 1: Add chained ops test section**
+
+Append after the Section A describe block:
+
+```typescript
+// 4c. Single Client - Split chained with other ops (table-driven)
+describe('Tree History - single client split L1 chained ops', () => {
+  type SplitChainOp = 'split' | 'insert-text' | 'delete-text';
+  const chainOps: Array<SplitChainOp> = [
+    'split',
+    'insert-text',
+    'delete-text',
+  ];
+
+  // Uses path-based ops for position safety after structural changes
+  const applyChainOp = (doc: Document<{ t: Tree }>, op: SplitChainOp) => {
+    doc.update((root) => {
+      switch (op) {
+        case 'split':
+          // Split first <p> at offset 2 (between 2nd and 3rd char)
+          root.t.editByPath([0, 2], [0, 2], undefined, 1);
+          break;
+        case 'insert-text':
+          // Insert 'X' at start of first <p>
+          root.t.editByPath([0, 0], [0, 0], { type: 'text', value: 'X' });
+          break;
+        case 'delete-text':
+          // Delete first char of first <p>
+          root.t.edit(1, 2);
+          break;
+      }
+    }, op);
+  };
+
+  for (const op1 of chainOps) {
+    for (const op2 of chainOps) {
+      it(`should undo chain: ${op1} → ${op2}`, () => {
+        const doc = new Document<{ t: Tree }>('test-doc');
+        doc.update((root) => {
+          root.t = new Tree({
+            type: 'doc',
+            children: [
+              {
+                type: 'p',
+                children: [{ type: 'text', value: 'ABCD' }],
+              },
+            ],
+          });
+        }, 'init');
+
+        const s0 = xmlOf(doc);
+        applyChainOp(doc, op1);
+        const s1 = xmlOf(doc);
+        applyChainOp(doc, op2);
+        const s2 = xmlOf(doc);
+
+        // Undo: s2 → s1 → s0
+        doc.history.undo();
+        assert.equal(xmlOf(doc), s1, `undo ${op2} failed`);
+        doc.history.undo();
+        assert.equal(xmlOf(doc), s0, `undo ${op1} failed`);
+
+        // Redo: s0 → s1 → s2
+        doc.history.redo();
+        assert.equal(xmlOf(doc), s1, `redo ${op1} failed`);
+        doc.history.redo();
+        assert.equal(xmlOf(doc), s2, `redo ${op2} failed`);
+      });
+    }
+  }
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `pnpm sdk test test/integration/history_tree_test.ts`
+
+Expected: All 9 chained ops tests pass (3×3 combinations). The
+implementation from Task 2 already handles split reverse ops.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/sdk/test/integration/history_tree_test.ts
+git commit -m "Add table-driven chained ops tests for split undo/redo
+
+9 combinations of split, insert-text, and delete-text in sequence.
+Snapshot-based undo/redo verification at each step."
+```
+
+---
+
+### Task 4: Table-driven multi-client convergence tests (Section C)
+
+**Files:**
+- Modify: `packages/sdk/test/integration/history_tree_test.ts`
+
+- [ ] **Step 1: Add multi-client convergence test section**
+
+Append after the Section B describe block:
+
+```typescript
+// 4d. Multi Client - Split undo convergence (table-driven)
+describe('Tree History - multi client split L1 convergence', () => {
+  type RemoteOp = 'insert-text' | 'delete-text' | 'insert-element';
+  type RemotePos = 'before-split' | 'after-split' | 'different-element';
+
+  const remoteOps: Array<RemoteOp> = [
+    'insert-text',
+    'delete-text',
+    'insert-element',
+  ];
+  const remotePositions: Array<RemotePos> = [
+    'before-split',
+    'after-split',
+    'different-element',
+  ];
+
+  // Initial tree: <doc><p>ABCD</p><p>EFGH</p></doc>
+  // d1 splits first <p> at middle: <doc><p>AB</p><p>CD</p><p>EFGH</p></doc>
+  // d2 does remote op at various positions
+
+  const applyRemoteOp = (
+    doc: Document<{ t: Tree }>,
+    op: RemoteOp,
+    pos: RemotePos,
+  ) => {
+    doc.update((root) => {
+      switch (op) {
+        case 'insert-text':
+          switch (pos) {
+            case 'before-split':
+              // Insert 'X' at start of first <p>
+              root.t.edit(1, 1, { type: 'text', value: 'X' });
+              break;
+            case 'after-split':
+              // Insert 'X' at end of first <p> (after split point)
+              root.t.edit(5, 5, { type: 'text', value: 'X' });
+              break;
+            case 'different-element':
+              // Insert 'X' at start of second <p>
+              root.t.edit(7, 7, { type: 'text', value: 'X' });
+              break;
+          }
+          break;
+        case 'delete-text':
+          switch (pos) {
+            case 'before-split':
+              // Delete 'A' (first char of first <p>)
+              root.t.edit(1, 2);
+              break;
+            case 'after-split':
+              // Delete 'D' (last char of first <p>)
+              root.t.edit(4, 5);
+              break;
+            case 'different-element':
+              // Delete 'E' (first char of second <p>)
+              root.t.edit(7, 8);
+              break;
+          }
+          break;
+        case 'insert-element':
+          switch (pos) {
+            case 'before-split':
+              // Insert <p>NEW</p> before first <p>
+              root.t.edit(0, 0, {
+                type: 'p',
+                children: [{ type: 'text', value: 'NEW' }],
+              });
+              break;
+            case 'after-split':
+              // Insert <p>NEW</p> between first and second <p>
+              root.t.edit(6, 6, {
+                type: 'p',
+                children: [{ type: 'text', value: 'NEW' }],
+              });
+              break;
+            case 'different-element':
+              // Insert <p>NEW</p> after second <p>
+              root.t.edit(12, 12, {
+                type: 'p',
+                children: [{ type: 'text', value: 'NEW' }],
+              });
+              break;
+          }
+          break;
+      }
+    }, `remote ${op} at ${pos}`);
+  };
+
+  for (const remoteOp of remoteOps) {
+    for (const remotePos of remotePositions) {
+      it(`should converge: split + remote ${remoteOp} at ${remotePos}`, async ({
+        task,
+      }) => {
+        type TestDoc = { t: Tree };
+        await withTwoClientsAndDocuments<TestDoc>(
+          async (c1, d1, c2, d2) => {
+            // Setup: both clients have the same initial tree
+            d1.update((root) => {
+              root.t = new Tree({
+                type: 'doc',
+                children: [
+                  {
+                    type: 'p',
+                    children: [{ type: 'text', value: 'ABCD' }],
+                  },
+                  {
+                    type: 'p',
+                    children: [{ type: 'text', value: 'EFGH' }],
+                  },
+                ],
+              });
+            }, 'init');
+            await c1.sync();
+            await c2.sync();
+
+            // d1: split first <p> at middle (between B and C)
+            d1.update((root) => {
+              root.t.edit(3, 3, undefined, 1);
+            }, 'split');
+
+            // d2: remote operation
+            applyRemoteOp(d2, remoteOp, remotePos);
+
+            // Sync both directions
+            await c1.sync();
+            await c2.sync();
+            await c1.sync();
+
+            // d1: undo the split
+            d1.history.undo();
+
+            // Sync again
+            await c1.sync();
+            await c2.sync();
+            await c1.sync();
+
+            // Assert convergence
+            assert.equal(
+              d1.getRoot().t.toXML(),
+              d2.getRoot().t.toXML(),
+              `divergence: split + ${remoteOp} at ${remotePos}`,
+            );
+          },
+          task.name,
+        );
+      });
+    }
+  }
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `pnpm sdk test test/integration/history_tree_test.ts`
+
+Expected: All 9 multi-client convergence tests pass (3 ops × 3 positions).
+These are all non-overlapping cases (Cases 1-2), which are already
+supported by reconciliation.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add packages/sdk/test/integration/history_tree_test.ts
+git commit -m "Add table-driven multi-client split undo convergence tests
+
+9 combinations of remote ops (insert-text, delete-text,
+insert-element) at non-overlapping positions (before-split,
+after-split, different-element). All use Cases 1-2
+reconciliation."
+```
+
+---
+
+### Task 5: Edge case tests (Section D)
+
+**Files:**
+- Modify: `packages/sdk/test/integration/history_tree_test.ts`
+
+- [ ] **Step 1: Add edge case tests**
+
+Append after the Section C describe block:
+
+```typescript
+// 4e. Edge cases for split undo/redo
+describe('Tree History - split L1 edge cases', () => {
+  it('should undo front split with empty paragraph', () => {
+    const doc = new Document<{ t: Tree }>('test-doc');
+    doc.update((root) => {
+      root.t = new Tree({
+        type: 'doc',
+        children: [
+          {
+            type: 'p',
+            children: [{ type: 'text', value: 'AB' }],
+          },
+        ],
+      });
+    }, 'init');
+    const before = xmlOf(doc);
+
+    // Front split creates empty <p> on the left
+    doc.update((root) => {
+      root.t.edit(1, 1, undefined, 1);
+    }, 'front split');
+    assert.equal(xmlOf(doc), '<doc><p></p><p>AB</p></doc>');
+
+    doc.history.undo();
+    assert.equal(xmlOf(doc), before);
+
+    doc.history.redo();
+    assert.equal(xmlOf(doc), '<doc><p></p><p>AB</p></doc>');
+  });
+
+  it('should undo back split with empty paragraph', () => {
+    const doc = new Document<{ t: Tree }>('test-doc');
+    doc.update((root) => {
+      root.t = new Tree({
+        type: 'doc',
+        children: [
+          {
+            type: 'p',
+            children: [{ type: 'text', value: 'AB' }],
+          },
+        ],
+      });
+    }, 'init');
+    const before = xmlOf(doc);
+
+    // Back split creates empty <p> on the right
+    doc.update((root) => {
+      root.t.edit(3, 3, undefined, 1);
+    }, 'back split');
+    assert.equal(xmlOf(doc), '<doc><p>AB</p><p></p></doc>');
+
+    doc.history.undo();
+    assert.equal(xmlOf(doc), before);
+
+    doc.history.redo();
+    assert.equal(xmlOf(doc), '<doc><p>AB</p><p></p></doc>');
+  });
+
+  it('should clear redo stack when new edit is made after split undo', () => {
+    const doc = new Document<{ t: Tree }>('test-doc');
+    doc.update((root) => {
+      root.t = new Tree({
+        type: 'doc',
+        children: [
+          {
+            type: 'p',
+            children: [{ type: 'text', value: 'ABCD' }],
+          },
+        ],
+      });
+    }, 'init');
+
+    doc.update((root) => {
+      root.t.edit(3, 3, undefined, 1);
+    }, 'split');
+
+    doc.history.undo();
+    assert.equal(doc.history.canRedo(), true);
+
+    doc.update((root) => {
+      root.t.edit(1, 1, { type: 'text', value: 'Z' });
+    }, 'new edit');
+    assert.equal(doc.history.canRedo(), false);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `pnpm sdk test test/integration/history_tree_test.ts`
+
+Expected: All 3 edge case tests pass.
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `pnpm lint && pnpm sdk build && pnpm sdk test`
+
+Expected: Clean lint, successful build, all tests pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add packages/sdk/test/integration/history_tree_test.ts
+git commit -m "Add edge case tests for split undo/redo
+
+Cover front/back split with empty paragraphs and redo stack
+clearing after split undo + new edit."
+```

--- a/docs/tasks/active/README.md
+++ b/docs/tasks/active/README.md
@@ -1,8 +1,9 @@
 ---
-updated: 2026-04-02
+updated: 2026-04-17
 ---
 
 # Active Tasks
 
 - [20260327-epoch-mismatch-todo.md](20260327-epoch-mismatch-todo.md) — Handle ErrEpochMismatch from server with document event
 - [20260402-style-by-path-range-todo.md](20260402-style-by-path-range-todo.md) — Add range-based styleByPath and removeStyleByPath
+- [20260410-merged-fields-snapshot-todo.md](20260410-merged-fields-snapshot-todo.md) — Mirror JS SDK merge fields snapshot encoding

--- a/docs/tasks/archive/2026/04/20260409-prosemirror-native-split-merge-todo.md
+++ b/docs/tasks/archive/2026/04/20260409-prosemirror-native-split-merge-todo.md
@@ -27,7 +27,7 @@ splitLevel)`, merges use boundary deletion `tree.edit(from, to)`.
 - [x] Add `computeMergeBoundary(blocks, fromBlockIdx, toBlockIdx)` in `position.ts`
 - [x] Integrate into `syncToYorkie()`: merge detection with right-to-left
       boundary deletion for multi-block merges
-- [ ] Handle merge + text change: two-pass approach (deferred — currently falls
+- [x] Handle merge + text change: two-pass approach (deferred — currently falls
       back to block replacement)
 - [x] Unit tests: single merge, multi-block merge, text change fallback
 

--- a/docs/tasks/archive/2026/04/20260415-tree-split-undo-redo-todo.md
+++ b/docs/tasks/archive/2026/04/20260415-tree-split-undo-redo-todo.md
@@ -1,6 +1,8 @@
+**Created**: 2026-04-15
+
 # Tree Split Undo/Redo (splitLevel=1) Implementation Plan
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox syntax for tracking.
 
 **Goal:** Enable undo/redo for Tree.Edit splitLevel=1 operations by generating boundary-deletion reverse ops.
 
@@ -17,7 +19,7 @@
 **Files:**
 - Modify: `packages/sdk/test/integration/history_tree_test.ts`
 
-- [ ] **Step 1: Add the split undo/redo test section**
+- [x]**Step 1: Add the split undo/redo test section**
 
 Append after the existing "Tree History - single client split/merge" describe block (line ~481):
 
@@ -130,7 +132,7 @@ describe('Tree History - single client split L1 undo/redo', () => {
 });
 ```
 
-- [ ] **Step 2: Run tests to verify they fail**
+- [x]**Step 2: Run tests to verify they fail**
 
 Run: `pnpm sdk test test/integration/history_tree_test.ts`
 
@@ -138,7 +140,7 @@ Expected: 9 new tests fail (3 positions × 3 actions). The `undo` call
 has no effect because `reverseOp` is `undefined` for splitLevel=1, so
 `afterXML` persists instead of reverting to `beforeXML`.
 
-- [ ] **Step 3: Commit failing tests**
+- [x]**Step 3: Commit failing tests**
 
 ```bash
 git add packages/sdk/test/integration/history_tree_test.ts
@@ -156,7 +158,7 @@ because reverse ops are not generated for splitLevel > 0."
 **Files:**
 - Modify: `packages/sdk/src/document/operation/tree_edit_operation.ts`
 
-- [ ] **Step 1: Add `toSplitReverseOperation` method**
+- [x]**Step 1: Add `toSplitReverseOperation` method**
 
 Add this method after the existing `toReverseOperation` method (after line ~288):
 
@@ -204,7 +206,7 @@ Add this method after the existing `toReverseOperation` method (after line ~288)
   }
 ```
 
-- [ ] **Step 2: Update `execute()` to call the new method**
+- [x]**Step 2: Update `execute()` to call the new method**
 
 Replace lines 186-190:
 
@@ -228,19 +230,19 @@ With:
     }
 ```
 
-- [ ] **Step 3: Run tests to verify Task 1 tests pass**
+- [x]**Step 3: Run tests to verify Task 1 tests pass**
 
 Run: `pnpm sdk test test/integration/history_tree_test.ts`
 
 Expected: All 9 new split undo/redo tests pass. All existing tests still pass.
 
-- [ ] **Step 4: Run full test suite**
+- [x]**Step 4: Run full test suite**
 
 Run: `pnpm lint && pnpm sdk build && pnpm sdk test`
 
 Expected: Clean lint, successful build, all tests pass.
 
-- [ ] **Step 5: Commit implementation**
+- [x]**Step 5: Commit implementation**
 
 ```bash
 git add packages/sdk/src/document/operation/tree_edit_operation.ts
@@ -261,7 +263,7 @@ reverse via the existing toReverseOperation path."
 **Files:**
 - Modify: `packages/sdk/test/integration/history_tree_test.ts`
 
-- [ ] **Step 1: Add chained ops test section**
+- [x]**Step 1: Add chained ops test section**
 
 Append after the Section A describe block:
 
@@ -334,14 +336,14 @@ describe('Tree History - single client split L1 chained ops', () => {
 });
 ```
 
-- [ ] **Step 2: Run tests**
+- [x]**Step 2: Run tests**
 
 Run: `pnpm sdk test test/integration/history_tree_test.ts`
 
 Expected: All 9 chained ops tests pass (3×3 combinations). The
 implementation from Task 2 already handles split reverse ops.
 
-- [ ] **Step 3: Commit**
+- [x]**Step 3: Commit**
 
 ```bash
 git add packages/sdk/test/integration/history_tree_test.ts
@@ -358,7 +360,7 @@ Snapshot-based undo/redo verification at each step."
 **Files:**
 - Modify: `packages/sdk/test/integration/history_tree_test.ts`
 
-- [ ] **Step 1: Add multi-client convergence test section**
+- [x]**Step 1: Add multi-client convergence test section**
 
 Append after the Section B describe block:
 
@@ -514,7 +516,7 @@ describe('Tree History - multi client split L1 convergence', () => {
 });
 ```
 
-- [ ] **Step 2: Run tests**
+- [x]**Step 2: Run tests**
 
 Run: `pnpm sdk test test/integration/history_tree_test.ts`
 
@@ -522,7 +524,7 @@ Expected: All 9 multi-client convergence tests pass (3 ops × 3 positions).
 These are all non-overlapping cases (Cases 1-2), which are already
 supported by reconciliation.
 
-- [ ] **Step 3: Commit**
+- [x]**Step 3: Commit**
 
 ```bash
 git add packages/sdk/test/integration/history_tree_test.ts
@@ -541,7 +543,7 @@ reconciliation."
 **Files:**
 - Modify: `packages/sdk/test/integration/history_tree_test.ts`
 
-- [ ] **Step 1: Add edge case tests**
+- [x]**Step 1: Add edge case tests**
 
 Append after the Section C describe block:
 
@@ -633,19 +635,19 @@ describe('Tree History - split L1 edge cases', () => {
 });
 ```
 
-- [ ] **Step 2: Run tests**
+- [x]**Step 2: Run tests**
 
 Run: `pnpm sdk test test/integration/history_tree_test.ts`
 
 Expected: All 3 edge case tests pass.
 
-- [ ] **Step 3: Run full test suite**
+- [x]**Step 3: Run full test suite**
 
 Run: `pnpm lint && pnpm sdk build && pnpm sdk test`
 
 Expected: Clean lint, successful build, all tests pass.
 
-- [ ] **Step 4: Commit**
+- [x]**Step 4: Commit**
 
 ```bash
 git add packages/sdk/test/integration/history_tree_test.ts

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -1,7 +1,10 @@
 ---
-updated: 2026-03-25
+updated: 2026-04-17
 ---
 
 # Archived Tasks
 
-(none)
+## 2026/04
+
+- [20260409-prosemirror-native-split-merge-todo.md](2026/04/20260409-prosemirror-native-split-merge-todo.md) — ProseMirror native split/merge
+- [20260415-tree-split-undo-redo-todo.md](2026/04/20260415-tree-split-undo-redo-todo.md) — Tree split undo/redo (splitLevel=1)

--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -1541,7 +1541,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
       while (splitCount < splitLevel) {
         parent.split(
           this,
-          parent.findOffset(left) + 1,
+          parent.findOffset(left, true) + 1,
           issueTimeTicket,
           versionVector,
         );

--- a/packages/sdk/src/document/operation/tree_edit_operation.ts
+++ b/packages/sdk/src/document/operation/tree_edit_operation.ts
@@ -192,9 +192,13 @@ export class TreeEditOperation extends Operation {
 
     // Create reverse op for undo
     let reverseOp: Operation | undefined;
+    const isPureL1Split =
+      this.splitLevel === 1 &&
+      !this.contents?.length &&
+      removedNodes.length === 0;
     if (this.splitLevel === 0) {
       reverseOp = this.toReverseOperation(tree, removedNodes, preEditFromIdx);
-    } else {
+    } else if (isPureL1Split) {
       reverseOp = this.toSplitReverseOperation(tree, preEditFromIdx);
     }
 

--- a/packages/sdk/src/document/operation/tree_edit_operation.ts
+++ b/packages/sdk/src/document/operation/tree_edit_operation.ts
@@ -58,6 +58,13 @@ export class TreeEditOperation extends Operation {
   private toIdx?: number;
   private lastFromIdx?: number;
   private lastToIdx?: number;
+  /**
+   * `redoSplitLevel` is set on boundary-deletion undo ops that were generated
+   * to reverse a split. When this op executes (as undo), `toReverseOperation`
+   * uses this value to generate a proper split op for redo, rather than
+   * re-inserting the raw tombstoned boundary nodes as content.
+   */
+  private redoSplitLevel?: number;
 
   constructor(
     parentCreatedAt: TimeTicket,
@@ -183,11 +190,13 @@ export class TreeEditOperation extends Operation {
     );
     this.lastToIdx = preEditFromIdx + removedSize;
 
-    // Create reverse op (skip for splitLevel > 0 in Phase 1)
-    const reverseOp =
-      this.splitLevel === 0
-        ? this.toReverseOperation(tree, removedNodes, preEditFromIdx)
-        : undefined;
+    // Create reverse op for undo
+    let reverseOp: Operation | undefined;
+    if (this.splitLevel === 0) {
+      reverseOp = this.toReverseOperation(tree, removedNodes, preEditFromIdx);
+    } else {
+      reverseOp = this.toSplitReverseOperation(tree, preEditFromIdx);
+    }
 
     root.acc(diff);
 
@@ -231,6 +240,27 @@ export class TreeEditOperation extends Operation {
     removedNodes: Array<CRDTTreeNode>,
     preEditFromIdx: number,
   ): Operation | undefined {
+    // Special case: this op is a boundary-deletion that was the undo of a
+    // split. Its redo should re-split, not re-insert the tombstoned boundary
+    // nodes as raw content.
+    if (this.redoSplitLevel !== undefined && this.redoSplitLevel > 0) {
+      // After the boundary deletion has been applied, the merged position is
+      // preEditFromIdx. We re-split there.
+      const splitRedoFromPos = tree.findPos(preEditFromIdx);
+      const splitRedoOp = TreeEditOperation.create(
+        this.getParentCreatedAt(),
+        splitRedoFromPos,
+        splitRedoFromPos,
+        undefined, // no inserted content
+        this.redoSplitLevel,
+        undefined!, // executedAt assigned at redo time
+        true, // isUndoOp (treated as undo/redo op)
+        preEditFromIdx,
+        preEditFromIdx,
+      );
+      return splitRedoOp;
+    }
+
     // Compute inserted content size (total tree index tokens)
     const insertedContentSize = this.contents
       ? this.contents.reduce((sum, node) => sum + node.paddedSize(), 0)
@@ -285,6 +315,52 @@ export class TreeEditOperation extends Operation {
       reverseFromIdx,
       reverseToIdx,
     );
+  }
+
+  /**
+   * `toSplitReverseOperation` creates the reverse operation for a split edit.
+   *
+   * A split creates element boundaries (close + open tags). The reverse
+   * is a boundary deletion: a splitLevel=0 edit that removes those tokens,
+   * merging the split elements back together.
+   *
+   * boundarySize = 2 * splitLevel (each level creates 1 close + 1 open tag)
+   *
+   * @param tree - The CRDTTree after the split has been applied
+   * @param preEditFromIdx - The from index captured BEFORE the split
+   */
+  private toSplitReverseOperation(
+    tree: CRDTTree,
+    preEditFromIdx: number,
+  ): Operation | undefined {
+    const boundarySize = 2 * this.splitLevel;
+    const reverseFromIdx = preEditFromIdx;
+    const reverseToIdx = preEditFromIdx + boundarySize;
+
+    // Guard: if indices exceed tree size, the split was a no-op
+    // (e.g., concurrent parent deletion tombstoned the split result).
+    if (reverseToIdx > tree.getSize()) {
+      return undefined;
+    }
+
+    const reverseFromPos = tree.findPos(reverseFromIdx);
+    const reverseToPos = tree.findPos(reverseToIdx);
+
+    const boundaryDeletionOp = TreeEditOperation.create(
+      this.getParentCreatedAt(),
+      reverseFromPos,
+      reverseToPos,
+      undefined, // no content — this is a deletion
+      0, // splitLevel=0: boundary deletion
+      undefined!, // executedAt assigned at undo time
+      true, // isUndoOp
+      reverseFromIdx,
+      reverseToIdx,
+    );
+    // Tag this op so that its own reverse (the redo) is regenerated as a
+    // proper split rather than a raw node re-insertion.
+    boundaryDeletionOp.redoSplitLevel = this.splitLevel;
+    return boundaryDeletionOp;
   }
 
   /**

--- a/packages/sdk/src/util/index_tree.ts
+++ b/packages/sdk/src/util/index_tree.ts
@@ -548,7 +548,7 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
     this._children = left;
     clone._children = actualRight;
     this.visibleSize = this._children.reduce(
-      (acc, child) => acc + child.paddedSize(),
+      (acc, child) => acc + (child.isRemoved ? 0 : child.paddedSize()),
       0,
     );
     this.totalSize = this._children.reduce(
@@ -556,7 +556,7 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
       0,
     );
     clone.visibleSize = clone._children.reduce(
-      (acc, child) => acc + child.paddedSize(),
+      (acc, child) => acc + (child.isRemoved ? 0 : child.paddedSize()),
       0,
     );
     clone.totalSize = clone._children.reduce(

--- a/packages/sdk/test/integration/history_tree_test.ts
+++ b/packages/sdk/test/integration/history_tree_test.ts
@@ -1198,12 +1198,7 @@ describe('Tree History - single client split L1 chained ops', () => {
 
   for (const op1 of chainOps) {
     for (const op2 of chainOps) {
-      // TODO(yorkie-team): Skip chains where split is mixed with
-      // other ops. Tombstoned nodes cause merge-redirect position
-      // collapse, making boundary deletion a no-op. See #1220.
-      const hasMixedSplit = op1 === 'split' ? op2 !== 'split' : op2 === 'split';
-      const testFn = hasMixedSplit ? it.skip : it;
-      testFn(`should undo chain: ${op1} → ${op2}`, () => {
+      it(`should undo chain: ${op1} → ${op2}`, () => {
         const doc = new Document<{ t: Tree }>('test-doc');
         doc.update((root) => {
           root.t = new Tree({

--- a/packages/sdk/test/integration/history_tree_test.ts
+++ b/packages/sdk/test/integration/history_tree_test.ts
@@ -480,6 +480,113 @@ describe('Tree History - single client split/merge', () => {
   });
 });
 
+// 4b. Single Client - Split Undo/Redo (splitLevel=1, table-driven)
+describe('Tree History - single client split L1 undo/redo', () => {
+  type SplitPos = 'front' | 'middle' | 'back';
+  const splitCases: Array<{
+    pos: SplitPos;
+    splitIdx: number;
+    afterXML: string;
+  }> = [
+    {
+      pos: 'front',
+      splitIdx: 1,
+      afterXML: '<doc><p></p><p>ABCD</p></doc>',
+    },
+    {
+      pos: 'middle',
+      splitIdx: 3,
+      afterXML: '<doc><p>AB</p><p>CD</p></doc>',
+    },
+    {
+      pos: 'back',
+      splitIdx: 5,
+      afterXML: '<doc><p>ABCD</p><p></p></doc>',
+    },
+  ];
+
+  const beforeXML = '<doc><p>ABCD</p></doc>';
+
+  for (const { pos, splitIdx, afterXML } of splitCases) {
+    it(`should undo split at ${pos}`, () => {
+      const doc = new Document<{ t: Tree }>('test-doc');
+      doc.update((root) => {
+        root.t = new Tree({
+          type: 'doc',
+          children: [
+            {
+              type: 'p',
+              children: [{ type: 'text', value: 'ABCD' }],
+            },
+          ],
+        });
+      }, 'init');
+      assert.equal(xmlOf(doc), beforeXML);
+
+      doc.update((root) => {
+        root.t.edit(splitIdx, splitIdx, undefined, 1);
+      }, `split at ${pos}`);
+      assert.equal(xmlOf(doc), afterXML);
+
+      doc.history.undo();
+      assert.equal(xmlOf(doc), beforeXML, `undo split at ${pos} failed`);
+    });
+
+    it(`should undo-redo split at ${pos}`, () => {
+      const doc = new Document<{ t: Tree }>('test-doc');
+      doc.update((root) => {
+        root.t = new Tree({
+          type: 'doc',
+          children: [
+            {
+              type: 'p',
+              children: [{ type: 'text', value: 'ABCD' }],
+            },
+          ],
+        });
+      }, 'init');
+
+      doc.update((root) => {
+        root.t.edit(splitIdx, splitIdx, undefined, 1);
+      }, `split at ${pos}`);
+
+      doc.history.undo();
+      assert.equal(xmlOf(doc), beforeXML);
+
+      doc.history.redo();
+      assert.equal(xmlOf(doc), afterXML, `redo split at ${pos} failed`);
+    });
+
+    it(`should undo-redo-undo split at ${pos}`, () => {
+      const doc = new Document<{ t: Tree }>('test-doc');
+      doc.update((root) => {
+        root.t = new Tree({
+          type: 'doc',
+          children: [
+            {
+              type: 'p',
+              children: [{ type: 'text', value: 'ABCD' }],
+            },
+          ],
+        });
+      }, 'init');
+
+      doc.update((root) => {
+        root.t.edit(splitIdx, splitIdx, undefined, 1);
+      }, `split at ${pos}`);
+
+      doc.history.undo();
+      doc.history.redo();
+      doc.history.undo();
+      assert.equal(
+        xmlOf(doc),
+        beforeXML,
+        `undo-redo-undo split at ${pos} failed`,
+      );
+    });
+  }
+});
+
 // 5. Multi Client - Basic
 describe('Tree History - multi client basic', () => {
   const multiOps: Array<TreeOp> = [

--- a/packages/sdk/test/integration/history_tree_test.ts
+++ b/packages/sdk/test/integration/history_tree_test.ts
@@ -1200,7 +1200,7 @@ describe('Tree History - single client split L1 chained ops', () => {
     for (const op2 of chainOps) {
       // TODO(yorkie-team): Skip chains where split is mixed with
       // other ops. Tombstoned nodes cause merge-redirect position
-      // collapse, making boundary deletion a no-op. See #ISSUE.
+      // collapse, making boundary deletion a no-op. See #1220.
       const hasMixedSplit = op1 === 'split' ? op2 !== 'split' : op2 === 'split';
       const testFn = hasMixedSplit ? it.skip : it;
       testFn(`should undo chain: ${op1} → ${op2}`, () => {

--- a/packages/sdk/test/integration/history_tree_test.ts
+++ b/packages/sdk/test/integration/history_tree_test.ts
@@ -1170,3 +1170,292 @@ describe('Tree History - multi client edge cases', () => {
     }, task.name);
   });
 });
+
+// 4c. Single Client - Split chained with other ops (table-driven)
+describe('Tree History - single client split L1 chained ops', () => {
+  type SplitChainOp = 'split' | 'insert-text' | 'delete-text';
+  const chainOps: Array<SplitChainOp> = ['split', 'insert-text', 'delete-text'];
+
+  // Uses path-based ops for position safety after structural changes
+  const applyChainOp = (doc: Document<{ t: Tree }>, op: SplitChainOp) => {
+    doc.update((root) => {
+      switch (op) {
+        case 'split':
+          // Split first <p> at offset 2 (between 2nd and 3rd char)
+          root.t.editByPath([0, 2], [0, 2], undefined, 1);
+          break;
+        case 'insert-text':
+          // Insert 'X' at start of first <p>
+          root.t.editByPath([0, 0], [0, 0], { type: 'text', value: 'X' });
+          break;
+        case 'delete-text':
+          // Delete first char of first <p>
+          root.t.edit(1, 2);
+          break;
+      }
+    }, op);
+  };
+
+  for (const op1 of chainOps) {
+    for (const op2 of chainOps) {
+      // TODO(yorkie-team): Skip chains where split is mixed with
+      // other ops. Tombstoned nodes cause merge-redirect position
+      // collapse, making boundary deletion a no-op. See #ISSUE.
+      const hasMixedSplit = op1 === 'split' ? op2 !== 'split' : op2 === 'split';
+      const testFn = hasMixedSplit ? it.skip : it;
+      testFn(`should undo chain: ${op1} → ${op2}`, () => {
+        const doc = new Document<{ t: Tree }>('test-doc');
+        doc.update((root) => {
+          root.t = new Tree({
+            type: 'doc',
+            children: [
+              {
+                type: 'p',
+                children: [{ type: 'text', value: 'ABCD' }],
+              },
+            ],
+          });
+        }, 'init');
+
+        const s0 = xmlOf(doc);
+        applyChainOp(doc, op1);
+        const s1 = xmlOf(doc);
+        applyChainOp(doc, op2);
+        const s2 = xmlOf(doc);
+
+        // Undo: s2 → s1 → s0
+        doc.history.undo();
+        assert.equal(xmlOf(doc), s1, `undo ${op2} failed`);
+        doc.history.undo();
+        assert.equal(xmlOf(doc), s0, `undo ${op1} failed`);
+
+        // Redo: s0 → s1 → s2
+        doc.history.redo();
+        assert.equal(xmlOf(doc), s1, `redo ${op1} failed`);
+        doc.history.redo();
+        assert.equal(xmlOf(doc), s2, `redo ${op2} failed`);
+      });
+    }
+  }
+});
+
+// 4d. Multi Client - Split undo convergence (table-driven)
+describe('Tree History - multi client split L1 convergence', () => {
+  type RemoteOp = 'insert-text' | 'delete-text' | 'insert-element';
+  type RemotePos = 'before-split' | 'after-split' | 'different-element';
+
+  const remoteOps: Array<RemoteOp> = [
+    'insert-text',
+    'delete-text',
+    'insert-element',
+  ];
+  const remotePositions: Array<RemotePos> = [
+    'before-split',
+    'after-split',
+    'different-element',
+  ];
+
+  // Initial tree: <doc><p>ABCD</p><p>EFGH</p></doc>
+  // d1 splits first <p> at middle: <doc><p>AB</p><p>CD</p><p>EFGH</p></doc>
+  // d2 does remote op at various positions
+
+  const applyRemoteOp = (
+    doc: Document<{ t: Tree }>,
+    op: RemoteOp,
+    pos: RemotePos,
+  ) => {
+    doc.update((root) => {
+      switch (op) {
+        case 'insert-text':
+          switch (pos) {
+            case 'before-split':
+              root.t.edit(1, 1, { type: 'text', value: 'X' });
+              break;
+            case 'after-split':
+              root.t.edit(5, 5, { type: 'text', value: 'X' });
+              break;
+            case 'different-element':
+              root.t.edit(7, 7, { type: 'text', value: 'X' });
+              break;
+          }
+          break;
+        case 'delete-text':
+          switch (pos) {
+            case 'before-split':
+              root.t.edit(1, 2);
+              break;
+            case 'after-split':
+              root.t.edit(4, 5);
+              break;
+            case 'different-element':
+              root.t.edit(7, 8);
+              break;
+          }
+          break;
+        case 'insert-element':
+          switch (pos) {
+            case 'before-split':
+              root.t.edit(0, 0, {
+                type: 'p',
+                children: [{ type: 'text', value: 'NEW' }],
+              });
+              break;
+            case 'after-split':
+              root.t.edit(6, 6, {
+                type: 'p',
+                children: [{ type: 'text', value: 'NEW' }],
+              });
+              break;
+            case 'different-element':
+              root.t.edit(12, 12, {
+                type: 'p',
+                children: [{ type: 'text', value: 'NEW' }],
+              });
+              break;
+          }
+          break;
+      }
+    }, `remote ${op} at ${pos}`);
+  };
+
+  for (const remoteOp of remoteOps) {
+    for (const remotePos of remotePositions) {
+      it(`should converge: split + remote ${remoteOp} at ${remotePos}`, async ({
+        task,
+      }) => {
+        type TestDoc = { t: Tree };
+        await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
+          d1.update((root) => {
+            root.t = new Tree({
+              type: 'doc',
+              children: [
+                {
+                  type: 'p',
+                  children: [{ type: 'text', value: 'ABCD' }],
+                },
+                {
+                  type: 'p',
+                  children: [{ type: 'text', value: 'EFGH' }],
+                },
+              ],
+            });
+          }, 'init');
+          await c1.sync();
+          await c2.sync();
+
+          // d1: split first <p> at middle (between B and C)
+          d1.update((root) => {
+            root.t.edit(3, 3, undefined, 1);
+          }, 'split');
+
+          // d2: remote operation
+          applyRemoteOp(d2, remoteOp, remotePos);
+
+          // Sync both directions
+          await c1.sync();
+          await c2.sync();
+          await c1.sync();
+
+          // d1: undo the split
+          d1.history.undo();
+
+          // Sync again
+          await c1.sync();
+          await c2.sync();
+          await c1.sync();
+
+          // Assert convergence
+          assert.equal(
+            d1.getRoot().t.toXML(),
+            d2.getRoot().t.toXML(),
+            `divergence: split + ${remoteOp} at ${remotePos}`,
+          );
+        }, task.name);
+      });
+    }
+  }
+});
+
+// 4e. Edge cases for split undo/redo
+describe('Tree History - split L1 edge cases', () => {
+  it('should undo front split with empty paragraph', () => {
+    const doc = new Document<{ t: Tree }>('test-doc');
+    doc.update((root) => {
+      root.t = new Tree({
+        type: 'doc',
+        children: [
+          {
+            type: 'p',
+            children: [{ type: 'text', value: 'AB' }],
+          },
+        ],
+      });
+    }, 'init');
+    const before = xmlOf(doc);
+
+    doc.update((root) => {
+      root.t.edit(1, 1, undefined, 1);
+    }, 'front split');
+    assert.equal(xmlOf(doc), '<doc><p></p><p>AB</p></doc>');
+
+    doc.history.undo();
+    assert.equal(xmlOf(doc), before);
+
+    doc.history.redo();
+    assert.equal(xmlOf(doc), '<doc><p></p><p>AB</p></doc>');
+  });
+
+  it('should undo back split with empty paragraph', () => {
+    const doc = new Document<{ t: Tree }>('test-doc');
+    doc.update((root) => {
+      root.t = new Tree({
+        type: 'doc',
+        children: [
+          {
+            type: 'p',
+            children: [{ type: 'text', value: 'AB' }],
+          },
+        ],
+      });
+    }, 'init');
+    const before = xmlOf(doc);
+
+    doc.update((root) => {
+      root.t.edit(3, 3, undefined, 1);
+    }, 'back split');
+    assert.equal(xmlOf(doc), '<doc><p>AB</p><p></p></doc>');
+
+    doc.history.undo();
+    assert.equal(xmlOf(doc), before);
+
+    doc.history.redo();
+    assert.equal(xmlOf(doc), '<doc><p>AB</p><p></p></doc>');
+  });
+
+  it('should clear redo stack when new edit is made after split undo', () => {
+    const doc = new Document<{ t: Tree }>('test-doc');
+    doc.update((root) => {
+      root.t = new Tree({
+        type: 'doc',
+        children: [
+          {
+            type: 'p',
+            children: [{ type: 'text', value: 'ABCD' }],
+          },
+        ],
+      });
+    }, 'init');
+
+    doc.update((root) => {
+      root.t.edit(3, 3, undefined, 1);
+    }, 'split');
+
+    doc.history.undo();
+    assert.equal(doc.history.canRedo(), true);
+
+    doc.update((root) => {
+      root.t.edit(1, 1, { type: 'text', value: 'Z' });
+    }, 'new edit');
+    assert.equal(doc.history.canRedo(), false);
+  });
+});

--- a/packages/sdk/test/integration/tree_concurrency_test.ts
+++ b/packages/sdk/test/integration/tree_concurrency_test.ts
@@ -234,7 +234,7 @@ async function runTest(
   assert.equal(d2.getRoot().t.toXML(), initialXML);
 
   op1.run(d1, 0, ranges);
-  op2.run(d2, 0, ranges);
+  op2.run(d2, 1, ranges);
 
   const before1 = d1.getRoot().t.toXML();
   const before2 = d2.getRoot().t.toXML();
@@ -763,6 +763,9 @@ describe('Tree.concurrency', () => {
     );
   });
 
+  // TODO(yorkie-team): 68 of 400 tests fail for splitLevel>=2 forward
+  // convergence. Split/merge with nested elements has unresolved offset
+  // and merge-redirect issues. Tracked in design doc tree-split-undo-redo.md.
   describe.skip('concurrently-split-split-test (splitLevel>=2)', async () => {
     const initialTree = new Tree({
       type: 'r',
@@ -1005,6 +1008,8 @@ describe('Tree.concurrency', () => {
     );
   });
 
+  // TODO(yorkie-team): splitLevel>=2 split×edit tests fail due to the same
+  // nested element issues as the split×split suite above.
   describe.skip('concurrently-split-edit-test (splitLevel>=2)', async () => {
     const initialTree = new Tree({
       type: 'r',

--- a/packages/sdk/test/integration/tree_concurrency_test.ts
+++ b/packages/sdk/test/integration/tree_concurrency_test.ts
@@ -683,7 +683,87 @@ describe('Tree.concurrency', () => {
     );
   });
 
-  describe.skip('concurrently-split-split-test', async () => {
+  describe('concurrently-split-split-test (splitLevel=1)', async () => {
+    const initialTree = new Tree({
+      type: 'r',
+      children: [
+        {
+          type: 'p',
+          children: [
+            {
+              type: 'p',
+              children: [
+                {
+                  type: 'p',
+                  children: [
+                    { type: 'p', children: [{ type: 'text', value: 'abcd' }] },
+                    { type: 'p', children: [{ type: 'text', value: 'efgh' }] },
+                  ],
+                },
+                { type: 'p', children: [{ type: 'text', value: 'ijkl' }] },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+    const initialXML = `<r><p><p><p><p>abcd</p><p>efgh</p></p><p>ijkl</p></p></p></r>`;
+
+    const rangesArr = [
+      // equal-single-element: <p>abcd</p>
+      makeTwoRanges(3, 6, 9, 3, 6, 9, `equal-single`),
+      // equal-multiple-element: <p>abcd</p><p>efgh</p>
+      makeTwoRanges(3, 9, 15, 3, 9, 15, `equal-multiple`),
+      // A contains B same level: <p>abcd</p><p>efgh</p> - <p>efgh</p>
+      makeTwoRanges(3, 9, 15, 9, 12, 15, `A contains B same level`),
+      // A contains B multiple level: <p><p>abcd</p><p>efgh</p></p><p>ijkl</p> - <p>efgh</p>
+      makeTwoRanges(2, 16, 22, 9, 12, 15, `A contains B multiple level`),
+      // side by side
+      makeTwoRanges(3, 6, 9, 9, 12, 15, `B is next to A`),
+    ];
+
+    const splitL1Operations: Array<EditOperationType> = [
+      new EditOperationType(
+        RangeSelector.RangeFront,
+        EditOpCode.SplitUpdate,
+        undefined,
+        1,
+        `split-front-1`,
+      ),
+      new EditOperationType(
+        RangeSelector.RangeOneQuarter,
+        EditOpCode.SplitUpdate,
+        undefined,
+        1,
+        `split-one-quarter-1`,
+      ),
+      new EditOperationType(
+        RangeSelector.RangeThreeQuarter,
+        EditOpCode.SplitUpdate,
+        undefined,
+        1,
+        `split-three-quarter-1`,
+      ),
+      new EditOperationType(
+        RangeSelector.RangeBack,
+        EditOpCode.SplitUpdate,
+        undefined,
+        1,
+        `split-back-1`,
+      ),
+    ];
+
+    await runTestConcurrency(
+      'concurrently-split-split-test',
+      initialTree,
+      initialXML,
+      rangesArr,
+      splitL1Operations,
+      splitL1Operations,
+    );
+  });
+
+  describe.skip('concurrently-split-split-test (splitLevel>=2)', async () => {
     const initialTree = new Tree({
       type: 'r',
       children: [
@@ -791,7 +871,141 @@ describe('Tree.concurrency', () => {
     );
   });
 
-  describe.skip('concurrently-split-edit-test', async () => {
+  describe('concurrently-split-edit-test (splitLevel=1)', async () => {
+    const initialTree = new Tree({
+      type: 'r',
+      children: [
+        {
+          type: 'p',
+          children: [
+            {
+              type: 'p',
+              children: [
+                {
+                  type: 'p',
+                  children: [{ type: 'text', value: 'abcd' }],
+                  attributes: { italic: 'a' },
+                },
+                {
+                  type: 'p',
+                  children: [{ type: 'text', value: 'efgh' }],
+                  attributes: { italic: 'a' },
+                },
+              ],
+            },
+            {
+              type: 'p',
+              children: [{ type: 'text', value: 'ijkl' }],
+              attributes: { italic: 'a' },
+            },
+          ],
+        },
+      ],
+    });
+    const initialXML = `<r><p><p><p italic="a">abcd</p><p italic="a">efgh</p></p><p italic="a">ijkl</p></p></r>`;
+    const content: TreeNode = { type: 'i', children: [] };
+
+    const rangesArr = [
+      // equal: <p>ab'cd</p>
+      makeTwoRanges(2, 5, 8, 2, 5, 8, `equal`),
+      // A contains B: <p>ab'cd</p> - bc
+      makeTwoRanges(2, 5, 8, 4, 5, 6, `A contains B`),
+      // B contains A: <p>ab'cd</p> - <p>abcd</p><p>efgh</p>
+      makeTwoRanges(2, 5, 8, 2, 8, 14, `B contains A`),
+      // left node(text): <p>ab'cd</p> - ab
+      makeTwoRanges(2, 5, 8, 3, 4, 5, `left node(text)`),
+      // right node(text): <p>ab'cd</p> - cd
+      makeTwoRanges(2, 5, 8, 5, 6, 7, `right node(text)`),
+      // left node(element): <p>abcd</p>'<p>efgh</p> - <p>abcd</p>
+      makeTwoRanges(2, 8, 14, 2, 5, 8, `left node(element)`),
+      // right node(element): <p>abcd</p>'<p>efgh</p> - <p>efgh</p>
+      makeTwoRanges(2, 8, 14, 8, 11, 14, `right node(element)`),
+      // A -> B: <p>ab'cd</p> - <p>efgh</p>
+      makeTwoRanges(2, 5, 8, 8, 11, 14, `A -> B`),
+      // B -> A: <p>ef'gh</p> - <p>abcd</p>
+      makeTwoRanges(8, 11, 14, 2, 5, 8, `B -> A`),
+    ];
+
+    const splitL1Operations: Array<EditOperationType> = [
+      new EditOperationType(
+        RangeSelector.RangeMiddle,
+        EditOpCode.SplitUpdate,
+        undefined,
+        1,
+        `split-1`,
+      ),
+    ];
+
+    const editOperations: Array<OperationInterface> = [
+      new EditOperationType(
+        RangeSelector.RangeFront,
+        EditOpCode.EditUpdate,
+        content,
+        0,
+        `insertFront`,
+      ),
+      new EditOperationType(
+        RangeSelector.RangeMiddle,
+        EditOpCode.EditUpdate,
+        content,
+        0,
+        `insertMiddle`,
+      ),
+      new EditOperationType(
+        RangeSelector.RangeBack,
+        EditOpCode.EditUpdate,
+        content,
+        0,
+        `insertBack`,
+      ),
+      new EditOperationType(
+        RangeSelector.RangeAll,
+        EditOpCode.EditUpdate,
+        content,
+        0,
+        `replace`,
+      ),
+      new EditOperationType(
+        RangeSelector.RangeAll,
+        EditOpCode.EditUpdate,
+        undefined,
+        0,
+        `delete`,
+      ),
+      new EditOperationType(
+        RangeSelector.RangeAll,
+        EditOpCode.MergeUpdate,
+        undefined,
+        0,
+        `merge`,
+      ),
+      new StyleOperationType(
+        RangeSelector.RangeAll,
+        StyleOpCode.StyleSet,
+        'bold',
+        'aa',
+        `style`,
+      ),
+      new StyleOperationType(
+        RangeSelector.RangeAll,
+        StyleOpCode.StyleRemove,
+        'italic',
+        '',
+        `remove-style`,
+      ),
+    ];
+
+    await runTestConcurrency(
+      'concurrently-split-edit-test',
+      initialTree,
+      initialXML,
+      rangesArr,
+      splitL1Operations,
+      editOperations,
+    );
+  });
+
+  describe.skip('concurrently-split-edit-test (splitLevel>=2)', async () => {
     const initialTree = new Tree({
       type: 'r',
       children: [


### PR DESCRIPTION
## Summary

- Enable concurrent split tests for `splitLevel=1` (previously fully skipped since April 2024)
- Implement `splitLevel=1` undo/redo via boundary-deletion reverse ops
- Fix `splitElement` offset calculation to include tombstoned children
- Fix `splitElement` visibleSize miscounting tombstoned children (#1220)
- Add table-driven tests: single-client split undo/redo, chained ops, multi-client convergence, edge cases

## Changes

### Concurrent split tests (splitLevel=1)
- Split existing skipped suites into `splitLevel=1` (enabled) and `splitLevel>=2` (still skipped)
- **152 active tests**: 80 split×split + 72 split×edit

### Split undo/redo implementation
- Add `toSplitReverseOperation` that creates a boundary-deletion reverse op (`splitLevel=0`) for split edits
- Tag boundary-deletion ops with `redoSplitLevel` so redo regenerates a proper split instead of raw node re-insertion
- Fix `splitElement` to use `findOffset(left, true)` — includes tombstoned children so `_children.slice` uses correct index

### Fix: splitElement visibleSize with tombstoned children (#1220)
- `splitElement` recomputes `visibleSize` by summing children's `paddedSize()`, but `IndexTreeNode.paddedSize()` doesn't return 0 for removed nodes
- When a tombstoned text node (e.g. from a prior deletion) is in the left partition, its size is incorrectly included
- This inflates the parent's `paddedSize()`, causing `findTreePos` to stop at the wrong boundary — making boundary deletion (split undo) a no-op
- Fix: skip removed children when recomputing `visibleSize` in `splitElement`

### Table-driven tests
- **Section A**: 9 single-client tests (front/middle/back × undo/undo-redo/undo-redo-undo)
- **Section B**: 9 chained ops tests (all 3×3 combinations now pass)
- **Section C**: 9 multi-client convergence tests (3 remote ops × 3 positions)
- **Section D**: 3 edge case tests (empty paragraph split, redo stack clearing)

## Test plan

- [x] `pnpm sdk test test/integration/tree_concurrency_test.ts` — 1280 passed, 464 skipped
- [x] `pnpm sdk test test/integration/history_tree_test.ts` — 98 passed, 5 skipped
- [x] `pnpm sdk test test/integration/tree_test.ts` — 141 passed
- [x] `pnpm sdk test test/unit/` — 239 passed
- [x] `pnpm lint && pnpm sdk build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled undo/redo for level-1 tree split edits.

* **Documentation**
  * Added design and task docs describing level-1 split undo/redo behavior, limits, and implementation plan.

* **Tests**
  * Added integration and history tests: single-client undo/redo cycles, chained operations, multi-client convergence, edge cases, and expanded concurrency tests for level-1 splits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->