### PR TITLE
Reframe isRealtime as alternative, not deprecated

### DIFF
--- a/docs/design/polling-sync-mode.md
+++ b/docs/design/polling-sync-mode.md
@@ -112,10 +112,11 @@ client.attachChannel(channel, { syncMode: SyncMode.Polling });
 client.attach(doc, { syncMode: SyncMode.Polling });
 ```
 
-`isRealtime` continues to map `true → Realtime`, `false → Manual` for
-back-compat. If both `syncMode` and `isRealtime` are provided,
-`syncMode` wins. No runtime warning is emitted; the JSDoc marks
-`isRealtime` as `@deprecated` for IDE hints only.
+`isRealtime` continues to map `true → Realtime`, `false → Manual`. It
+is not deprecated — for the existing two-state choice it remains a
+valid and concise way to opt in. `syncMode` is required only when the
+new `Polling` mode is wanted. If both options are provided, `syncMode`
+wins.
 
 ### Heartbeat / interval defaults
 
@@ -255,7 +256,7 @@ v0.7.x server and vice versa. Rolling deploy is safe.
 | Default mode stays `Realtime` for both resources.                                           | Avoids breaking apps that subscribe to broadcast or rely on real-time document sync. Polling is a deliberate, explicit optimization. |
 | Channel polling default interval is 3s; Realtime is 30s.                                    | In Polling mode the heartbeat carries `sessionCount`, so freshness matters. In Realtime, the stream pushes presence and the heartbeat is only TTL maintenance. |
 | Both Channel and Document polling reuse the existing sync loop.                             | `runSyncLoop` already drives both channel `RefreshChannel` and document `PushPullChanges` via `attachment.needSync()`. Polling adds a time-based branch to `needSync` / `needRealtimeSync` rather than spinning a parallel loop, avoiding two scheduling sources. |
-| `isRealtime` retained without runtime warning.                                              | Behavior unchanged for legacy callers. Deprecation noise has costs and the team chose to skip it. JSDoc `@deprecated` is enough for IDE feedback. |
+| `isRealtime` is retained as a non-deprecated alternative.                                   | `isRealtime` and `syncMode` cover different scopes: `isRealtime` is the original two-state toggle (Realtime/Manual), `syncMode` adds the new `Polling` value. Either works for the original choice; only `syncMode` can express Polling. JSDoc points users to `syncMode` when they want Polling instead of marking `isRealtime` deprecated. |
 | No adaptive polling in v1.                                                                  | Threshold values would be guesswork without production `sessionCount` distribution data. Static 3s already validated. Revisit after running 200K. |
 | No server-side changes.                                                                     | Existing server already handles unary RefreshChannel and PushPullChanges paths. Validated by production 20K benchmark. |
 

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -287,11 +287,16 @@ export interface AttachChannelOptions {
   syncMode?: SyncMode;
 
   /**
-   * `isRealtime` determines whether to automatically watch channel changes
-   * and send heartbeats. If false (manual mode), the client must call sync()
-   * explicitly to refresh the TTL.
-   * Default is true for backward compatibility.
-   * @deprecated Use `syncMode` instead. Kept for back-compat.
+   * `isRealtime` controls whether the SDK opens a watch stream and sends
+   * heartbeats automatically. Default is true.
+   * - `true`: equivalent to `syncMode: SyncMode.Realtime`.
+   * - `false`: equivalent to `syncMode: SyncMode.Manual` — caller must
+   *   invoke `sync()` to refresh the TTL.
+   *
+   * For the new `Polling` mode (recommended for large channels where
+   * broadcast is not needed), use `syncMode: SyncMode.Polling` directly.
+   *
+   * If both `syncMode` and `isRealtime` are set, `syncMode` wins.
    */
   isRealtime?: boolean;
 


### PR DESCRIPTION
#### What this PR does / why we need it?

Removes the \`@deprecated\` JSDoc tag from \`AttachChannelOptions.isRealtime\` that landed with #1243 and rewrites the doc-comment to reflect what \`isRealtime\` actually is: an alternative to \`syncMode\`, not a legacy alias.

\`isRealtime\` (boolean) covers Realtime/Manual — the original two-state choice. \`syncMode\` (enum) covers Realtime/Manual/Polling. The new \`Polling\` value is the only thing \`isRealtime\` cannot express, so \`syncMode\` is needed only when a caller wants Polling (typical trigger: large channels where broadcast is not required and approximate \`sessionCount\` is acceptable). For everything else, either option remains valid.

#### Any background context you want to provide?

- Originally #1243 added \`@deprecated\` on \`isRealtime\`. That contradicts the design intent stated during the PR's review thread, where \`isRealtime\` was meant to stay supported alongside \`syncMode\`. The tag would surface a strikethrough in IDEs and push users away from a perfectly valid form.
- The design doc had two stale rows (one in the API description block, one in the Design Decisions table) that referenced the now-removed tag; both are updated.
- No behavior change. The runtime resolution (\`syncMode > isRealtime > default Realtime\`) is unchanged.

#### What are the relevant tickets?

Follow-up to #1243.

### Checklist
- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything

🤖 Generated with [Claude Code](https://claude.com/claude-code)