### PR TITLE
Fix Polling channel subscriber notification, expose polling via React

### DIFF
--- a/examples/react-polling-playground/README.md
+++ b/examples/react-polling-playground/README.md
@@ -1,0 +1,47 @@
+# react-polling-playground
+
+Interactive demo for `SyncMode.Polling` on both Channel and Document, driven
+through `@yorkie-js/react` (`<ChannelProvider>` and `<DocumentProvider>`).
+
+## What it verifies
+
+- `<ChannelProvider syncMode={SyncMode.Polling} channelHeartbeatInterval={...}>`
+  refreshes `sessionCount` via heartbeat and does not open a watch stream.
+- `<DocumentProvider syncMode={SyncMode.Polling} documentPollInterval={...}>`
+  delivers remote changes within the polling interval without a watch stream.
+- Switching modes at runtime (Realtime / Polling / Manual) re-attaches the
+  resource with the new mode — visible in the per-panel log.
+
+## Run
+
+A local Yorkie server is expected (default `http://localhost:8080`):
+
+```sh
+docker compose -f ../../docker/docker-compose.yml up --build -d
+```
+
+Then from this directory:
+
+```sh
+pnpm install
+VITE_YORKIE_API_ADDR=http://localhost:8080 \
+VITE_YORKIE_API_KEY= \
+pnpm dev
+```
+
+Open two tabs of the printed URL; they share the same channel / document
+session via the URL `?key=` parameter. Toggle modes from the top control
+strip. In **Polling**, set the interval (default 2000ms) and watch the log
+ticks line up with the chosen interval. In **Realtime**, remote changes
+arrive immediately via the watch stream.
+
+## Notes
+
+- `channelHeartbeatInterval` and `documentPollInterval` are applied at
+  attach time. Changing them re-attaches the resource (the `key` prop on
+  the providers triggers this), which is fine for a demo but not what
+  production code would want — runtime transitions should use
+  `client.changeSyncMode(...)`.
+- Polling Channel does not receive broadcast events; this is by design.
+- Polling Document is invisible to other watchers (no `DocWatched`
+  event).

--- a/examples/react-polling-playground/index.html
+++ b/examples/react-polling-playground/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Yorkie Polling Playground</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/examples/react-polling-playground/package.json
+++ b/examples/react-polling-playground/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "react-polling-playground",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "@yorkie-js/react": "workspace:*",
+    "@yorkie-js/sdk": "workspace:*",
+    "react": "^19.2.1",
+    "react-dom": "^19.2.1"
+  },
+  "devDependencies": {
+    "@types/react": "^19.2.7",
+    "@types/react-dom": "^19.2.3",
+    "@vitejs/plugin-react": "^5.1.1",
+    "typescript": "^5.9.3",
+    "vite": "^7.3.2",
+    "vite-tsconfig-paths": "^5.1.4"
+  }
+}

--- a/examples/react-polling-playground/src/App.tsx
+++ b/examples/react-polling-playground/src/App.tsx
@@ -1,0 +1,107 @@
+import { useMemo, useState } from 'react';
+import { YorkieProvider, SyncMode } from '@yorkie-js/react';
+import ChannelPanel from './ChannelPanel';
+import DocumentPanel from './DocumentPanel';
+
+const urlParams = new URLSearchParams(window.location.search);
+const sessionKey =
+  urlParams.get('key') ||
+  `polling-playground-${new Date()
+    .toISOString()
+    .substring(0, 10)
+    .replace(/-/g, '')}`;
+
+export default function App() {
+  const [channelMode, setChannelMode] = useState<SyncMode>(SyncMode.Polling);
+  const [documentMode, setDocumentMode] = useState<SyncMode>(SyncMode.Polling);
+  const [channelInterval, setChannelInterval] = useState<number>(2000);
+  const [documentInterval, setDocumentInterval] = useState<number>(2000);
+
+  const apiKey = import.meta.env.VITE_YORKIE_API_KEY ?? '';
+  const rpcAddr =
+    import.meta.env.VITE_YORKIE_API_ADDR ?? 'http://localhost:8080';
+
+  const yorkieOpts = useMemo(() => ({ apiKey, rpcAddr }), [apiKey, rpcAddr]);
+
+  return (
+    <div className="app">
+      <h1>Yorkie Polling Playground</h1>
+      <p className="lede">
+        Verifies <code>SyncMode.Polling</code> works through the React SDK
+        for both Channel and Document. Open a second tab with the same{' '}
+        <code>?key=…</code> to see remote changes flow in.
+      </p>
+
+      <div className="callout">
+        Session key: <strong>{sessionKey}</strong> &middot; rpcAddr:{' '}
+        <code>{rpcAddr}</code>
+      </div>
+
+      <div className="controls">
+        <fieldset>
+          <legend>Channel</legend>
+          <label>
+            syncMode
+            <select
+              value={channelMode}
+              onChange={(e) => setChannelMode(e.target.value as SyncMode)}
+            >
+              <option value={SyncMode.Realtime}>Realtime</option>
+              <option value={SyncMode.Polling}>Polling</option>
+              <option value={SyncMode.Manual}>Manual</option>
+            </select>
+          </label>
+          <label>
+            heartbeat (ms)
+            <input
+              type="number"
+              min={500}
+              step={500}
+              value={channelInterval}
+              onChange={(e) => setChannelInterval(Number(e.target.value))}
+            />
+          </label>
+        </fieldset>
+        <fieldset>
+          <legend>Document</legend>
+          <label>
+            syncMode
+            <select
+              value={documentMode}
+              onChange={(e) => setDocumentMode(e.target.value as SyncMode)}
+            >
+              <option value={SyncMode.Realtime}>Realtime</option>
+              <option value={SyncMode.Polling}>Polling</option>
+              <option value={SyncMode.Manual}>Manual</option>
+            </select>
+          </label>
+          <label>
+            pollInterval (ms)
+            <input
+              type="number"
+              min={500}
+              step={500}
+              value={documentInterval}
+              onChange={(e) => setDocumentInterval(Number(e.target.value))}
+            />
+          </label>
+        </fieldset>
+      </div>
+
+      <YorkieProvider {...yorkieOpts}>
+        <div className="panels">
+          <ChannelPanel
+            channelKey={sessionKey}
+            syncMode={channelMode}
+            channelHeartbeatInterval={channelInterval}
+          />
+          <DocumentPanel
+            docKey={sessionKey}
+            syncMode={documentMode}
+            documentPollInterval={documentInterval}
+          />
+        </div>
+      </YorkieProvider>
+    </div>
+  );
+}

