### PR TITLE
Implement toJSON for Bytes and Date primitive types

### DIFF
--- a/packages/sdk/src/document/crdt/primitive.ts
+++ b/packages/sdk/src/document/crdt/primitive.ts
@@ -152,9 +152,14 @@ export class Primitive extends CRDTElement {
     if (this.valueType === PrimitiveType.String) {
       return `"${escapeString(this.value as string)}"`;
     }
+    if (this.valueType === PrimitiveType.Bytes) {
+      const bytes = this.value as Uint8Array;
+      return `"${btoa(String.fromCharCode(...bytes))}"`;
+    }
+    if (this.valueType === PrimitiveType.Date) {
+      return `"${(this.value as Date).toISOString()}"`;
+    }
 
-    // TODO(hackerwins): We need to consider the case where the value is
-    // a byte array and a date.
     return `${this.value}`;
   }
 

--- a/packages/sdk/test/integration/document_test.ts
+++ b/packages/sdk/test/integration/document_test.ts
@@ -1189,7 +1189,7 @@ describe('Document', function () {
         {
           name: 'bytes',
           input: new Uint8Array([1, 2]),
-          expectedJSON: `{"bytes":1,2}`,
+          expectedJSON: `{"bytes":"AQI="}`,
         },
         // {
         //   name: 'Date',

--- a/packages/sdk/test/unit/document/crdt/primitive_test.ts
+++ b/packages/sdk/test/unit/document/crdt/primitive_test.ts
@@ -70,4 +70,15 @@ describe('Primitive', function () {
       assert.deepEqual(valFromBytes, value);
     }
   });
+
+  it('toJSON for Bytes and Date', function () {
+    const bytes = Primitive.of(new Uint8Array([65, 66]), InitialTimeTicket);
+    assert.equal(bytes.toJSON(), '"QUI="');
+
+    const date = Primitive.of(
+      new Date('1995-12-17T03:24:00.000Z'),
+      InitialTimeTicket,
+    );
+    assert.equal(date.toJSON(), '"1995-12-17T03:24:00.000Z"');
+  });
 });


### PR DESCRIPTION
## Summary

- Encode `Bytes` as base64 and `Date` as ISO 8601 in `Primitive.toJSON()`, matching the Go SDK's `Marshal()` behavior
- Previously both fell through to the default `${this.value}` path, producing `[object Uint8Array]` and lossy date strings
- Add unit tests for the new serialization

Fixes https://github.com/yorkie-team/yorkie/issues/422