### PR TITLE
Prevent race conditions between sync loop and detach/deactivate

### DIFF
--- a/packages/sdk/src/client/attachment.ts
+++ b/packages/sdk/src/client/attachment.ts
@@ -48,6 +48,8 @@ export class Attachment<R extends Attachable> {
   private watchStream?: WatchStream;
   private watchLoopTimerID?: ReturnType<typeof setTimeout>;
   private watchAbortController?: AbortController;
+  private syncPromise?: Promise<void>;
+  private _detaching = false;
 
   constructor(
     reconnectStreamDelay: number,
@@ -155,6 +157,56 @@ export class Attachment<R extends Attachable> {
     };
 
     await doLoop();
+  }
+
+  /**
+   * `markDetaching` marks this attachment as being in the process of detaching.
+   * Once marked, the sync loop will skip this attachment.
+   */
+  public markDetaching(): void {
+    this._detaching = true;
+  }
+
+  /**
+   * `isDetaching` returns whether this attachment is being detached.
+   */
+  public isDetaching(): boolean {
+    return this._detaching;
+  }
+
+  /**
+   * `resetDetaching` resets the detaching flag so the attachment can resume
+   * syncing. Used when a detach RPC fails and the document remains attached.
+   */
+  public resetDetaching(): void {
+    this._detaching = false;
+  }
+
+  /**
+   * `setSyncPromise` sets the in-progress sync promise for this attachment.
+   */
+  public setSyncPromise(promise: Promise<void>): void {
+    this.syncPromise = promise;
+  }
+
+  /**
+   * `clearSyncPromise` clears the in-progress sync promise.
+   */
+  public clearSyncPromise(): void {
+    this.syncPromise = undefined;
+  }
+
+  /**
+   * `waitForSyncComplete` waits for any in-progress sync to complete.
+   */
+  public async waitForSyncComplete(): Promise<void> {
+    if (this.syncPromise) {
+      try {
+        await this.syncPromise;
+      } catch {
+        // Ignore sync errors — we just need it to finish
+      }
+    }
   }
 
   /**

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -312,6 +312,7 @@ export class Client {
   private taskQueue: Array<() => Promise<any>>;
   private processing = false;
   private keepalive = false;
+  private deactivating = false;
 
   /**
    * @param rpcAddr - the address of the RPC server.
@@ -395,6 +396,7 @@ export class Client {
 
         this.id = res.clientId;
         this.status = ClientStatus.Activated;
+        this.deactivating = false;
         this.runSyncLoop();
 
         logger.info(`[AC] c:"${this.getKey()}" activated, id:"${this.id}"`);
@@ -431,6 +433,9 @@ export class Client {
       return Promise.resolve();
     }
 
+    // Mark as deactivating immediately so the sync loop exits early.
+    this.deactivating = true;
+
     const task = async () => {
       try {
         await this.rpcClient.deactivateClient(
@@ -444,6 +449,7 @@ export class Client {
         logger.info(`[DC] c"${this.getKey()}" deactivated`);
       } catch (err) {
         logger.error(`[DC] c:"${this.getKey()}" err :`, err);
+        this.deactivating = false;
         await this.handleConnectError(err);
         throw err;
       }
@@ -650,8 +656,14 @@ export class Client {
     }
     doc.update((_, p) => p.clear());
 
+    // Mark as detaching immediately so the sync loop skips this document.
+    attachment.markDetaching();
+
     const task = async () => {
       try {
+        // Wait for any in-progress sync to finish before detaching.
+        await attachment.waitForSyncComplete();
+
         const res = await this.rpcClient.detachDocument(
           {
             clientId: this.id!,
@@ -673,6 +685,7 @@ export class Client {
         return doc;
       } catch (err) {
         logger.error(`[DD] c:"${this.getKey()}" err :`, err);
+        attachment.resetDetaching();
         await this.handleConnectError(err);
         throw err;
       }
@@ -1377,7 +1390,7 @@ export class Client {
    */
   private runSyncLoop(): void {
     const doLoop = async (): Promise<void> => {
-      if (!this.isActive()) {
+      if (!this.isActive() || this.deactivating) {
         logger.debug(`[SL] c:"${this.getKey()}" exit sync loop`);
         this.conditions[ClientCondition.SyncLoop] = false;
         return;
@@ -1387,7 +1400,17 @@ export class Client {
         await this.enqueueTask(async () => {
           const syncs: Array<any> = [];
           for (const [, attachment] of this.attachmentMap) {
+            // Stop syncing if client is being deactivated.
+            if (this.deactivating) {
+              break;
+            }
+
             if (!attachment.needSync(this.channelHeartbeatInterval)) {
+              continue;
+            }
+
+            // Skip documents that are being detached.
+            if (attachment.isDetaching()) {
               continue;
             }
 
@@ -1396,8 +1419,12 @@ export class Client {
               attachment.changeEventReceived = false;
             }
 
-            syncs.push(
-              this.syncInternal(attachment, attachment.syncMode!).catch((e) => {
+            const syncPromise = this.syncInternal(
+              attachment,
+              attachment.syncMode!,
+            )
+              .then(() => {})
+              .catch((e) => {
                 if (isErrorCode(e, Code.ErrUnauthenticated)) {
                   attachment.resource.publish([
                     {
@@ -1422,14 +1449,26 @@ export class Client {
                 }
 
                 throw e;
-              }),
-            );
+              })
+              .finally(() => {
+                attachment.clearSyncPromise();
+              });
+
+            attachment.setSyncPromise(syncPromise);
+            syncs.push(syncPromise);
           }
 
           await Promise.all(syncs);
           setTimeout(doLoop, this.syncLoopDuration);
         });
       } catch (err) {
+        // If the client is deactivating, suppress sync errors from
+        // in-flight RPCs and stop the sync loop quietly.
+        if (this.deactivating) {
+          this.conditions[ClientCondition.SyncLoop] = false;
+          return;
+        }
+
         logger.error(`[SL] c:"${this.getKey()}" sync failed:`, err);
         if (await this.handleConnectError(err)) {
           setTimeout(doLoop, this.retrySyncLoopDelay);

--- a/packages/sdk/test/integration/client_test.ts
+++ b/packages/sdk/test/integration/client_test.ts
@@ -920,4 +920,35 @@ describe.sequential('Client', function () {
     await c1.deactivate();
     await c2.deactivate();
   });
+
+  it('Should not produce document not attached error on detach during sync', async function ({
+    task,
+  }) {
+    // Use a short sync loop to increase the chance of overlap.
+    const c1 = new yorkie.Client({
+      rpcAddr: testRPCAddr,
+      syncLoopDuration: 50,
+      reconnectStreamDelay: 1000,
+    });
+    await c1.activate();
+
+    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
+    const doc = new yorkie.Document<{ key: string }>(docKey);
+    await c1.attach(doc, { syncMode: SyncMode.Realtime });
+
+    // Make a local change so the sync loop has something to push.
+    doc.update((root) => {
+      root.key = 'value';
+    });
+
+    // Detach immediately — the sync loop may be trying to sync concurrently.
+    // Before the fix, this could cause "document not attached" from the server
+    // if the sync RPC arrives after the detach RPC is processed.
+    await c1.detach(doc);
+
+    // Verify the document is properly detached without errors.
+    assert.equal(doc.getStatus(), 'detached');
+
+    await c1.deactivate();
+  });
 });


### PR DESCRIPTION
## Summary

- Fix `document not attached` error caused by race condition between detach and sync loop (#856)
- Fix `client not activated` error caused by race condition between deactivate (keepalive) and sync loop

## Changes

**Detach/Sync race:** Add a `detaching` flag to `Attachment` that is set immediately when detach is requested. The sync loop checks this flag and skips the document. The detach task awaits any in-progress sync before sending the detach RPC.

**Deactivate/Sync race:** Add a `deactivating` flag to `Client` that is set immediately when deactivate is called. The sync loop checks this flag at three points: loop entry, attachment iteration, and error handling. This is especially important for keepalive deactivation during page unload, which bypasses the task queue.

## Test plan

- [x] Add integration test for detach during active sync loop
- [x] All 2238 existing tests pass (42 test files, webhook test excluded due to Docker env)
- [x] Manual test on CodePair: enter/leave documents repeatedly — no `document not attached` or `client not activated` errors

Closes #856

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced document detachment to properly handle concurrent synchronization operations, preventing potential timing-related errors.
  * Improved client deactivation to manage in-flight operations gracefully.

* **Tests**
  * Added integration test for document detachment during active synchronization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->