### PR TITLE
Clear history after attach and make undo/redo no-op on empty stack

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -590,6 +590,10 @@ export class Client {
           });
         }
 
+        // Clear undo/redo stacks so that initialRoot setup operations
+        // are not reachable via undo.
+        doc.clearHistory();
+
         return doc;
       } catch (err) {
         logger.error(`[AD] c:"${this.getKey()}" err :`, err);

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -1395,7 +1395,12 @@ export class Document<
     ]);
   }
 
-  private clearHistory() {
+  /**
+   * `clearHistory` flushes both undo and redo stacks. This is used
+   * after applying a snapshot or initialRoot so that setup operations
+   * are not reachable via undo.
+   */
+  public clearHistory() {
     this.internalHistory.clearRedo();
     this.internalHistory.clearUndo();
   }

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -1973,10 +1973,7 @@ export class Document<
       : this.internalHistory.popRedo();
 
     if (!ops) {
-      throw new YorkieError(
-        Code.ErrRefused,
-        `There is no operation to be ${isUndo ? 'undone' : 'redone'}`,
-      );
+      return;
     }
 
     this.ensureClone();

--- a/packages/sdk/test/integration/document_test.ts
+++ b/packages/sdk/test/integration/document_test.ts
@@ -943,21 +943,9 @@ describe('Document', function () {
       const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
       const doc = new yorkie.Document<TestDoc>(docKey);
 
-      assert.throws(
-        () => {
-          doc.history.undo();
-        },
-        Error,
-        'There is no operation to be undone',
-      );
-
-      assert.throws(
-        () => {
-          doc.history.redo();
-        },
-        Error,
-        'There is no operation to be redone',
-      );
+      // Calling undo/redo with empty stacks should be a no-op
+      doc.history.undo();
+      doc.history.redo();
     });
 
     it('update() that contains undo/redo must throw error', async function ({
@@ -1015,32 +1003,12 @@ describe('Document', function () {
       assert.equal(doc.toSortedJSON(), '{"counter":100}');
 
       for (let i = 0; i < 100; i++) {
-        if (i < 50) {
-          doc.history.undo();
-        } else {
-          assert.throws(
-            () => {
-              doc.history.undo();
-            },
-            Error,
-            'There is no operation to be undone',
-          );
-        }
+        doc.history.undo();
       }
       assert.equal(doc.toSortedJSON(), '{"counter":50}');
 
       for (let i = 0; i < 100; i++) {
-        if (i < 50) {
-          doc.history.redo();
-        } else {
-          assert.throws(
-            () => {
-              doc.history.redo();
-            },
-            Error,
-            'There is no operation to be redone',
-          );
-        }
+        doc.history.redo();
       }
       assert.equal(doc.toSortedJSON(), '{"counter":100}');
     });

--- a/packages/sdk/test/integration/history_tree_test.ts
+++ b/packages/sdk/test/integration/history_tree_test.ts
@@ -1,6 +1,10 @@
 import { describe, it, assert } from 'vitest';
-import { Document, Tree } from '@yorkie-js/sdk/src/yorkie';
-import { withTwoClientsAndDocuments } from '@yorkie-js/sdk/test/integration/integration_helper';
+import yorkie, { Document, Tree } from '@yorkie-js/sdk/src/yorkie';
+import {
+  testRPCAddr,
+  toDocKey,
+  withTwoClientsAndDocuments,
+} from '@yorkie-js/sdk/test/integration/integration_helper';
 
 /**
  * Test State Space:
@@ -2545,4 +2549,79 @@ describe('Tree History - multi client style vs edit/split convergence', () => {
       });
     }
   }
+});
+
+// Verify: attach clears undo stack so initialRoot cannot be undone.
+//
+// Previously, creating a tree via client.attach({ initialRoot }) left the
+// creation on the undo stack. Typing characters and undoing more times
+// than characters typed could revert the tree creation, destroying the doc.
+describe('Tree History - undo past initial tree via initialRoot', () => {
+  it('should not allow undoing past initialRoot after attach', async function ({
+    task,
+  }) {
+    type DocType = { content: Tree };
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    await c1.activate();
+    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
+    const doc = new yorkie.Document<DocType>(docKey);
+
+    // Attach with initialRoot containing a Tree (like wafflebase ensureTree)
+    await c1.attach(doc, {
+      initialRoot: {
+        content: new Tree({
+          type: 'doc',
+          children: [
+            {
+              type: 'block',
+              attributes: { id: 'block-1' },
+              children: [{ type: 'inline', children: [] }],
+            },
+          ],
+        }),
+      },
+    });
+
+    const initialXml = doc.getRoot().content.toXML();
+
+    // After attach, the undo stack should be empty — initialRoot is
+    // not an undoable user action.
+    assert.equal(
+      doc.getUndoStackForTest().length,
+      0,
+      'undo stack should be empty after attach',
+    );
+    assert.equal(doc.history.canUndo(), false);
+
+    // Insert 4 characters one by one (like typing "asdf")
+    for (const ch of ['a', 's', 'd', 'f']) {
+      doc.update((root) => {
+        root.content.editByPath([0, 0, 0], [0, 0, 0], {
+          type: 'text',
+          value: ch,
+        });
+      }, `type '${ch}'`);
+    }
+
+    // Undo 4 times — should revert each character
+    for (let i = 0; i < 4; i++) {
+      assert.equal(doc.history.canUndo(), true);
+      doc.history.undo();
+    }
+    assert.equal(doc.getRoot().content.toXML(), initialXml);
+
+    // 5th undo — should be blocked, tree stays intact
+    assert.equal(
+      doc.history.canUndo(),
+      false,
+      'should not be able to undo past initialRoot',
+    );
+    assert.equal(
+      doc.getRoot().content.toXML(),
+      initialXml,
+      'tree should remain intact',
+    );
+
+    await c1.deactivate();
+  });
 });


### PR DESCRIPTION
## Summary

- Clear undo/redo history after `attach()` so that `initialRoot` setup operations are not reachable via undo
- Make `undo()`/`redo()` a no-op when the stack is empty instead of throwing `YorkieError`

## Motivation

When a document is attached with `initialRoot`, the tree creation goes through `doc.update()` which pushes reverse operations onto the undo stack. If a user undoes enough times, they can revert the `initialRoot` setup itself — for example, a `Tree` field becomes `undefined`, causing "Block not found" crashes in applications.

Also, throwing on empty undo/redo stacks is unnecessarily strict. Most editors simply ignore extra undo/redo calls; forcing callers to always guard with `canUndo()`/`canRedo()` adds boilerplate and error surface.

## Changes

| File | Change |
|------|--------|
| `client.ts` | Call `doc.clearHistory()` after `initialRoot` is applied in `attachDocument()` |
| `document.ts` | Make `clearHistory()` public; change `executeUndoRedo` to return early instead of throwing when stack is empty |
| `document_test.ts` | Update tests to expect no-op instead of throw |
| `history_tree_test.ts` | Add integration test: attach with `initialRoot` Tree → type 4 chars → undo 5 times → tree stays intact |

## Test plan

- [x] New test: `should not allow undoing past initialRoot after attach`
- [x] All `history_tree_test.ts` pass (201 passed, 6 skipped)
- [x] All `history_text_test.ts` and `history_array_test.ts` pass (151 passed, 6 skipped)
- [x] All `document_test.ts` undo/redo and InitialRoot tests pass
- [x] Lint and build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)