### PR TITLE
Copy attributes to split node in cloneElement

### DIFF
--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -1248,6 +1248,57 @@ export class CRDTTree extends CRDTElement implements GCParent {
               addDataSizes(diff, curr.getDataSize());
             }
           }
+
+          // Propagate style to unknown split siblings so that a
+          // style operation whose range was determined before the
+          // split also covers the right part of the split.
+          if (tokenType === TokenType.Start && versionVector !== undefined) {
+            let current: CRDTTreeNode = node;
+            while (current.insNextID) {
+              const next = this.findFloorNode(current.insNextID);
+              if (!next || next.isText) {
+                break;
+              }
+              if (ticketKnown(versionVector, next.id.getCreatedAt())) {
+                break;
+              }
+              const siblingPairs = next.setAttrs(attributes, editedAt);
+              const siblingAffectedAttrs = siblingPairs.reduce(
+                (acc: { [key: string]: string }, [, curr]) => {
+                  if (curr) {
+                    acc[curr.getKey()] = attrs[curr.getKey()];
+                  }
+                  return acc;
+                },
+                {},
+              );
+              if (Object.keys(siblingAffectedAttrs).length > 0) {
+                const parentOfNext = next.parent!;
+                const previousNext = next.prevSibling || parentOfNext;
+                changes.push({
+                  type: TreeChangeType.Style,
+                  from: this.toIndex(parentOfNext, previousNext),
+                  to: this.toIndex(next, next),
+                  fromPath: this.toPath(parentOfNext, previousNext),
+                  toPath: this.toPath(next, next),
+                  actor: editedAt.getActorID(),
+                  value: siblingAffectedAttrs,
+                });
+              }
+              for (const [prev] of siblingPairs) {
+                if (prev) {
+                  pairs.push({ parent: next, child: prev });
+                }
+              }
+              for (const [key] of Object.entries(attrs)) {
+                const curr = next.attrs?.getNodeMapByKey().get(key);
+                if (curr !== undefined) {
+                  addDataSizes(diff, curr.getDataSize());
+                }
+              }
+              current = next;
+            }
+          }
         }
       },
     );
@@ -1343,6 +1394,45 @@ export class CRDTTree extends CRDTElement implements GCParent {
             toPath: this.toPath(node, node),
             value: attributesToRemove,
           });
+
+          // Propagate remove-style to unknown split siblings.
+          if (tokenType === TokenType.Start && versionVector !== undefined) {
+            let current: CRDTTreeNode = node;
+            while (current.insNextID) {
+              const next = this.findFloorNode(current.insNextID);
+              if (!next || next.isText) {
+                break;
+              }
+              if (ticketKnown(versionVector, next.id.getCreatedAt())) {
+                break;
+              }
+              if (!next.attrs) {
+                next.attrs = new RHT();
+              }
+              let removedAny = false;
+              for (const value of attributesToRemove) {
+                const nodesTobeRemoved = next.attrs.remove(value, editedAt);
+                removedAny = removedAny || nodesTobeRemoved.length > 0;
+                for (const rhtNode of nodesTobeRemoved) {
+                  pairs.push({ parent: next, child: rhtNode });
+                }
+              }
+              if (removedAny) {
+                const parentOfNext = next.parent!;
+                const previousNext = next.prevSibling || parentOfNext;
+                changes.push({
+                  actor: editedAt.getActorID()!,
+                  type: TreeChangeType.RemoveStyle,
+                  from: this.toIndex(parentOfNext, previousNext),
+                  to: this.toIndex(next, next),
+                  fromPath: this.toPath(parentOfNext, previousNext),
+                  toPath: this.toPath(next, next),
+                  value: attributesToRemove,
+                });
+              }
+              current = next;
+            }
+          }
         }
       },
     );

--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -626,7 +626,7 @@ export class CRDTTreeNode
       CRDTTreeNodeID.of(issueTimeTicket(), 0),
       this.type,
       undefined,
-      undefined,
+      this.attrs?.deepcopy(),
       this.removedAt,
     );
   }

--- a/packages/sdk/test/unit/document/crdt/tree_test.ts
+++ b/packages/sdk/test/unit/document/crdt/tree_test.ts
@@ -949,6 +949,33 @@ describe('CRDTTree.Split', function () {
     assert.equal(t.getSize(), 6);
   });
 
+  it('Can split element nodes with attributes', function () {
+    //       0   1 2 3 4 5 6 7 8 9 10 11    12
+    // <root> <p> h e l l o w o r l  d  </p>  </root>
+    const t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
+    const pNode = new CRDTTreeNode(posT(), 'p');
+    pNode.setAttrs({ bold: 'true' }, MTT);
+    t.editT([0, 0], [pNode], 0, timeT(), timeT);
+    t.editT(
+      [1, 1],
+      [new CRDTTreeNode(posT(), 'text', 'helloworld')],
+      0,
+      timeT(),
+      timeT,
+    );
+    assert.deepEqual(
+      t.toXML(),
+      /*html*/ `<root><p bold="true">helloworld</p></root>`,
+    );
+
+    // Split at position 6 (after 'hello'), splitLevel 1.
+    t.editT([6, 6], undefined, 1, timeT(), timeT);
+    assert.deepEqual(
+      t.toXML(),
+      /*html*/ `<root><p bold="true">hello</p><p bold="true">world</p></root>`,
+    );
+  });
+
   it('Can split element nodes multi-level', function () {
     //       0   1   2 3 4    5    6
     // <root> <p> <b> a b </b> </p> </root>

--- a/packages/sdk/test/unit/document/document_size_test.ts
+++ b/packages/sdk/test/unit/document/document_size_test.ts
@@ -30,8 +30,7 @@ describe('Node Size', () => {
     assert.equal(toXML(rightElem!), '<p>world</p>');
   });
 
-  it.skip('split tree node with attribute test', () => {
-    // TODO(raararaara): We need to check if the attributes are copied correctly when splitting elements.
+  it('split tree node with attribute test', () => {
     const attributes = new RHT();
     attributes.set('bold', 'true', ITT);
 


### PR DESCRIPTION
## Summary
- Fix attributes not being copied to the cloned node during `cloneElement` (used by `splitElement`)
- Use `this.attrs?.deepcopy()` instead of `undefined` so both halves retain the same attributes after split
- Propagate style/remove-style to unknown split siblings for convergence: when a style operation's range was determined before a concurrent split, the right part was missed
- 4 previously-failing integration tests (`split-1 × style/remove-style` for `equal` and `B contains A` ranges) now pass

Companion PR to yorkie-team/yorkie#1759

## Test plan
- [x] Unit test `Can split element nodes with attributes` passes
- [x] Integration: `tree_concurrency_test.ts` — 1280 passed, 0 failed (was 1276 passed, 4 failed)
- [x] Build succeeds (`pnpm sdk build`)
- [x] Tested against locally-built yorkie server with the companion fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Element attributes are now properly preserved during cloning and splitting operations.
  * Enhanced attribute handling for split element nodes.

* **Tests**
  * Added test coverage for element splitting with attributes.
  * Enabled previously skipped test for attribute preservation during element operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->