--- a/examples/react-polling-playground/src/ChannelPanel.tsx
+++ b/examples/react-polling-playground/src/ChannelPanel.tsx
@@ -1,0 +1,70 @@
+import { useEffect, useRef, useState } from 'react';
+import { ChannelProvider, SyncMode, useChannel } from '@yorkie-js/react';
+
+type Props = {
+  channelKey: string;
+  syncMode: SyncMode;
+  channelHeartbeatInterval: number;
+};
+
+export default function ChannelPanel(props: Props) {
+  return (
+    <div className="panel">
+      <h2>Channel</h2>
+      <div className="meta">
+        Mode: <strong>{props.syncMode}</strong> &middot; heartbeat{' '}
+        {props.channelHeartbeatInterval}ms
+      </div>
+      <ChannelProvider
+        key={`${props.channelKey}-${props.syncMode}-${props.channelHeartbeatInterval}`}
+        channelKey={props.channelKey}
+        syncMode={props.syncMode}
+        channelHeartbeatInterval={props.channelHeartbeatInterval}
+      >
+        <ChannelView />
+      </ChannelProvider>
+    </div>
+  );
+}
+
+function ChannelView() {
+  const { sessionCount, loading, error } = useChannel();
+  const [log, setLog] = useState<Array<string>>([]);
+  const prevCount = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (loading) return;
+    const ts = new Date().toISOString().substring(11, 23);
+    if (prevCount.current === null) {
+      setLog((l) => [`${ts}  attached, sessionCount=${sessionCount}`, ...l]);
+    } else if (prevCount.current !== sessionCount) {
+      setLog((l) => [
+        `${ts}  sessionCount: ${prevCount.current} → ${sessionCount}`,
+        ...l,
+      ]);
+    }
+    prevCount.current = sessionCount;
+  }, [sessionCount, loading]);
+
+  if (loading) return <div>Loading channel…</div>;
+  if (error) return <div>Channel error: {error.message}</div>;
+
+  return (
+    <>
+      <div className="stat">{sessionCount}</div>
+      <div className="stat-label">sessionCount (active sessions)</div>
+      <div className="log">
+        {log.length === 0 && (
+          <div className="line">
+            <span className="ts">—</span> waiting for first tick…
+          </div>
+        )}
+        {log.map((line, i) => (
+          <div className="line" key={i}>
+            {line}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/examples/react-polling-playground/src/DocumentPanel.tsx
+++ b/examples/react-polling-playground/src/DocumentPanel.tsx
@@ -1,0 +1,119 @@
+import { useEffect, useRef, useState } from 'react';
+import {
+  DocumentProvider,
+  SyncMode,
+  useDocument,
+  JSONObject,
+} from '@yorkie-js/react';
+
+type DocRoot = {
+  counter?: number;
+  text?: string;
+};
+
+type Props = {
+  docKey: string;
+  syncMode: SyncMode;
+  documentPollInterval: number;
+};
+
+export default function DocumentPanel(props: Props) {
+  return (
+    <div className="panel">
+      <h2>Document</h2>
+      <div className="meta">
+        Mode: <strong>{props.syncMode}</strong> &middot; pollInterval{' '}
+        {props.documentPollInterval}ms
+      </div>
+      <DocumentProvider
+        key={`${props.docKey}-${props.syncMode}-${props.documentPollInterval}`}
+        docKey={props.docKey}
+        initialRoot={{ counter: 0, text: '' }}
+        syncMode={props.syncMode}
+        documentPollInterval={props.documentPollInterval}
+      >
+        <DocumentView />
+      </DocumentProvider>
+    </div>
+  );
+}
+
+function DocumentView() {
+  const { root, update, loading, error } = useDocument<DocRoot>();
+  const [log, setLog] = useState<Array<string>>([]);
+  const prevSnapshot = useRef<string>('');
+
+  useEffect(() => {
+    if (loading) return;
+    const snapshot = JSON.stringify({
+      counter: root.counter ?? 0,
+      text: root.text ?? '',
+    });
+    if (prevSnapshot.current === '') {
+      const ts = new Date().toISOString().substring(11, 23);
+      setLog((l) => [`${ts}  attached, ${snapshot}`, ...l]);
+    } else if (prevSnapshot.current !== snapshot) {
+      const ts = new Date().toISOString().substring(11, 23);
+      setLog((l) => [`${ts}  remote change: ${snapshot}`, ...l]);
+    }
+    prevSnapshot.current = snapshot;
+  }, [root, loading]);
+
+  if (loading) return <div>Loading document…</div>;
+  if (error) return <div>Document error: {error.message}</div>;
+
+  const r = root as JSONObject<DocRoot>;
+
+  return (
+    <>
+      <div className="stat">{r.counter ?? 0}</div>
+      <div className="stat-label">root.counter</div>
+      <div style={{ marginTop: 12 }}>
+        <button
+          onClick={() =>
+            update((root) => {
+              root.counter = (root.counter ?? 0) + 1;
+            })
+          }
+        >
+          Increment
+        </button>
+        <button
+          className="secondary"
+          onClick={() =>
+            update((root) => {
+              root.counter = 0;
+              root.text = '';
+            })
+          }
+        >
+          Reset
+        </button>
+      </div>
+      <div style={{ marginTop: 12 }}>
+        <input
+          className="kv-input"
+          placeholder="root.text"
+          value={r.text ?? ''}
+          onChange={(e) =>
+            update((root) => {
+              root.text = e.target.value;
+            })
+          }
+        />
+      </div>
+      <div className="log">
+        {log.length === 0 && (
+          <div className="line">
+            <span className="ts">—</span> waiting for first sync…
+          </div>
+        )}
+        {log.map((line, i) => (
+          <div className="line" key={i}>
+            {line}
+          </div>
+        ))}
+      </div>
+    </>
+  );
+}

--- a/examples/react-polling-playground/src/main.tsx
+++ b/examples/react-polling-playground/src/main.tsx
@@ -1,0 +1,10 @@
+import ReactDOM from 'react-dom/client';
+import { StrictMode } from 'react';
+import App from './App';
+import './styles.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <StrictMode>
+    <App />
+  </StrictMode>,
+);

--- a/examples/react-polling-playground/src/styles.css
+++ b/examples/react-polling-playground/src/styles.css
@@ -1,0 +1,88 @@
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: #fafafa;
+  color: #1a1a1a;
+}
+.app { max-width: 1100px; margin: 0 auto; padding: 24px; }
+.app h1 { margin: 0 0 4px; font-size: 22px; }
+.app .lede { margin: 0 0 20px; color: #666; font-size: 14px; }
+
+.controls {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+  margin-bottom: 20px;
+}
+.controls fieldset {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  padding: 8px 14px 12px;
+  display: flex;
+  gap: 16px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+.controls legend { font-size: 12px; color: #888; padding: 0 4px; }
+.controls label { font-size: 13px; color: #444; display: flex; gap: 6px; align-items: center; }
+.controls select, .controls input {
+  font: inherit;
+  padding: 4px 8px;
+  border: 1px solid #ccc;
+  border-radius: 4px;
+}
+
+.panels { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.panel {
+  background: #fff;
+  border: 1px solid #e5e5e5;
+  border-radius: 8px;
+  padding: 16px;
+}
+.panel h2 { margin: 0 0 12px; font-size: 16px; }
+.panel .meta { font-size: 12px; color: #777; margin-bottom: 12px; }
+.panel .stat { font-size: 28px; font-weight: 600; }
+.panel .stat-label { font-size: 12px; color: #888; }
+
+.log {
+  margin-top: 12px;
+  background: #0f1115;
+  color: #cfe;
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  font-size: 12px;
+  padding: 8px 10px;
+  border-radius: 4px;
+  height: 160px;
+  overflow-y: auto;
+}
+.log .line { white-space: pre-wrap; }
+.log .ts { color: #888; }
+
+button {
+  font: inherit;
+  padding: 6px 12px;
+  border: 1px solid #1a73e8;
+  background: #1a73e8;
+  color: #fff;
+  border-radius: 4px;
+  cursor: pointer;
+}
+button.secondary { background: #fff; color: #1a73e8; }
+button + button { margin-left: 8px; }
+
+input.kv-input {
+  width: 100%;
+  padding: 6px 8px;
+  font: inherit;
+}
+
+.callout {
+  background: #fff8e1;
+  border: 1px solid #f1d27a;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 13px;
+  margin-bottom: 16px;
+}

--- a/examples/react-polling-playground/src/vite-env.d.ts
+++ b/examples/react-polling-playground/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_YORKIE_API_KEY: string;
+  readonly VITE_YORKIE_API_ADDR: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/examples/react-polling-playground/tsconfig.json
+++ b/examples/react-polling-playground/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": false,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "paths": {
+      "@yorkie-js/sdk/src/*": ["../../packages/sdk/src/*"]
+    }
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/examples/react-polling-playground/tsconfig.node.json
+++ b/examples/react-polling-playground/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/examples/react-polling-playground/vite.config.ts
+++ b/examples/react-polling-playground/vite.config.ts
@@ -1,0 +1,21 @@
+import path from 'path';
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  base: '',
+  plugins: [react(), tsconfigPaths()],
+  resolve: {
+    alias: [
+      {
+        find: '@yorkie-js/react',
+        replacement: path.resolve(__dirname, '../../packages/react/src'),
+      },
+      {
+        find: '@yorkie-js/sdk/src',
+        replacement: path.resolve(__dirname, '../../packages/sdk/src'),
+      },
+    ],
+  },
+});

--- a/packages/react/src/ChannelProvider.tsx
+++ b/packages/react/src/ChannelProvider.tsx
@@ -47,6 +47,7 @@ export function useYorkieChannel(
   clientError: Error | undefined,
   channelKey: string,
   syncMode: SyncMode,
+  channelHeartbeatInterval: number | undefined,
   channelStore: Store<ChannelContextType>,
 ) {
   const channelRef = useRef<Channel | undefined>(undefined);
@@ -89,7 +90,7 @@ export function useYorkieChannel(
 
       try {
         const newChannel = new Channel(channelKey);
-        await client.attach(newChannel, { syncMode });
+        await client.attach(newChannel, { syncMode, channelHeartbeatInterval });
 
         channelRef.current = newChannel;
 
@@ -137,7 +138,15 @@ export function useYorkieChannel(
       }
       detachChannel();
     };
-  }, [client, clientLoading, clientError, channelKey, syncMode, didMount]);
+  }, [
+    client,
+    clientLoading,
+    clientError,
+    channelKey,
+    syncMode,
+    channelHeartbeatInterval,
+    didMount,
+  ]);
 }
 
 /**
@@ -171,6 +180,12 @@ export type ChannelProviderProps = PropsWithChildren<{
    * falls back to `SyncMode.Realtime`.
    */
   isRealtime?: boolean;
+
+  /**
+   * `channelHeartbeatInterval` overrides the heartbeat interval (ms).
+   * Applied at attach time. Defaults: Polling=3000, Realtime=30000.
+   */
+  channelHeartbeatInterval?: number;
 }>;
 
 /**
@@ -196,6 +211,7 @@ export const ChannelProvider: React.FC<ChannelProviderProps> = ({
   channelKey,
   syncMode,
   isRealtime,
+  channelHeartbeatInterval,
 }) => {
   const { client, loading: clientLoading, error: clientError } = useYorkie();
 
@@ -216,8 +232,7 @@ export const ChannelProvider: React.FC<ChannelProviderProps> = ({
 
   // Resolve syncMode: explicit syncMode wins, then isRealtime, else Realtime.
   const resolvedSyncMode: SyncMode =
-    syncMode ??
-    (isRealtime === false ? SyncMode.Manual : SyncMode.Realtime);
+    syncMode ?? (isRealtime === false ? SyncMode.Manual : SyncMode.Realtime);
 
   useYorkieChannel(
     client,
@@ -225,6 +240,7 @@ export const ChannelProvider: React.FC<ChannelProviderProps> = ({
     clientError,
     channelKey,
     resolvedSyncMode,
+    channelHeartbeatInterval,
     channelStore,
   );
 

--- a/packages/react/src/DocumentProvider.tsx
+++ b/packages/react/src/DocumentProvider.tsx
@@ -29,6 +29,7 @@ import {
   StreamConnectionStatus,
   Client,
   RevisionSummary,
+  SyncMode,
 } from '@yorkie-js/sdk';
 import { useYorkie } from './YorkieProvider';
 import { createDocumentStore } from './createDocumentStore';
@@ -56,6 +57,8 @@ export function useYorkieDocument<R, P extends Indexable = Indexable>(
   initialRoot: R,
   initialPresence: P,
   enableDevtools: boolean,
+  syncMode: SyncMode | undefined,
+  documentPollInterval: number | undefined,
   docStore: Store<DocumentContextType<R, P>>,
 ) {
   const initialRootRef = useRef(initialRoot);
@@ -131,6 +134,8 @@ export function useYorkieDocument<R, P extends Indexable = Indexable>(
         await client?.attach(newDoc, {
           initialRoot: initialRootRef.current,
           initialPresence: initialPresenceRef.current,
+          syncMode,
+          documentPollInterval,
         });
 
         const update = (callback: (root: R, presence: Presence<P>) => void) => {
@@ -179,7 +184,16 @@ export function useYorkieDocument<R, P extends Indexable = Indexable>(
         unsub();
       }
     };
-  }, [client, clientLoading, clientError, docKey, docStore, didMount]);
+  }, [
+    client,
+    clientLoading,
+    clientError,
+    docKey,
+    docStore,
+    didMount,
+    syncMode,
+    documentPollInterval,
+  ]);
 }
 
 export type DocumentContextType<R, P extends Indexable = Indexable> = {
@@ -206,12 +220,24 @@ export const DocumentProvider = <R, P extends Indexable = Indexable>({
   initialRoot = {} as R,
   initialPresence = {} as P,
   enableDevtools = false,
+  syncMode,
+  documentPollInterval,
   children,
 }: {
   docKey: string;
   initialRoot?: R;
   initialPresence?: P;
   enableDevtools?: boolean;
+  /**
+   * `syncMode` defines the synchronization mode of the document.
+   * Defaults to `SyncMode.Realtime`.
+   */
+  syncMode?: SyncMode;
+  /**
+   * `documentPollInterval` (ms) — only used when `syncMode` is `Polling`.
+   * Default: 3000. Applied at attach time.
+   */
+  documentPollInterval?: number;
   children?: React.ReactNode;
 }) => {
   const { client, loading: clientLoading, error: clientError } = useYorkie();
@@ -246,6 +272,8 @@ export const DocumentProvider = <R, P extends Indexable = Indexable>({
     initialRoot,
     initialPresence,
     enableDevtools,
+    syncMode,
+    documentPollInterval,
     documentStore,
   );
 

--- a/packages/react/src/useYorkieDoc.ts
+++ b/packages/react/src/useYorkieDoc.ts
@@ -19,6 +19,7 @@ import {
   Indexable,
   Presence,
   StreamConnectionStatus,
+  SyncMode,
 } from '@yorkie-js/sdk';
 import pkg from '../package.json';
 import { useYorkieClient } from './YorkieProvider';
@@ -38,6 +39,8 @@ export function useYorkieDoc<R, P extends Indexable = Indexable>(
     initialRoot?: R;
     initialPresence?: P;
     enableDevtools?: boolean;
+    syncMode?: SyncMode;
+    documentPollInterval?: number;
   },
 ): {
   root: R;
@@ -90,6 +93,8 @@ export function useYorkieDoc<R, P extends Indexable = Indexable>(
     opts?.initialRoot ?? ({} as R),
     opts?.initialPresence ?? ({} as P),
     opts?.enableDevtools ?? false,
+    opts?.syncMode,
+    opts?.documentPollInterval,
     documentStore,
   );
 

--- a/packages/react/test/unit/useYorkieDoc.test.ts
+++ b/packages/react/test/unit/useYorkieDoc.test.ts
@@ -173,6 +173,8 @@ describe('useYorkieDoc', () => {
         {},
         {},
         false,
+        undefined,
+        undefined,
         mockDocumentStore,
       );
     });

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -2044,7 +2044,15 @@ export class Client {
           },
         );
 
-        resource.updateSessionCount(Number(res.sessionCount), 0);
+        const prevCount = resource.getSessionCount();
+        if (resource.updateSessionCount(Number(res.sessionCount), 0)) {
+          if (resource.getSessionCount() !== prevCount) {
+            resource.publish({
+              type: ChannelEventType.PresenceChanged,
+              count: resource.getSessionCount(),
+            });
+          }
+        }
         attachment.updateHeartbeatTime();
 
         logger.debug(

--- a/packages/sdk/test/integration/channel_polling_test.ts
+++ b/packages/sdk/test/integration/channel_polling_test.ts
@@ -77,6 +77,45 @@ describe('Channel Polling', function () {
     await c.deactivate();
   });
 
+  it('Polling notifies subscribers when sessionCount changes', async function ({
+    task,
+  }) {
+    const channelKey = `${toDocKey(task.name)}-${new Date().getTime()}`;
+
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    await c1.activate();
+    await c2.activate();
+
+    const ch1 = new Channel(channelKey);
+    await c1.attachChannel(ch1, {
+      syncMode: SyncMode.Polling,
+      channelHeartbeatInterval: 200,
+    });
+
+    const observed: Array<number> = [];
+    const unsub = ch1.subscribe('presence', (event) => {
+      observed.push(event.count);
+    });
+
+    // Second client joins; the first client is in Polling mode and should
+    // observe the count change via its heartbeat refresh, not a watch event.
+    const ch2 = new Channel(channelKey);
+    await c2.attachChannel(ch2);
+
+    // Wait for at least one poll tick to deliver the new count.
+    await new Promise((r) => setTimeout(r, 600));
+
+    assert.isAtLeast(observed.length, 1);
+    assert.isAtLeast(observed[observed.length - 1], 2);
+
+    unsub();
+    await c1.detachChannel(ch1);
+    await c2.detachChannel(ch2);
+    await c1.deactivate();
+    await c2.deactivate();
+  });
+
   it('changeSyncMode transitions Realtime ↔ Polling for channels', async function ({
     task,
   }) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: link:../../packages/sdk
       next:
         specifier: 16.2.3
-        version: 16.2.3(@babel/core@7.28.5)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.94.2)
+        version: 16.2.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.94.2)
       react:
         specifier: 19.2.1
         version: 19.2.1
@@ -95,7 +95,7 @@ importers:
         version: link:../../packages/sdk
       next:
         specifier: 16.2.3
-        version: 16.2.3(@babel/core@7.28.5)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.94.2)
+        version: 16.2.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.94.2)
       react:
         specifier: 19.2.1
         version: 19.2.1
