### PR TITLE
Drop isRealtime from core SDK, keep it as React-only prop

### DIFF
--- a/docs/design/polling-sync-mode.md
+++ b/docs/design/polling-sync-mode.md
@@ -26,11 +26,11 @@ worth this cost: `sessionCount` is documented as approximate, so the
 similar reasoning applies — receiving CRDT changes within a few seconds
 is fine.
 
-The SDK currently offers two channel modes (`Realtime`, `Manual` via
-`isRealtime`) and four document modes (`Realtime`, `RealtimePushOnly`,
-`RealtimeSyncOff`, `Manual`), all of which open a watch stream in the
-non-Manual cases. There is no mode that runs the heartbeat or sync loop
-without a stream.
+The SDK currently offers two channel modes (`Realtime`, `Manual`) and
+four document modes (`Realtime`, `RealtimePushOnly`, `RealtimeSyncOff`,
+`Manual`), all of which open a watch stream in the non-Manual cases.
+There is no mode that runs the heartbeat or sync loop without a
+stream.
 
 ### Goals
 
@@ -93,7 +93,6 @@ implementation-internal:
 ```ts
 export interface AttachChannelOptions {
   syncMode?: SyncMode;                      // default: Realtime
-  isRealtime?: boolean;                     // legacy; ignored if syncMode is set
   channelHeartbeatInterval?: number;        // default: polling=3000, realtime=30000
 }
 
@@ -112,10 +111,12 @@ client.attachChannel(channel, { syncMode: SyncMode.Polling });
 client.attach(doc, { syncMode: SyncMode.Polling });
 ```
 
-`isRealtime` continues to map `true → Realtime`, `false → Manual` for
-back-compat. If both `syncMode` and `isRealtime` are provided,
-`syncMode` wins. No runtime warning is emitted; the JSDoc marks
-`isRealtime` as `@deprecated` for IDE hints only.
+The legacy `isRealtime` boolean has been removed from
+`AttachChannelOptions`. Use `syncMode: SyncMode.Realtime` (or the
+default) and `syncMode: SyncMode.Manual` for the cases it covered. The
+React SDK's `<ChannelProvider>` keeps `isRealtime` as a convenience
+prop and translates internally to `syncMode`, so React consumers do
+not need code changes for the original two-state choice.
 
 ### Heartbeat / interval defaults
 
@@ -221,20 +222,26 @@ existing server code without modification.
 
 ### Compatibility
 
-No breaking changes. `Realtime` remains the default for both
-resources. All existing call sites are unaffected.
+`Realtime` remains the default for both resources. Direct callers of
+`attachChannel(ch, { isRealtime: ... })` must migrate to `syncMode`.
+The React SDK's `<ChannelProvider isRealtime={...}>` continues to
+work because `ChannelProvider` translates `isRealtime` into `syncMode`
+internally; React consumers do not need code changes for the original
+two-state choice.
 
 | Call pattern                                       | Behavior after change |
 |----------------------------------------------------|----------------------|
 | `attachChannel(ch)`                                | unchanged (Realtime)  |
-| `attachChannel(ch, { isRealtime: true })`          | unchanged             |
-| `attachChannel(ch, { isRealtime: false })`         | unchanged (Manual)    |
+| `attachChannel(ch, { isRealtime: true })`          | **REMOVED** — use `{ syncMode: Realtime }` (or omit) |
+| `attachChannel(ch, { isRealtime: false })`         | **REMOVED** — use `{ syncMode: Manual }` |
 | `attachChannel(ch, { syncMode: Polling })`         | NEW                   |
 | `attach(doc)`                                      | unchanged (Realtime)  |
 | `attach(doc, { syncMode: Polling })`               | NEW                   |
+| `<ChannelProvider isRealtime={...}>` (React)       | unchanged             |
+| `<ChannelProvider syncMode={...}>` (React)         | NEW                   |
 
-Server-client wire format is unchanged, so a v0.8 SDK works against a
-v0.7.x server and vice versa. Rolling deploy is safe.
+Server-client wire format is unchanged, so the new SDK works against
+a v0.7.x server and vice versa. Rolling deploy is safe.
 
 ### Risks and Mitigation
 
