### PR TITLE
Release v0.7.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and Yorkie JS SDK adheres to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+## [v0.7.7] - 2026-04-26
+
+### Added
+
+- Support splitLevel>=2 undo/redo with multi-client convergence by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1234
+- Add DedupCounter parse support in YSON by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1232
+
+### Fixed
+
+- Port splitLevel>=2 convergence fixes from Go server by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1233
+
 ## [v0.7.6] - 2026-04-23
 
 ### Added

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yorkie-js/devtools",
   "displayName": "Yorkie Devtools",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "A browser extension that helps you debug Yorkie.",
   "homepage": "https://yorkie.dev/",
   "scripts": {

--- a/packages/prosemirror/package.json
+++ b/packages/prosemirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/prosemirror",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "ProseMirror binding for Yorkie collaborative editing",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/react",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "A set of hooks and providers for Yorkie JS SDK",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/schema",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Yorkie Schema for Yorkie Document",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/sdk",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "description": "Yorkie JS SDK",
   "main": "./src/yorkie.ts",
   "publishConfig": {


### PR DESCRIPTION
## Changes

### Added
- Support splitLevel>=2 undo/redo with multi-client convergence #1234
- Add DedupCounter parse support in YSON #1232

### Fixed
- Port splitLevel>=2 convergence fixes from Go server #1233

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Undo/redo now works with multi-client convergence in advanced scenarios
  * Added DedupCounter parsing support in YSON

* **Bug Fixes**
  * Fixed convergence issues in advanced split scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->