@@ -147,7 +147,7 @@ importers:
         version: 0.555.0(react@19.2.1)
       next:
         specifier: 16.2.3
-        version: 16.2.3(@babel/core@7.28.5)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.94.2)
+        version: 16.2.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.94.2)
       react:
         specifier: ^19.2.1
         version: 19.2.1
@@ -287,6 +287,40 @@ importers:
       vite:
         specifier: ^7.3.2
         version: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(yaml@2.8.2)
+
+  examples/react-polling-playground:
+    dependencies:
+      '@yorkie-js/react':
+        specifier: workspace:*
+        version: link:../../packages/react
+      '@yorkie-js/sdk':
+        specifier: workspace:*
+        version: link:../../packages/sdk
+      react:
+        specifier: ^19.2.1
+        version: 19.2.1
+      react-dom:
+        specifier: ^19.2.1
+        version: 19.2.1(react@19.2.1)
+    devDependencies:
+      '@types/react':
+        specifier: ^19.2.7
+        version: 19.2.7
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.7)
+      '@vitejs/plugin-react':
+        specifier: ^5.1.1
+        version: 5.1.1(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(yaml@2.8.2))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.2
+        version: 7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(yaml@2.8.2)
+      vite-tsconfig-paths:
+        specifier: ^5.1.4
+        version: 5.1.4(typescript@5.9.3)(vite@7.3.2(@types/node@24.10.1)(jiti@2.6.1)(less@4.4.2)(lightningcss@1.30.2)(sass@1.94.2)(yaml@2.8.2))
 
   examples/react-revision:
     dependencies:
