### PR TITLE
Add content correctness tests for overlapping undo

### DIFF
--- a/packages/sdk/test/integration/history_text_test.ts
+++ b/packages/sdk/test/integration/history_text_test.ts
@@ -702,7 +702,7 @@ describe('Text History - reconcile cases', () => {
   // mechanism. Fixing it requires either:
   // - Resurrect (un-tombstone) instead of re-insert, or
   // - Node-ID-based overlap detection to suppress redundant re-inserts
-  it('Case 3 correctness: both undo of overlapping deletes should restore original', async ({
+  it.skip('Case 3 correctness: both undo of overlapping deletes should restore original', async ({
     task,
   }) => {
     type TestDoc = { t: Text };
@@ -739,7 +739,7 @@ describe('Text History - reconcile cases', () => {
   // Same issue as Case 3: overlapping range produces duplicate content.
   // Case 5: d1 delete [4,8)="4567", d2 delete [2,6)="2345"
   // After both undo: "45" appears twice → "012345456789"
-  it('Case 5 correctness: both undo of partially overlapping deletes should restore original', async ({
+  it.skip('Case 5 correctness: both undo of partially overlapping deletes should restore original', async ({
     task,
   }) => {
     type TestDoc = { t: Text };

--- a/packages/sdk/test/integration/history_text_test.ts
+++ b/packages/sdk/test/integration/history_text_test.ts
@@ -702,7 +702,7 @@ describe('Text History - reconcile cases', () => {
   // mechanism. Fixing it requires either:
   // - Resurrect (un-tombstone) instead of re-insert, or
   // - Node-ID-based overlap detection to suppress redundant re-inserts
-  it.skip('Case 3 correctness: both undo of overlapping deletes should restore original', async ({
+  it('Case 3 correctness: both undo of overlapping deletes should restore original', async ({
     task,
   }) => {
     type TestDoc = { t: Text };
@@ -739,7 +739,7 @@ describe('Text History - reconcile cases', () => {
   // Same issue as Case 3: overlapping range produces duplicate content.
   // Case 5: d1 delete [4,8)="4567", d2 delete [2,6)="2345"
   // After both undo: "45" appears twice → "012345456789"
-  it.skip('Case 5 correctness: both undo of partially overlapping deletes should restore original', async ({
+  it('Case 5 correctness: both undo of partially overlapping deletes should restore original', async ({
     task,
   }) => {
     type TestDoc = { t: Text };

--- a/packages/sdk/test/integration/history_text_test.ts
+++ b/packages/sdk/test/integration/history_text_test.ts
@@ -691,6 +691,87 @@ describe('Text History - reconcile cases', () => {
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
     }, task.name);
   });
+
+  // Correctness tests: overlapping deletes + both undo produces duplicate
+  // content. Both clients converge (same wrong state), but the content
+  // is incorrect — deleted characters are re-inserted twice because each
+  // client's undo deep-copies and re-inserts its own removed content,
+  // creating duplicate nodes for the overlapping range.
+  //
+  // This is a fundamental limitation of the deep-copy re-insert undo
+  // mechanism. Fixing it requires either:
+  // - Resurrect (un-tombstone) instead of re-insert, or
+  // - Node-ID-based overlap detection to suppress redundant re-inserts
+  it.skip('Case 3 correctness: both undo of overlapping deletes should restore original', async ({
+    task,
+  }) => {
+    type TestDoc = { t: Text };
+    await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.t = new Text();
+        root.t.edit(0, 0, '0123456789');
+      }, 'init');
+      await c1.sync();
+      await c2.sync();
+
+      // d1: delete [4,6) = "45", d2: delete [2,8) = "234567"
+      d1.update((root) => root.t.edit(4, 6, ''), 'd1 delete');
+      d2.update((root) => root.t.edit(2, 8, ''), 'd2 delete larger');
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      // Both undo → should fully restore "0123456789"
+      d1.history.undo();
+      d2.history.undo();
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      const d1Text = d1.getRoot().t.toString();
+      const d2Text = d2.getRoot().t.toString();
+      assert.equal(d1Text, d2Text, 'convergence');
+      assert.equal(d1Text, '0123456789', 'content correctness after undo');
+    }, task.name);
+  });
+
+  // Same issue as Case 3: overlapping range produces duplicate content.
+  // Case 5: d1 delete [4,8)="4567", d2 delete [2,6)="2345"
+  // After both undo: "45" appears twice → "012345456789"
+  it.skip('Case 5 correctness: both undo of partially overlapping deletes should restore original', async ({
+    task,
+  }) => {
+    type TestDoc = { t: Text };
+    await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.t = new Text();
+        root.t.edit(0, 0, '0123456789');
+      }, 'init');
+      await c1.sync();
+      await c2.sync();
+
+      // d1: delete [4,8) = "4567", d2: delete [2,6) = "2345" (overlap at "45")
+      d1.update((root) => root.t.edit(4, 8, ''), 'd1 delete');
+      d2.update((root) => root.t.edit(2, 6, ''), 'd2 overlap start');
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      // Both undo → should fully restore "0123456789"
+      d1.history.undo();
+      d2.history.undo();
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      const d1Text = d1.getRoot().t.toString();
+      const d2Text = d2.getRoot().t.toString();
+      assert.equal(d1Text, d2Text, 'convergence');
+      assert.equal(d1Text, '0123456789', 'content correctness after undo');
+    }, task.name);
+  });
 });
 
 describe('Text History - multi client edge cases', () => {


### PR DESCRIPTION
## Summary

- Add 2 correctness tests for Text overlapping undo (Cases 3, 5)
- Tests verify content is correct after both clients undo overlapping deletes, not just convergence
- Both tests fail (marked `skip`) — overlapping undo produces duplicate content

## Problem

Existing reconciliation tests only assert `d1.toSortedJSON() === d2.toSortedJSON()` (convergence). They don't verify the content is actually correct. This masks a fundamental issue:

When two clients delete overlapping ranges and both undo, the shared content is re-inserted twice because each client deep-copies and re-inserts its own removed content as new CRDT nodes.

| Test | d1 delete | d2 delete | Expected after both undo | Actual |
|------|-----------|-----------|--------------------------|--------|
| Case 3 | "45" | "234567" | "0123456789" | "012345674589" |
| Case 5 | "4567" | "2345" | "0123456789" | "012345456789" |

This is the same root cause as Tree's Cases 3-6. Tree additionally has convergence failures (asymmetric integer indices), but the content correctness issue exists in both Text and Tree.

## Root Cause

The undo mechanism deep-copies removed nodes and re-inserts them as **new CRDT nodes**. When undo ranges overlap, the overlapping content gets duplicated. Fixing this requires either:
- **Resurrect (un-tombstone)** semantics instead of re-insert, or
- **Node-ID-based overlap detection** to suppress redundant re-inserts

## Test plan

- [x] 71 existing Text history tests pass
- [x] 2 new tests correctly fail and are marked `skip`
- [x] Lint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added integration tests covering undo behavior in collaborative text editing scenarios with overlapping delete operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->