@@ -255,7 +262,7 @@ v0.7.x server and vice versa. Rolling deploy is safe.
 | Default mode stays `Realtime` for both resources.                                           | Avoids breaking apps that subscribe to broadcast or rely on real-time document sync. Polling is a deliberate, explicit optimization. |
 | Channel polling default interval is 3s; Realtime is 30s.                                    | In Polling mode the heartbeat carries `sessionCount`, so freshness matters. In Realtime, the stream pushes presence and the heartbeat is only TTL maintenance. |
 | Both Channel and Document polling reuse the existing sync loop.                             | `runSyncLoop` already drives both channel `RefreshChannel` and document `PushPullChanges` via `attachment.needSync()`. Polling adds a time-based branch to `needSync` / `needRealtimeSync` rather than spinning a parallel loop, avoiding two scheduling sources. |
-| `isRealtime` retained without runtime warning.                                              | Behavior unchanged for legacy callers. Deprecation noise has costs and the team chose to skip it. JSDoc `@deprecated` is enough for IDE feedback. |
+| `isRealtime` removed from core SDK; React SDK keeps it as a convenience prop translated to `syncMode`. | `isRealtime` and `syncMode` covered different scopes (boolean two-state vs three-state enum). Keeping both in the core API meant docs had to explain when to use which, while only `syncMode` could express the new `Polling` mode. Removal in the core gives one canonical option there; the React layer keeps `isRealtime` because that prop is widely used in templates and the boolean form is concise for the original Realtime/Manual choice. |
 | No adaptive polling in v1.                                                                  | Threshold values would be guesswork without production `sessionCount` distribution data. Static 3s already validated. Revisit after running 200K. |
 | No server-side changes.                                                                     | Existing server already handles unary RefreshChannel and PushPullChanges paths. Validated by production 20K benchmark. |
 