@@ -1576,183 +1610,155 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.4':
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -2124,28 +2130,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.2.3':
     resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.2.3':
     resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.2.3':
     resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.2.3':
     resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
@@ -2505,42 +2507,36 @@ packages:
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm-musl@2.5.1':
     resolution: {integrity: sha512-6E+m/Mm1t1yhB8X412stiKFG3XykmgdIOqhjWj+VL8oHkKABfu/gjFj8DvLrYVHSBNC+/u5PeNrujiSQ1zwd1Q==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-arm64-glibc@2.5.1':
     resolution: {integrity: sha512-LrGp+f02yU3BN9A+DGuY3v3bmnFUggAITBGriZHUREfNEzZh/GO06FF5u2kx8x+GBEUYfyTGamol4j3m9ANe8w==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-arm64-musl@2.5.1':
     resolution: {integrity: sha512-cFOjABi92pMYRXS7AcQv9/M1YuKRw8SZniCDw0ssQb/noPkRzA+HBDkwmyOJYp5wXcsTrhxO0zq1U11cK9jsFg==}
     engines: {node: '>= 10.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-linux-x64-glibc@2.5.1':
     resolution: {integrity: sha512-GcESn8NZySmfwlTsIur+49yDqSny2IhPeZfXunQi48DMugKeZ7uy1FX83pO0X22sHntJ4Ub+9k34XQCX+oHt2A==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@parcel/watcher-linux-x64-musl@2.5.1':
     resolution: {integrity: sha512-n0E2EQbatQ3bXhcH2D1XIAANAcTZkQICBPVaxMeaCVBtOpBZpWJuf7LwyWPSBDITb7In8mqQgJ7gH8CILCURXg==}
     engines: {node: '>= 10.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@parcel/watcher-win32-arm64@2.5.1':
     resolution: {integrity: sha512-RFzklRvmc3PkjKjry3hLF9wD7ppR4AKcWNzH7kXR7GUe0Igb3Nz8fyPwtZCSquGrhU5HhUNDr/mKBqj7tqA2Vw==}
@@ -3301,67 +3297,56 @@ packages:
     resolution: {integrity: sha512-k9oD15soC/Ln6d2Wv/JOFPzZXIAIFLp6B+i14KhxAfnq76ajt0EhYc5YPeX6W1xJkAdItcVT+JhKl1QZh44/qw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.53.3':
     resolution: {integrity: sha512-vTNlKq+N6CK/8UktsrFuc+/7NlEYVxgaEgRXVUVK258Z5ymho29skzW1sutgYjqNnquGwVUObAaxae8rZ6YMhg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.53.3':
     resolution: {integrity: sha512-RGrFLWgMhSxRs/EWJMIFM1O5Mzuz3Xy3/mnxJp/5cVhZ2XoCAxJnmNsEyeMJtpK+wu0FJFWz+QF4mjCA7AUQ3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.53.3':
     resolution: {integrity: sha512-kASyvfBEWYPEwe0Qv4nfu6pNkITLTb32p4yTgzFCocHnJLAHs+9LjUu9ONIhvfT/5lv4YS5muBHyuV84epBo/A==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.53.3':
     resolution: {integrity: sha512-JiuKcp2teLJwQ7vkJ95EwESWkNRFJD7TQgYmCnrPtlu50b4XvT5MOmurWNrCj3IFdyjBQ5p9vnrX4JM6I8OE7g==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.53.3':
     resolution: {integrity: sha512-EoGSa8nd6d3T7zLuqdojxC20oBfNT8nexBbB/rkxgKj5T5vhpAQKKnD+h3UkoMuTyXkP5jTjK/ccNRmQrPNDuw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.53.3':
     resolution: {integrity: sha512-4s+Wped2IHXHPnAEbIB0YWBv7SDohqxobiiPA1FIWZpX+w9o2i4LezzH/NkFUl8LRci/8udci6cLq+jJQlh+0g==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.53.3':
     resolution: {integrity: sha512-68k2g7+0vs2u9CxDt5ktXTngsxOQkSEV/xBbwlqYcUrAVh6P9EgMZvFsnHy4SEiUl46Xf0IObWVbMvPrr2gw8A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.53.3':
     resolution: {integrity: sha512-VYsFMpULAz87ZW6BVYw3I6sWesGpsP9OPcyKe8ofdg9LHxSbRMd7zrVrr5xi/3kMZtpWL/wC+UIJWJYVX5uTKg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.53.3':
     resolution: {integrity: sha512-3EhFi1FU6YL8HTUJZ51imGJWEX//ajQPfqWLI3BQq4TlvHy4X0MOr5q3D2Zof/ka0d5FNdPwZXm3Yyib/UEd+w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.53.3':
     resolution: {integrity: sha512-eoROhjcc6HbZCJr+tvVT8X4fW3/5g/WkGvvmwz/88sDtSJzO7r/blvoBDgISDiCjDRZmHpwud7h+6Q9JxFwq1Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.53.3':
     resolution: {integrity: sha512-OueLAWgrNSPGAdUdIjSWXw+u/02BRTcnfw9PN41D2vq/JSEPnJnVuBgw18VkN8wcd4fjUs+jFHVM4t9+kBSNLw==}
@@ -3579,56 +3564,48 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-gnu@1.3.96':
     resolution: {integrity: sha512-c/IiJ0s1y3Ymm2BTpyC/xr6gOvoqAVETrivVXHq68xgNms95luSpbYQ28rqaZC8bQC8M5zdXpSc0T8DJu8RJGw==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.3':
     resolution: {integrity: sha512-j4SJniZ/qaZ5g8op+p1G9K1z22s/EYGg1UXIb3+Cg4nsxEpF5uSIGEE4mHUfA70L0BR9wKT2QF/zv3vkhfpX4g==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-arm64-musl@1.3.96':
     resolution: {integrity: sha512-i5/UTUwmJLri7zhtF6SAo/4QDQJDH2fhYJaBIUhrICmIkRO/ltURmpejqxsM/ye9Jqv5zG7VszMC0v/GYn/7BQ==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.3':
     resolution: {integrity: sha512-aKttAZnz8YB1VJwPQZtyU8Uk0BfMP63iDMkvjhJzRZVgySmqt/apWSdnoIcZlUoGheBrcqbMC17GGUmur7OT5A==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-gnu@1.3.96':
     resolution: {integrity: sha512-USdaZu8lTIkm4Yf9cogct/j5eqtdZqTgcTib4I+NloUW0E/hySou3eSyp3V2UAA1qyuC72ld1otXuyKBna0YKQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.3':
     resolution: {integrity: sha512-oe8FctPu1gnUsdtGJRO2rvOUIkkIIaHqsO9xxN0bTR7dFTlPTGi2Fhk1tnvXeyAvCPxLIcwD8phzKg6wLv9yug==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-musl@1.3.96':
     resolution: {integrity: sha512-QYErutd+G2SNaCinUVobfL7jWWjGTI0QEoQ6hqTp7PxCJS/dmKmj3C5ZkvxRYcq7XcZt7ovrYCTwPTHzt6lZBg==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.3':
     resolution: {integrity: sha512-L9AjzP2ZQ/Xh58e0lTRMLvEDrcJpR7GwZqAtIeNLcTK7JVE+QineSyHp0kLkO1rttCHyCy0U74kDTj0dRz6raA==}
@@ -3738,28 +3715,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.17':
     resolution: {integrity: sha512-HvZLfGr42i5anKtIeQzxdkw/wPqIbpeZqe7vd3V9vI3RQxe3xU1fLjss0TjyhxWcBaipk7NYwSrwTwK1hJARMg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.17':
     resolution: {integrity: sha512-M3XZuORCGB7VPOEDH+nzpJ21XPvK5PyjlkSFkFziNHGLc5d6g3di2McAAblmaSUNl8IOmzYwLx9NsE7bplNkwQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.17':
     resolution: {integrity: sha512-k7f+pf9eXLEey4pBlw+8dgfJHY4PZ5qOUFDyNf7SI6lHjQ9Zt7+NcscjpwdCEbYi6FI5c2KDTDWyf2iHcCSyyQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.17':
     resolution: {integrity: sha512-cEytGqSSoy7zK4JRWiTCx43FsKP/zGr0CsuMawhH67ONlH+T79VteQeJQRO/X7L0juEUA8ZyuYikcRBf0vsxhg==}
@@ -4107,49 +4080,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -6234,56 +6199,48 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.30.2:
     resolution: {integrity: sha512-UK65WJAbwIJbiBFXpxrbTNArtfuznvxAJw4Q2ZGlU8kPeDIWEX1dg3rn2veBVUylA2Ezg89ktszWbaQnxD/e3A==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.21.8:
     resolution: {integrity: sha512-01gWShXrgoIb8urzShpn1RWtZuaSyKSzF2hfO+flzlTPoACqcO3rgcu/3af4Cw54e8vKzL5hPRo4kROmgaOMLg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.30.2:
     resolution: {integrity: sha512-5Vh9dGeblpTxWHpOx8iauV02popZDsCYMPIgiuw97OJ5uaDsL86cnqSFs5LZkG3ghHoX5isLgWzMs+eD1YzrnA==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.21.8:
     resolution: {integrity: sha512-yVB5vYJjJb/Aku0V9QaGYIntvK/1TJOlNB9GmkNpXX5bSSP2pYW4lWW97jxFMHO908M0zjEt1qyOLMyqojHL+Q==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.30.2:
     resolution: {integrity: sha512-Cfd46gdmj1vQ+lR6VRTTadNHu6ALuw2pKR9lYq4FnhvgBc4zWY1EtZcAc6EffShbb1MFrIPfLDXD6Xprbnni4w==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.21.8:
     resolution: {integrity: sha512-TYi+KNtBVK0+FZvxTX/d5XJb+tw3Jq+2Rr9hW359wp1afsi1Vkg+uVGgbn+m2dipa5XwpCseQq81ylMlXuyfPw==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.30.2:
     resolution: {integrity: sha512-XJaLUUFXb6/QG2lGIW6aIk6jKdtjtcffUT0NKvIqhSBY3hh9Ch+1LCeH80dR9q9LBjG3ewbDjnumefsLsP6aiA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.30.2:
     resolution: {integrity: sha512-FZn+vaj7zLv//D/192WFFVA0RgHawIcHqLX9xuWiQt7P0PtdFEVaxgF9rjM/IRYHQXNnk61/H/gb2Ei+kUQ4xQ==}
@@ -13305,7 +13262,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -13316,7 +13273,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -13338,7 +13295,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.1(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.1(jiti@2.6.1)))(eslint@9.39.1(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -13367,7 +13324,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.6.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.59.1(eslint@9.39.4(jiti@2.6.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.6.1)))(eslint@9.39.4(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -14837,7 +14794,7 @@ snapshots:
 
   negotiator@1.0.0: {}
 
-  next@16.2.3(@babel/core@7.28.5)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.94.2):
+  next@16.2.3(react-dom@19.2.1(react@19.2.1))(react@19.2.1)(sass@1.94.2):
     dependencies:
       '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
@@ -14846,7 +14803,7 @@ snapshots:
       postcss: 8.5.12
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
-      styled-jsx: 5.1.6(@babel/core@7.28.5)(react@19.2.1)
+      styled-jsx: 5.1.6(react@19.2.1)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.3
       '@next/swc-darwin-x64': 16.2.3
@@ -16148,12 +16105,10 @@ snapshots:
 
   style-mod@4.1.3: {}
 
-  styled-jsx@5.1.6(@babel/core@7.28.5)(react@19.2.1):
+  styled-jsx@5.1.6(react@19.2.1):
     dependencies:
       client-only: 0.0.1
       react: 19.2.1
-    optionalDependencies:
-      '@babel/core': 7.28.5
 
   sucrase@3.35.1:
     dependencies:


### PR DESCRIPTION
## Summary

- **SDK fix**: Polling channel was updating `sessionCount` via heartbeat but **never firing subscribers**, so any UI relying on `channel.subscribe(...)` (including `@yorkie-js/react`'s `useChannel()`) didn't re-render. The watch-stream path correctly publishes `PresenceChanged`; the polling path was missing the same call.
- **React SDK**: thread polling-related props through `<DocumentProvider>` (`syncMode`, `documentPollInterval`) and `<ChannelProvider>` (`channelHeartbeatInterval`). `syncMode` was already supported on `<ChannelProvider>` but interval was not. `<DocumentProvider>` had no polling knob at all.
- **Example**: new `examples/react-polling-playground/` exercising both Channel and Document Polling through the React Providers, with separate per-resource mode/interval controls.

## Why this matters

The existing channel polling integration tests only asserted via `ch.getSessionCount()` direct reads, which masked the missing publish call. End-to-end React usage exposes it: the count is correct in the SDK state but the UI never knows.

A new regression test (`Polling notifies subscribers when sessionCount changes`) subscribes to `'presence'` events and verifies the callback fires from a polling-driven count change.

## Test plan

- [x] `pnpm sdk test test/integration/channel_polling_test.ts test/integration/document_polling_test.ts` — 12/12 (8 existing channel + 1 new + 3 document)
- [x] `pnpm react test` — 88/88
- [x] `pnpm react build`
- [x] `pnpm --filter react-polling-playground build`
- [ ] Manual verification: open `examples/react-polling-playground` in two tabs and confirm sessionCount updates within `channelHeartbeatInterval` under Polling mode

## Notes

- One-tab interval changes re-attach the resource (provider `key` prop), which is fine for a demo but production should use `client.changeSyncMode(...)`.
- `<ChannelProvider isRealtime>` continues to work as a Realtime/Manual shortcut.
- Server-side: no changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable heartbeat interval for channels and poll interval for documents in Polling sync mode
  * Added React polling playground example demonstrating channel and document synchronization with Polling sync mode, including runtime mode switching

* **Documentation**
  * Added comprehensive playground documentation with setup instructions and usage examples

<!-- end of auto-generated comment: release notes by coderabbit.ai -->