### PR TITLE
Add DedupCounter parse support in YSON

### DIFF
--- a/packages/sdk/src/document/yson/index.ts
+++ b/packages/sdk/src/document/yson/index.ts
@@ -34,6 +34,7 @@ export type {
   YSONDate as Date,
   YSONBinData as BinData,
   YSONCounter as Counter,
+  YSONDedupCounter as DedupCounter,
 } from './types';
 
 export {
@@ -44,6 +45,7 @@ export {
   isDate,
   isBinData,
   isCounter,
+  isDedupCounter,
   isObject,
 } from './types';
 

--- a/packages/sdk/src/document/yson/parser.ts
+++ b/packages/sdk/src/document/yson/parser.ts
@@ -79,17 +79,18 @@ export function parse<T = YSONValue>(yson: string): T {
  * - `Long(64)` → `{"__yson_type":"Long","__yson_data":64}`
  * - `Date("...")` → `{"__yson_type":"Date","__yson_data":"..."}`
  * - `BinData("...")` → `{"__yson_type":"BinData","__yson_data":"..."}`
+ * - `DedupCounter(Int(15),"b64")` → `{"__yson_type":"DedupCounter","__yson_data":{"__yson_type":"Int","__yson_data":15},"__yson_registers":"b64"}`
  * - `Counter(Int(10))` → `{"__yson_type":"Counter","__yson_data":{"__yson_type":"Int","__yson_data":10}}`
  */
 function preprocessYSON(yson: string): string {
   let result = yson;
 
   // Handle DedupCounter first (compound structure incompatible with general replacements)
-  // DedupCounter(Int(15),"base64...") → {"__yson_type":"DedupCounter","__yson_value":{"__yson_type":"Int","__yson_data":15},"__yson_registers":"base64..."}
+  // DedupCounter(Int(15),"base64...") → {"__yson_type":"DedupCounter","__yson_data":{"__yson_type":"Int","__yson_data":15},"__yson_registers":"base64..."}
   result = result.replace(
     /DedupCounter\(Int\((-?\d+)\),"([^"]+)"\)/g,
     (_, value, registers) => {
-      return `{"__yson_type":"DedupCounter","__yson_value":{"__yson_type":"Int","__yson_data":${value}},"__yson_registers":"${registers}"}`;
+      return `{"__yson_type":"DedupCounter","__yson_data":{"__yson_type":"Int","__yson_data":${value}},"__yson_registers":"${registers}"}`;
     },
   );
 
@@ -183,10 +184,10 @@ function postprocessValue(value: any): YSONValue {
 
   if (
     value.__yson_type === 'DedupCounter' &&
-    typeof value.__yson_value === 'object' &&
+    typeof value.__yson_data === 'object' &&
     typeof value.__yson_registers === 'string'
   ) {
-    const counterValue = postprocessValue(value.__yson_value);
+    const counterValue = postprocessValue(value.__yson_data);
     if (
       typeof counterValue === 'object' &&
       counterValue !== null &&

--- a/packages/sdk/src/document/yson/parser.ts
+++ b/packages/sdk/src/document/yson/parser.ts
@@ -26,6 +26,7 @@ import type {
   YSONDate,
   YSONBinData,
   YSONCounter,
+  YSONDedupCounter,
 } from './types';
 
 /**
@@ -83,7 +84,16 @@ export function parse<T = YSONValue>(yson: string): T {
 function preprocessYSON(yson: string): string {
   let result = yson;
 
-  // Handle Counter type first (as it may contain Int/Long)
+  // Handle DedupCounter first (compound structure incompatible with general replacements)
+  // DedupCounter(Int(15),"base64...") → {"__yson_type":"DedupCounter","__yson_value":{"__yson_type":"Int","__yson_data":15},"__yson_registers":"base64..."}
+  result = result.replace(
+    /DedupCounter\(Int\((-?\d+)\),"([^"]+)"\)/g,
+    (_, value, registers) => {
+      return `{"__yson_type":"DedupCounter","__yson_value":{"__yson_type":"Int","__yson_data":${value}},"__yson_registers":"${registers}"}`;
+    },
+  );
+
+  // Handle Counter type (as it may contain Int/Long)
   // Counter(Int(10)) → {"__yson_type":"Counter","__yson_data":{"__yson_type":"Int","__yson_data":10}}
   result = result.replace(
     /Counter\((Int|Long)\((-?\d+)\)\)/g,
@@ -169,6 +179,30 @@ function postprocessValue(value: any): YSONValue {
       type: 'BinData',
       value: value.__yson_data,
     } as YSONBinData;
+  }
+
+  if (
+    value.__yson_type === 'DedupCounter' &&
+    typeof value.__yson_value === 'object' &&
+    typeof value.__yson_registers === 'string'
+  ) {
+    const counterValue = postprocessValue(value.__yson_value);
+    if (
+      typeof counterValue === 'object' &&
+      counterValue !== null &&
+      'type' in counterValue &&
+      counterValue.type === 'Int'
+    ) {
+      return {
+        type: 'DedupCounter',
+        value: counterValue as YSONInt,
+        registers: value.__yson_registers,
+      } as YSONDedupCounter;
+    }
+    throw new YorkieError(
+      Code.ErrInvalidArgument,
+      'DedupCounter must contain Int',
+    );
   }
 
   if (

--- a/packages/sdk/src/document/yson/types.ts
+++ b/packages/sdk/src/document/yson/types.ts
@@ -168,6 +168,21 @@ export interface YSONCounter {
 }
 
 /**
+ * `YSONDedupCounter` represents a DedupCounter CRDT that uses HyperLogLog
+ * to count unique actors.
+ *
+ * @example
+ * ```typescript
+ * { type: 'DedupCounter', value: { type: 'Int', value: 15 }, registers: 'AQID...' }
+ * ```
+ */
+export interface YSONDedupCounter {
+  type: 'DedupCounter';
+  value: YSONInt;
+  registers: string;
+}
+
+/**
  * `YSONValue` represents any valid YSON value.
  *
  * Can be:
@@ -189,6 +204,7 @@ export type YSONValue =
   | YSONDate
   | YSONBinData
   | YSONCounter
+  | YSONDedupCounter
   | { [key: string]: YSONValue }
   | Array<YSONValue>;
 
@@ -277,6 +293,19 @@ export function isCounter(value: any): value is YSONCounter {
 }
 
 /**
+ * `isDedupCounter` checks if a value is a YSONDedupCounter object.
+ */
+export function isDedupCounter(value: any): value is YSONDedupCounter {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    value.type === 'DedupCounter' &&
+    typeof value.value === 'object' &&
+    typeof value.registers === 'string'
+  );
+}
+
+/**
  * `isObject` checks if a value is a plain YSON object (not a special type).
  */
 export function isObject(value: any): value is { [key: string]: YSONValue } {
@@ -290,6 +319,7 @@ export function isObject(value: any): value is { [key: string]: YSONValue } {
     !isLong(value) &&
     !isDate(value) &&
     !isBinData(value) &&
-    !isCounter(value)
+    !isCounter(value) &&
+    !isDedupCounter(value)
   );
 }

--- a/packages/sdk/test/unit/document/yson_test.ts
+++ b/packages/sdk/test/unit/document/yson_test.ts
@@ -227,6 +227,71 @@ describe('YSON Parser', () => {
     });
   });
 
+  describe('DedupCounter Type', () => {
+    it('should parse DedupCounter with Int and HLL registers', () => {
+      const result = YSON.parse('{"value":DedupCounter(Int(15),"AQIDBA==")}');
+      const obj = result as { value: YSON.YSONValue };
+
+      expect(YSON.isDedupCounter(obj.value)).toBe(true);
+      if (YSON.isDedupCounter(obj.value)) {
+        expect(obj.value.type).toBe('DedupCounter');
+        expect(YSON.isInt(obj.value.value)).toBe(true);
+        expect(obj.value.value.value).toBe(15);
+        expect(obj.value.registers).toBe('AQIDBA==');
+      }
+    });
+
+    it('should parse DedupCounter with zero value', () => {
+      const result = YSON.parse('{"value":DedupCounter(Int(0),"AAAA")}');
+      const obj = result as { value: YSON.YSONValue };
+
+      if (YSON.isDedupCounter(obj.value)) {
+        expect(obj.value.value.value).toBe(0);
+        expect(obj.value.registers).toBe('AAAA');
+      }
+    });
+
+    it('should parse DedupCounter alongside other types', () => {
+      const yson =
+        '{"counter":Counter(Int(10)),"dedup":DedupCounter(Int(5),"dGVzdA==")}';
+      const result = YSON.parse(yson);
+      const obj = result as any;
+
+      expect(YSON.isCounter(obj.counter)).toBe(true);
+      expect(YSON.isDedupCounter(obj.dedup)).toBe(true);
+      if (YSON.isDedupCounter(obj.dedup)) {
+        expect(obj.dedup.value.value).toBe(5);
+        expect(obj.dedup.registers).toBe('dGVzdA==');
+      }
+    });
+
+    it('isDedupCounter should not match Counter', () => {
+      const counter: YSON.Counter = {
+        type: 'Counter',
+        value: { type: 'Int', value: 10 },
+      };
+      expect(YSON.isDedupCounter(counter)).toBe(false);
+    });
+
+    it('isCounter should not match DedupCounter', () => {
+      const dedup: YSON.DedupCounter = {
+        type: 'DedupCounter',
+        value: { type: 'Int', value: 5 },
+        registers: 'AAAA',
+      };
+      expect(YSON.isCounter(dedup)).toBe(false);
+    });
+
+    it('isObject should not match DedupCounter', () => {
+      const dedup: YSON.DedupCounter = {
+        type: 'DedupCounter',
+        value: { type: 'Int', value: 5 },
+        registers: 'AAAA',
+      };
+      expect(YSON.isObject(dedup)).toBe(false);
+    });
+  });
+
   describe('Complex Document', () => {
     it('should parse document with all types', () => {
       const yson = `{
@@ -239,6 +304,7 @@ describe('YSON Parser', () => {
         "bytes": BinData("AQID"),
         "date": Date("2025-01-02T15:04:05.058Z"),
         "counter": Counter(Int(10)),
+        "dedup": DedupCounter(Int(3),"AQID"),
         "text": Text([{"val":"Hello"}]),
         "tree": Tree({"type":"p","children":[{"type":"text","value":"Hello World"}]})
       }`;
@@ -255,6 +321,7 @@ describe('YSON Parser', () => {
       expect(YSON.isBinData(obj.bytes)).toBe(true);
       expect(YSON.isDate(obj.date)).toBe(true);
       expect(YSON.isCounter(obj.counter)).toBe(true);
+      expect(YSON.isDedupCounter(obj.dedup)).toBe(true);
       expect(YSON.isText(obj.text)).toBe(true);
       expect(YSON.isTree(obj.tree)).toBe(true);
     });


### PR DESCRIPTION
## Summary

- Add `YSONDedupCounter` type and `isDedupCounter` type guard for the `DedupCounter(Int(N),"base64...")` YSON format
- Add regex pre-substitution and postprocess handler in YSON parser
- Companion to yorkie-team/yorkie#1774 which added DedupCounter YSON serialization on the server side

## Changes

| File | Change |
|------|--------|
| `yson/types.ts` | `YSONDedupCounter` interface, `isDedupCounter` guard, `YSONValue` union, `isObject` exclusion |
| `yson/parser.ts` | `DedupCounter(Int(N),"base64...")` regex preprocessing + postprocess handler |
| `yson/index.ts` | Export new type and guard |
| `yson_test.ts` | 6 DedupCounter parse tests + complex document test update |

## Test plan

- [x] DedupCounter with Int and HLL registers parses correctly
- [x] DedupCounter with zero value parses correctly
- [x] DedupCounter alongside Counter parses correctly
- [x] `isDedupCounter` does not match Counter
- [x] `isCounter` does not match DedupCounter
- [x] `isObject` does not match DedupCounter
- [x] Complex document with all types including DedupCounter
- [x] All existing YSON tests pass (no regressions)
- [x] `pnpm lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)