### PR TITLE
Port splitLevel>=2 convergence fixes from Go server

### DIFF
--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -647,9 +647,26 @@ export class CRDTTreeNode
     if (split) {
       split.insPrevID = this.id;
       if (this.insNextID) {
-        const insNext = tree.findFloorNode(this.insNextID)!;
-        insNext.insPrevID = split.id;
+        const insNext = tree.findFloorNode(this.insNextID);
         split.insNextID = this.insNextID;
+
+        if (insNext) {
+          insNext.insPrevID = split.id;
+
+          // §7.4 Empty Sibling Re-Parenting: When the existing
+          // InsNext sibling is in a different parent (due to a prior
+          // parent-level split), move the new empty split sibling to
+          // that parent. VV-independent for clone/root consistency.
+          if (
+            !this.isText &&
+            insNext.parent &&
+            insNext.parent !== split.parent &&
+            split.allChildren.length === 0
+          ) {
+            split.parent!.detachChild(split);
+            insNext.parent.insertBefore(split, insNext);
+          }
+        }
       }
       this.insNextID = split.id;
       tree.registerNode(split);
@@ -969,6 +986,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
     node: CRDTTreeNode,
     versionVector?: VersionVector,
     relaxParentCheck = false,
+    skipActorID?: string,
   ): CRDTTreeNode {
     if (!versionVector || !node) {
       return node;
@@ -981,16 +999,21 @@ export class CRDTTree extends CRDTElement implements GCParent {
         break;
       }
 
-      // Skip parent check when relaxParentCheck is true — at ancestor
-      // iterations of the split loop, a concurrent recursive split may
-      // have moved the sibling to a different parent. InsNextID is only
-      // set by splitElement, so its existence is sufficient evidence
-      // of a split sibling (same rationale as hasUnknownSplitSibling).
+      // §7.5: Skip parent check when relaxParentCheck is true — at
+      // ancestor iterations of the split loop, a concurrent recursive
+      // split may have moved the sibling to a different parent.
       if (!relaxParentCheck && next.parent !== current.parent) {
         break;
       }
 
       const actorID = next.id.getCreatedAt().getActorID();
+
+      // §7.7: Stop at siblings created by the current operation's
+      // actor. They are our own split products, not concurrent ones.
+      if (skipActorID !== undefined && actorID === skipActorID) {
+        break;
+      }
+
       const knownLamport = versionVector.get(actorID);
       if (
         knownLamport !== undefined &&
@@ -1485,6 +1508,30 @@ export class CRDTTree extends CRDTElement implements GCParent {
         ? this.advancePastUnknownSplitSiblings(toLeftRaw, versionVector)
         : toLeftRaw;
 
+    // Phase 3: Range Narrowing — when fromLeft and toLeft are in
+    // different parents (due to a concurrent element split), follow
+    // fromLeft's insNextID chain to find a split sibling in toParent
+    // and narrow the traversal range. The original fromParent/fromLeft
+    // are preserved for merge, split, and insert steps.
+    // VV-independent for clone/root consistency.
+    let collectFromParent: CRDTTreeNode = fromParent;
+    let collectFromLeft: CRDTTreeNode = fromLeft;
+    if (fromLeft !== fromParent && fromParent !== toParent) {
+      let current: CRDTTreeNode = fromLeft;
+      while (current.insNextID) {
+        const next = this.findFloorNode(current.insNextID);
+        if (!next || next.isText) {
+          break;
+        }
+        if (next.parent && next.parent === toParent) {
+          collectFromLeft = next;
+          collectFromParent = toParent;
+          break;
+        }
+        current = next;
+      }
+    }
+
     const fromIdx = this.toIndex(fromParent, fromLeft);
     const fromPath = this.toPath(fromParent, fromLeft);
 
@@ -1495,8 +1542,8 @@ export class CRDTTree extends CRDTElement implements GCParent {
     const preTombstoned = new Set<string>();
 
     this.traverseInPosRange(
-      fromParent,
-      fromLeft,
+      collectFromParent,
+      collectFromLeft,
       toParent,
       toLeft,
       ([node, tokenType], ended) => {
@@ -1668,13 +1715,15 @@ export class CRDTTree extends CRDTElement implements GCParent {
       let parent = fromParent;
       let left: CRDTTreeNode = fromLeft;
       while (splitCount < splitLevel) {
-        // Fix 13: Advance past unknown element split siblings at the
-        // current ancestor level with relaxed parent check.
+        // §7.5 Per-Iteration Advance: advance past unknown element
+        // split siblings at the current ancestor level. skipActorID
+        // (§7.7) prevents advancing past own split products.
         if (left !== parent) {
           left = this.advancePastUnknownSplitSiblings(
             left,
             versionVector,
             true,
+            editedAt.getActorID(),
           );
           // If the advance moved left to a node under a different
           // parent, update parent to match.
@@ -1685,35 +1734,10 @@ export class CRDTTree extends CRDTElement implements GCParent {
 
         parent.split(
           this,
-          parent.findOffset(left, true) + 1,
+          left !== parent ? parent.findOffset(left, true) + 1 : 0,
           issueTimeTicket,
           versionVector,
         );
-
-        // Fix 15: After Split(), advance left to the just-created split
-        // sibling so the next iteration's offset places all current-level
-        // split products on the left side of the ancestor split.
-        // Only during concurrent replay (versionVector non-nil).
-        // Only advance when the split sibling was created by a concurrent
-        // operation (unknown to the editing client). If it was created by
-        // this operation, its lamport is in the versionVector and we use
-        // the normal left=parent path.
-        if (versionVector && parent.insNextID) {
-          const splitSibling = this.findFloorNode(parent.insNextID);
-          if (splitSibling && !splitSibling.isText) {
-            const actorID = splitSibling.id.getCreatedAt().getActorID();
-            const knownLamport = versionVector.get(actorID);
-            if (
-              knownLamport === undefined ||
-              knownLamport < splitSibling.id.getCreatedAt().getLamport()
-            ) {
-              left = splitSibling;
-              parent = left.parent! as CRDTTreeNode;
-              splitCount++;
-              continue;
-            }
-          }
-        }
 
         left = parent;
         parent = parent.parent! as CRDTTreeNode;

--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -968,6 +968,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
   private advancePastUnknownSplitSiblings(
     node: CRDTTreeNode,
     versionVector?: VersionVector,
+    relaxParentCheck = false,
   ): CRDTTreeNode {
     if (!versionVector || !node) {
       return node;
@@ -980,9 +981,12 @@ export class CRDTTree extends CRDTElement implements GCParent {
         break;
       }
 
-      // Stop if the sibling has been moved to a different parent
-      // (e.g., by a higher-level concurrent split).
-      if (next.parent !== current.parent) {
+      // Skip parent check when relaxParentCheck is true — at ancestor
+      // iterations of the split loop, a concurrent recursive split may
+      // have moved the sibling to a different parent. InsNextID is only
+      // set by splitElement, so its existence is sufficient evidence
+      // of a split sibling (same rationale as hasUnknownSplitSibling).
+      if (!relaxParentCheck && next.parent !== current.parent) {
         break;
       }
 
@@ -1662,16 +1666,57 @@ export class CRDTTree extends CRDTElement implements GCParent {
     if (splitLevel > 0) {
       let splitCount = 0;
       let parent = fromParent;
-      let left = fromLeft;
+      let left: CRDTTreeNode = fromLeft;
       while (splitCount < splitLevel) {
+        // Fix 13: Advance past unknown element split siblings at the
+        // current ancestor level with relaxed parent check.
+        if (left !== parent) {
+          left = this.advancePastUnknownSplitSiblings(
+            left,
+            versionVector,
+            true,
+          );
+          // If the advance moved left to a node under a different
+          // parent, update parent to match.
+          if (left.parent && left.parent !== parent) {
+            parent = left.parent as CRDTTreeNode;
+          }
+        }
+
         parent.split(
           this,
           parent.findOffset(left, true) + 1,
           issueTimeTicket,
           versionVector,
         );
+
+        // Fix 15: After Split(), advance left to the just-created split
+        // sibling so the next iteration's offset places all current-level
+        // split products on the left side of the ancestor split.
+        // Only during concurrent replay (versionVector non-nil).
+        // Only advance when the split sibling was created by a concurrent
+        // operation (unknown to the editing client). If it was created by
+        // this operation, its lamport is in the versionVector and we use
+        // the normal left=parent path.
+        if (versionVector && parent.insNextID) {
+          const splitSibling = this.findFloorNode(parent.insNextID);
+          if (splitSibling && !splitSibling.isText) {
+            const actorID = splitSibling.id.getCreatedAt().getActorID();
+            const knownLamport = versionVector.get(actorID);
+            if (
+              knownLamport === undefined ||
+              knownLamport < splitSibling.id.getCreatedAt().getLamport()
+            ) {
+              left = splitSibling;
+              parent = left.parent! as CRDTTreeNode;
+              splitCount++;
+              continue;
+            }
+          }
+        }
+
         left = parent;
-        parent = parent.parent!;
+        parent = parent.parent! as CRDTTreeNode;
         splitCount++;
       }
       changes.push({

--- a/packages/sdk/src/util/index_tree.ts
+++ b/packages/sdk/src/util/index_tree.ts
@@ -545,17 +545,25 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
       actualRight.push(child);
     }
 
-    // Fix 16: Move concurrent inserts at the split boundary to the left.
-    // A concurrent insert placed between the split boundary and the next
-    // original child was positioned relative to the pre-split child order.
-    // Its CRDT position (after a left-partition child) means it should
-    // stay in the left partition.
+    // §7.3 Boundary Insert Migration: Move concurrent inserts at the
+    // split boundary to the left. Element split siblings (with insPrevID)
+    // are skipped — they are split products handled by §7.4.
     if (versionVector) {
       const movedToLeft: Array<T> = [];
       const remaining: Array<T> = [];
       let boundaryReached = false;
       for (const child of actualRight) {
         if (!boundaryReached) {
+          // Skip element split siblings — they are split products,
+          // not concurrent inserts. Text split siblings have
+          // deterministic IDs and act as normal boundary markers.
+          if (
+            (child as any).insPrevID !== undefined &&
+            !(child as any).isText
+          ) {
+            remaining.push(child);
+            continue;
+          }
           const actorID = (child as any).id.getCreatedAt().getActorID();
           const knownLamport = versionVector.get(actorID);
           if (

--- a/packages/sdk/src/util/index_tree.ts
+++ b/packages/sdk/src/util/index_tree.ts
@@ -545,6 +545,37 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
       actualRight.push(child);
     }
 
+    // Fix 16: Move concurrent inserts at the split boundary to the left.
+    // A concurrent insert placed between the split boundary and the next
+    // original child was positioned relative to the pre-split child order.
+    // Its CRDT position (after a left-partition child) means it should
+    // stay in the left partition.
+    if (versionVector) {
+      const movedToLeft: Array<T> = [];
+      const remaining: Array<T> = [];
+      let boundaryReached = false;
+      for (const child of actualRight) {
+        if (!boundaryReached) {
+          const actorID = (child as any).id.getCreatedAt().getActorID();
+          const knownLamport = versionVector.get(actorID);
+          if (
+            knownLamport === undefined ||
+            knownLamport < (child as any).id.getCreatedAt().getLamport()
+          ) {
+            movedToLeft.push(child);
+            continue;
+          }
+        }
+        boundaryReached = true;
+        remaining.push(child);
+      }
+      if (movedToLeft.length > 0) {
+        left.push(...movedToLeft);
+        actualRight.length = 0;
+        actualRight.push(...remaining);
+      }
+    }
+
     this._children = left;
     clone._children = actualRight;
     this.visibleSize = this._children.reduce(

--- a/packages/sdk/test/integration/tree_concurrency_test.ts
+++ b/packages/sdk/test/integration/tree_concurrency_test.ts
@@ -763,9 +763,6 @@ describe('Tree.concurrency', () => {
     );
   });
 
-  // TODO(yorkie-team): 68 of 400 tests fail for splitLevel>=2 forward
-  // convergence. Split/merge with nested elements has unresolved offset
-  // and merge-redirect issues. Tracked in design doc tree-split-undo-redo.md.
   describe('concurrently-split-split-test (splitLevel>=2)', async () => {
     const initialTree = new Tree({
       type: 'r',
@@ -1008,8 +1005,6 @@ describe('Tree.concurrency', () => {
     );
   });
 
-  // TODO(yorkie-team): splitLevel>=2 split×edit tests fail due to the same
-  // nested element issues as the split×split suite above.
   describe('concurrently-split-edit-test (splitLevel>=2)', async () => {
     const initialTree = new Tree({
       type: 'r',

--- a/packages/sdk/test/integration/tree_concurrency_test.ts
+++ b/packages/sdk/test/integration/tree_concurrency_test.ts
@@ -766,7 +766,7 @@ describe('Tree.concurrency', () => {
   // TODO(yorkie-team): 68 of 400 tests fail for splitLevel>=2 forward
   // convergence. Split/merge with nested elements has unresolved offset
   // and merge-redirect issues. Tracked in design doc tree-split-undo-redo.md.
-  describe.skip('concurrently-split-split-test (splitLevel>=2)', async () => {
+  describe('concurrently-split-split-test (splitLevel>=2)', async () => {
     const initialTree = new Tree({
       type: 'r',
       children: [
@@ -1010,7 +1010,7 @@ describe('Tree.concurrency', () => {
 
   // TODO(yorkie-team): splitLevel>=2 split×edit tests fail due to the same
   // nested element issues as the split×split suite above.
-  describe.skip('concurrently-split-edit-test (splitLevel>=2)', async () => {
+  describe('concurrently-split-edit-test (splitLevel>=2)', async () => {
     const initialTree = new Tree({
       type: 'r',
       children: [


### PR DESCRIPTION
## Summary

- Port Go server Fixes 13-18 to resolve all `splitLevel >= 2` concurrent divergences
- Mirrors changes from yorkie-team/yorkie#1776
- Design doc: `docs/design/concurrent-merge-split.md` in yorkie repo (restructured by algorithm phase)

### Changes

| Fix | Section | File | Description |
|-----|---------|------|-------------|
| Fix 13 | §7.5 | `tree.ts` | Propagate `advancePastUnknownSplitSiblings` into recursive split loop with relaxed parent check |
| Fix 14 | §7.6 | — | Already present in JS SDK (`findOffset` with `includeRemoved`) |
| Fix 15 | §7.7 | `tree.ts` | `skipActorID` parameter stops advancement at siblings created by the current actor |
| Fix 16 | §7.3 | `index_tree.ts` | Move concurrent inserts at split boundary to left partition; skip element split siblings during boundary scan |
| Fix 17 | §7.4 | `tree.ts` | Move empty split sibling to existing InsNext sibling's parent when parents differ |
| Fix 18 | §3 | `tree.ts` | Narrow traversal range when from/to positions span split parent boundaries |

### Root Cause

The recursive split loop creates element split siblings with non-deterministic IDs (new tickets). These siblings are only discoverable via the `insNextID` chain. Six issues prevented correct convergence — see yorkie-team/yorkie#1776 for details.

## Test plan

- [x] `tree_concurrency_test.ts`: 1744/1744 passed (27 previously skipped now enabled)
- [x] `pnpm sdk build`: pass
- [x] lint-staged: pass

## Squash merge message

```
Port splitLevel>=2 convergence fixes from Go server (Fixes 13-18)

Port six fixes for concurrent splitLevel>=2 divergences from the Go
server: per-iteration split sibling advance with skipActorID (§7.5,
§7.7), boundary insert migration with element sibling skip (§7.3),
empty sibling re-parenting (§7.4), and cross-parent range narrowing
(§3). Enable 27 previously-skipped concurrency tests.

All 1744 tree concurrency tests pass (was 1717 + 27 skipped).
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)