--- a/examples/nextjs-presence/components/RoomView.tsx
+++ b/examples/nextjs-presence/components/RoomView.tsx
@@ -23,7 +23,7 @@ function RoomView({ roomId, onLeave }: RoomViewProps) {
   }
 
   return (
-    <ChannelProvider channelKey={room.key} isRealtime={true}>
+    <ChannelProvider channelKey={room.key}>
       <div className="room-view">
         <div className="room-view-header">
           <button className="back-button" onClick={onLeave}>

--- a/packages/react/src/ChannelProvider.tsx
+++ b/packages/react/src/ChannelProvider.tsx
@@ -179,7 +179,7 @@ export type ChannelProviderProps = PropsWithChildren<{
  *
  * @example
  * ```tsx
- * import yorkie, { SyncMode } from '@yorkie-js/sdk';
+ * import { ChannelProvider, SyncMode } from '@yorkie-js/react';
  *
  * <YorkieProvider apiKey="..." rpcAddr="...">
  *   <ChannelProvider channelKey="room-123" syncMode={SyncMode.Realtime}>

--- a/packages/react/src/ChannelProvider.tsx
+++ b/packages/react/src/ChannelProvider.tsx
@@ -167,9 +167,8 @@ export type ChannelProviderProps = PropsWithChildren<{
    * - `false`: equivalent to `syncMode={SyncMode.Manual}`.
    *
    * Use `syncMode` directly when you want `SyncMode.Polling`, which this
-   * boolean prop cannot express.
-   *
-   * @default true
+   * boolean prop cannot express. When neither prop is set, the channel
+   * falls back to `SyncMode.Realtime`.
    */
   isRealtime?: boolean;
 }>;
@@ -180,12 +179,17 @@ export type ChannelProviderProps = PropsWithChildren<{
  *
  * @example
  * ```tsx
+ * import yorkie, { SyncMode } from '@yorkie-js/sdk';
+ *
  * <YorkieProvider apiKey="..." rpcAddr="...">
- *   <ChannelProvider channelKey="room-123" isRealtime={true}>
+ *   <ChannelProvider channelKey="room-123" syncMode={SyncMode.Realtime}>
  *     <ChatRoom />
  *   </ChannelProvider>
  * </YorkieProvider>
  * ```
+ *
+ * The boolean `isRealtime` prop is also accepted as a shortcut for
+ * the Realtime/Manual choice (`true` → Realtime, `false` → Manual).
  */
 export const ChannelProvider: React.FC<ChannelProviderProps> = ({
   children,

--- a/packages/react/src/ChannelProvider.tsx
+++ b/packages/react/src/ChannelProvider.tsx
@@ -22,7 +22,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Client, Channel } from '@yorkie-js/sdk';
+import { Client, Channel, SyncMode } from '@yorkie-js/sdk';
 import { Store } from './createStore';
 import {
   createChannelStore as createChannelStore,
@@ -46,7 +46,7 @@ export function useYorkieChannel(
   clientLoading: boolean,
   clientError: Error | undefined,
   channelKey: string,
-  isRealtime: boolean,
+  syncMode: SyncMode,
   channelStore: Store<ChannelContextType>,
 ) {
   const channelRef = useRef<Channel | undefined>(undefined);
@@ -89,7 +89,7 @@ export function useYorkieChannel(
 
       try {
         const newChannel = new Channel(channelKey);
-        await client.attach(newChannel, { isRealtime });
+        await client.attach(newChannel, { syncMode });
 
         channelRef.current = newChannel;
 
@@ -137,7 +137,7 @@ export function useYorkieChannel(
       }
       detachChannel();
     };
-  }, [client, clientLoading, clientError, channelKey, isRealtime, didMount]);
+  }, [client, clientLoading, clientError, channelKey, syncMode, didMount]);
 }
 
 /**
@@ -150,9 +150,25 @@ export type ChannelProviderProps = PropsWithChildren<{
   channelKey: string;
 
   /**
-   * `isRealtime` determines the synchronization mode.
-   * - true: Realtime mode (automatic updates via watch stream)
-   * - false: Manual mode (requires manual sync)
+   * `syncMode` selects how the channel keeps presence in sync with the server.
+   * - `SyncMode.Realtime` (default): open a watch stream and run the
+   *   heartbeat. Required to receive broadcast events.
+   * - `SyncMode.Polling`: heartbeat-only. No watch stream is opened.
+   *   Recommended for large channels where broadcast is not needed.
+   * - `SyncMode.Manual`: no automatic activity.
+   *
+   * If `isRealtime` is also set, `syncMode` wins.
+   */
+  syncMode?: SyncMode;
+
+  /**
+   * `isRealtime` is a convenience prop covering only Realtime/Manual.
+   * - `true`: equivalent to `syncMode={SyncMode.Realtime}`.
+   * - `false`: equivalent to `syncMode={SyncMode.Manual}`.
+   *
+   * Use `syncMode` directly when you want `SyncMode.Polling`, which this
+   * boolean prop cannot express.
+   *
    * @default true
    */
   isRealtime?: boolean;
@@ -174,7 +190,8 @@ export type ChannelProviderProps = PropsWithChildren<{
 export const ChannelProvider: React.FC<ChannelProviderProps> = ({
   children,
   channelKey,
-  isRealtime = true,
+  syncMode,
+  isRealtime,
 }) => {
   const { client, loading: clientLoading, error: clientError } = useYorkie();
 
@@ -193,12 +210,17 @@ export const ChannelProvider: React.FC<ChannelProviderProps> = ({
 
   const channelStore = channelStoreRef.current;
 
+  // Resolve syncMode: explicit syncMode wins, then isRealtime, else Realtime.
+  const resolvedSyncMode: SyncMode =
+    syncMode ??
+    (isRealtime === false ? SyncMode.Manual : SyncMode.Realtime);
+
   useYorkieChannel(
     client,
     clientLoading,
     clientError,
     channelKey,
-    isRealtime,
+    resolvedSyncMode,
     channelStore,
   );
 

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -20,7 +20,7 @@ import type {
   JSONObject,
   RevisionSummary,
 } from '@yorkie-js/sdk';
-import { Tree, Text, Counter } from '@yorkie-js/sdk';
+import { Tree, Text, Counter, SyncMode } from '@yorkie-js/sdk';
 
 import { useYorkieDoc } from './useYorkieDoc';
 import { YorkieProvider } from './YorkieProvider';
@@ -44,6 +44,7 @@ export {
   Tree,
   Text,
   Counter,
+  SyncMode,
   YorkieProvider,
   DocumentProvider,
   useDocument,

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -276,24 +276,15 @@ export interface AttachOptions<R, P> {
 export interface AttachChannelOptions {
   /**
    * `syncMode` selects how the channel keeps presence in sync with the server.
-   * - `SyncMode.Realtime` (default): open a watch stream and run the heartbeat.
-   *   Required to receive broadcast events.
-   * - `SyncMode.Polling`: heartbeat-only. No watch stream is opened. Polling
-   *   refreshes TTL and brings the latest sessionCount.
-   * - `SyncMode.Manual`: no automatic activity. Caller must invoke sync().
-   *
-   * If both `syncMode` and `isRealtime` are set, `syncMode` wins.
+   * Default is `SyncMode.Realtime`.
+   * - `SyncMode.Realtime`: open a watch stream and run the heartbeat. Required
+   *   to receive broadcast events.
+   * - `SyncMode.Polling`: heartbeat-only. No watch stream is opened. The
+   *   heartbeat refreshes TTL and brings the latest sessionCount. Recommended
+   *   for large channels where broadcast is not needed.
+   * - `SyncMode.Manual`: no automatic activity. Caller must invoke `sync()`.
    */
   syncMode?: SyncMode;
-
-  /**
-   * `isRealtime` determines whether to automatically watch channel changes
-   * and send heartbeats. If false (manual mode), the client must call sync()
-   * explicitly to refresh the TTL.
-   * Default is true for backward compatibility.
-   * @deprecated Use `syncMode` instead. Kept for back-compat.
-   */
-  isRealtime?: boolean;
 
   /**
    * `channelHeartbeatInterval` overrides the heartbeat interval (ms) for this
@@ -807,16 +798,7 @@ export class Client {
         channel.updateSessionCount(Number(res.sessionCount), 0);
         channel.applyStatus(ChannelStatus.Attached);
 
-        // Resolve syncMode (explicit > legacy isRealtime > default Realtime).
-        let syncMode: SyncMode;
-        if (opts.syncMode !== undefined) {
-          syncMode = opts.syncMode;
-        } else if (opts.isRealtime !== undefined) {
-          syncMode = opts.isRealtime ? SyncMode.Realtime : SyncMode.Manual;
-        } else {
-          syncMode = SyncMode.Realtime;
-        }
-
+        const syncMode = opts.syncMode ?? SyncMode.Realtime;
         this.assertValidChannelSyncMode(syncMode);
 
         if (

--- a/packages/sdk/test/integration/channel_polling_test.ts
+++ b/packages/sdk/test/integration/channel_polling_test.ts
@@ -144,69 +144,6 @@ describe('Channel Polling', function () {
     await c2.deactivate();
   });
 
-  it('Legacy isRealtime: true keeps Realtime mode (no behavior change)', async function ({
-    task,
-  }) {
-    const channelKey = `${toDocKey(task.name)}-${new Date().getTime()}`;
-
-    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
-    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
-    await c1.activate();
-    await c2.activate();
-
-    const ch1 = new Channel(channelKey);
-    const ch2 = new Channel(channelKey);
-
-    await c1.attachChannel(ch1, { isRealtime: true });
-    await c2.attachChannel(ch2, { isRealtime: true });
-
-    let received: any = null;
-    ch2.subscribe('chat', (event) => {
-      received = event.payload;
-    });
-
-    ch1.broadcast('chat', { msg: 'legacy' });
-    // Wait long enough for stream to deliver.
-    await new Promise((r) => setTimeout(r, 500));
-
-    assert.deepEqual(received, { msg: 'legacy' });
-
-    await c1.detach(ch1);
-    await c2.detach(ch2);
-    await c1.deactivate();
-    await c2.deactivate();
-  });
-
-  it('syncMode wins when both syncMode and isRealtime are set', async function ({
-    task,
-  }) {
-    const channelKey = `${toDocKey(task.name)}-${new Date().getTime()}`;
-
-    const c = new yorkie.Client({ rpcAddr: testRPCAddr });
-    await c.activate();
-
-    const ch = new Channel(channelKey);
-
-    // Conflicting options: syncMode says Polling, isRealtime says true.
-    let watchCalled = false;
-    const origWatch = (c as any).rpcClient.watch.bind((c as any).rpcClient);
-    (c as any).rpcClient.watch = (...args: Array<any>) => {
-      watchCalled = true;
-      return origWatch(...args);
-    };
-
-    await c.attachChannel(ch, {
-      syncMode: SyncMode.Polling,
-      isRealtime: true,
-    });
-
-    await new Promise((r) => setTimeout(r, 100));
-    assert.isFalse(watchCalled);
-
-    await c.detach(ch);
-    await c.deactivate();
-  });
-
   it('attachChannel rejects RealtimePushOnly with ErrInvalidArgument', async function ({
     task,
   }) {

--- a/packages/sdk/test/integration/presence_test.ts
+++ b/packages/sdk/test/integration/presence_test.ts
@@ -220,11 +220,11 @@ describe('Presence', function () {
     const ch2 = new yorkie.Channel(channelKey);
 
     // Attach client1 with manual sync mode (no watch stream)
-    await c1.attach(ch1, { isRealtime: false });
+    await c1.attach(ch1, { syncMode: yorkie.SyncMode.Manual });
     assert.equal(ch1.getSessionCount(), 1);
 
     // Attach client2 with manual sync mode
-    await c2.attach(ch2, { isRealtime: false });
+    await c2.attach(ch2, { syncMode: yorkie.SyncMode.Manual });
     assert.equal(ch2.getSessionCount(), 2);
 
     // In manual mode, p1's count doesn't update automatically
@@ -270,7 +270,7 @@ describe('Presence', function () {
     assert.equal(realtimeCh.getSessionCount(), 1);
 
     // c2: Attach with manual mode
-    await c2.attach(manualCh, { isRealtime: false });
+    await c2.attach(manualCh, { syncMode: yorkie.SyncMode.Manual });
     assert.equal(manualCh.getSessionCount(), 2);
 
     // c1's realtime presence should automatically receive the update
@@ -289,7 +289,7 @@ describe('Presence', function () {
     );
 
     // c3: Attach another client
-    await c3.attach(thirdCh, { isRealtime: false });
+    await c3.attach(thirdCh, { syncMode: yorkie.SyncMode.Manual });
     assert.equal(thirdCh.getSessionCount(), 3);
 
     // c1's realtime presence receives the update automatically


### PR DESCRIPTION
#### What this PR does / why we need it?

Removes \`isRealtime\` from \`AttachChannelOptions\` in the core SDK and migrates the React SDK's \`<ChannelProvider>\` to keep \`isRealtime\` as a convenience prop while routing through \`syncMode\` internally.

\`isRealtime\` is a boolean covering Realtime/Manual; it cannot express the new \`SyncMode.Polling\` mode added in #1243. Keeping both options in the core API forced documentation to explain when to pick which, with no scope where \`isRealtime\` was strictly better. After this change the core SDK has a single canonical option (\`syncMode\`) for sync mode selection, and the React layer keeps the boolean form because it is widely used in templates.

The React SDK previously had no way to opt into Polling — \`<ChannelProvider>\` accepted only \`isRealtime\`. This PR also adds a \`syncMode\` prop to \`<ChannelProvider>\` so React consumers can use \`SyncMode.Polling\`.

#### Any background context you want to provide?

- Breaking change for direct \`client.attachChannel(ch, { isRealtime: ... })\` callers. Migration: \`{ isRealtime: true }\` → omit (Realtime is the default) or \`{ syncMode: SyncMode.Realtime }\`; \`{ isRealtime: false }\` → \`{ syncMode: SyncMode.Manual }\`.
- Non-breaking for React consumers. \`<ChannelProvider isRealtime={...}>\` continues to work; existing apps such as the \`nextjs-presence\` example need no changes.
- React resolution semantics: \`syncMode\` wins if set; otherwise \`isRealtime\` is consulted; otherwise \`SyncMode.Realtime\`.
- Internal tests in \`presence_test.ts\` updated. Two tests in \`channel_polling_test.ts\` (back-compat with \`isRealtime: true\`, syncMode/isRealtime precedence) were removed because the option no longer exists; the broadcast-isolation test still covers the Realtime broadcast path.
- Design doc \`docs/design/polling-sync-mode.md\` updated: API snippet, compatibility table, design-decisions row.
- Server-side: no changes. Wire format unchanged.

#### What are the relevant tickets?

Follow-up to #1243.

### Checklist
- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything (in covered tests; breaking change is in the public API as documented)

🤖 Generated with [Claude Code](https://claude.com/claude-code)