### PR TITLE
Release v0.7.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and Yorkie JS SDK adheres to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+## [v0.7.8] - 2026-05-05
+
+### Added
+
+- Add SyncMode.Polling for Channel and Document by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1243
+
+### Changed
+
+- Drop isRealtime from core SDK, keep it as React-only prop by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1245
+- Bump dependencies to fix 25 Dependabot security alerts by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1240
+
+### Fixed
+
+- Filter pre-tombstoned descendants in tree reverseOp by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1239
+- Clear history after attach and make undo/redo no-op on empty stack by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1238
+- Fix editByPath split-then-merge and cross-boundary merge undo by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1237
+
 ## [v0.7.7] - 2026-04-26
 
 ### Added

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yorkie-js/devtools",
   "displayName": "Yorkie Devtools",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "A browser extension that helps you debug Yorkie.",
   "homepage": "https://yorkie.dev/",
   "scripts": {

--- a/packages/prosemirror/package.json
+++ b/packages/prosemirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/prosemirror",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "ProseMirror binding for Yorkie collaborative editing",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/react",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "A set of hooks and providers for Yorkie JS SDK",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/schema",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Yorkie Schema for Yorkie Document",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/sdk",
-  "version": "0.7.7",
+  "version": "0.7.8",
   "description": "Yorkie JS SDK",
   "main": "./src/yorkie.ts",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Bump Yorkie JS SDK to v0.7.8.

### Added

- Add SyncMode.Polling for Channel and Document (#1243)

### Changed

- Drop isRealtime from core SDK, keep it as React-only prop (#1245)
- Bump dependencies to fix 25 Dependabot security alerts (#1240)

### Fixed

- Filter pre-tombstoned descendants in tree reverseOp (#1239)
- Clear history after attach and make undo/redo no-op on empty stack (#1238)
- Fix editByPath split-then-merge and cross-boundary merge undo (#1237)

## Test plan

- [x] Versions bumped in all five publishable packages
- [x] CHANGELOG entry added
- [ ] CI passes