### PR TITLE
Demo session count flicker on sub-route in polling playground

### DIFF
--- a/examples/react-polling-playground/src/App.tsx
+++ b/examples/react-polling-playground/src/App.tsx
@@ -1,8 +1,13 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { YorkieProvider, SyncMode } from '@yorkie-js/react';
 import Leaderboard from './Leaderboard';
-import StockDetail from './StockDetail';
+import StockDetail, {
+  type SubView,
+  type ProviderPosition,
+} from './StockDetail';
 import { STOCKS } from './stocks';
+
+const SUB_VIEWS: ReadonlyArray<SubView> = ['overview', 'activity'];
 
 const initialParams = new URLSearchParams(window.location.search);
 const sessionKey =
@@ -14,6 +19,13 @@ function readSelectedStock(): string | null {
   const ticker = params.get('stock');
   if (!ticker) return null;
   return STOCKS.some((s) => s.ticker === ticker) ? ticker : null;
+}
+
+function readSubView(): SubView {
+  const seg = window.location.pathname.split('/').filter(Boolean).pop() ?? '';
+  return (SUB_VIEWS as ReadonlyArray<string>).includes(seg)
+    ? (seg as SubView)
+    : 'overview';
 }
 
 const MIN_HEARTBEAT_MS = 500;
@@ -28,6 +40,9 @@ export default function App() {
   const [selectedTicker, setSelectedTicker] = useState<string | null>(
     readSelectedStock,
   );
+  const [subView, setSubView] = useState<SubView>(readSubView);
+  const [providerPosition, setProviderPosition] =
+    useState<ProviderPosition>('inside');
 
   const commitHeartbeat = useCallback(() => {
     const next = Number(heartbeatDraft);
@@ -40,18 +55,31 @@ export default function App() {
   }, [heartbeatDraft, heartbeat]);
 
   useEffect(() => {
-    const onPop = () => setSelectedTicker(readSelectedStock());
+    const onPop = () => {
+      setSelectedTicker(readSelectedStock());
+      setSubView(readSubView());
+    };
     window.addEventListener('popstate', onPop);
     return () => window.removeEventListener('popstate', onPop);
   }, []);
 
-  const navigate = useCallback((ticker: string | null) => {
+  const navigateRoom = useCallback((ticker: string | null) => {
     const params = new URLSearchParams(window.location.search);
     if (ticker) params.set('stock', ticker);
     else params.delete('stock');
-    const next = `${window.location.pathname}?${params.toString()}`;
-    window.history.pushState({}, '', next);
+    const path = ticker ? '/overview' : '/';
+    const query = params.toString();
+    window.history.pushState({}, '', query ? `${path}?${query}` : path);
     setSelectedTicker(ticker);
+    setSubView('overview');
+  }, []);
+
+  const navigateSubView = useCallback((view: SubView) => {
+    const params = new URLSearchParams(window.location.search);
+    const query = params.toString();
+    const next = `/${view}${query ? `?${query}` : ''}`;
+    window.history.pushState({}, '', next);
+    setSubView(view);
   }, []);
 
   const apiKey = import.meta.env.VITE_YORKIE_API_KEY ?? '';
@@ -68,11 +96,10 @@ export default function App() {
       <header>
         <h1>📈 Live Stock Rooms</h1>
         <p className="lede">
-          Each stock is its own room (Yorkie Channel). Click a ticker to enter
-          and see how many people are watching it right now via{' '}
-          <code>SyncMode.Polling</code>. Open another tab on the same stock to
-          watch the count rise; pick a different stock to see the previous
-          room's count drop.
+          Each stock is its own room (Yorkie Channel). Inside a room, navigate
+          between sub-paths (<code>/overview</code> ↔ <code>/activity</code>)
+          and toggle the <code>ChannelProvider</code> position to see how its
+          placement affects the session count.
         </p>
       </header>
 
@@ -101,6 +128,18 @@ export default function App() {
             }}
           />
         </label>
+        <label>
+          <span className="control-label">Provider position</span>
+          <select
+            value={providerPosition}
+            onChange={(e) =>
+              setProviderPosition(e.target.value as ProviderPosition)
+            }
+          >
+            <option value="inside">Inside sub-route (flickers)</option>
+            <option value="outside">Outside sub-route (stable)</option>
+          </select>
+        </label>
         <div className="session-tag">
           session <code>{sessionKey}</code>
         </div>
@@ -113,18 +152,23 @@ export default function App() {
             syncMode={syncMode}
             heartbeatInterval={heartbeat}
             channelKey={`${sessionKey}-${selectedStock.ticker}`}
-            onBack={() => navigate(null)}
+            subView={subView}
+            providerPosition={providerPosition}
+            onChangeSubView={navigateSubView}
+            onBack={() => navigateRoom(null)}
           />
         ) : (
-          <Leaderboard onSelect={(ticker) => navigate(ticker)} />
+          <Leaderboard onSelect={(ticker) => navigateRoom(ticker)} />
         )}
       </YorkieProvider>
 
       <footer>
-        Tip: open this URL in two tabs with the same <code>?key=</code>. Send
-        them into the same stock to see <code>2 watching</code>; send them into
-        different stocks to see each room hold <code>1</code>. The list itself
-        attaches no channels — counts only exist inside a stock room.
+        Tip: open this URL in two tabs with the same <code>?key=</code>. Enter
+        the same stock in both. In one tab, keep clicking between{' '}
+        <code>/overview</code> and <code>/activity</code>. With{' '}
+        <code>Provider position: inside</code> the other tab will see the count
+        blink to <code>0</code> right after each navigation, then recover.
+        Switch to <code>outside</code> and the blink disappears.
       </footer>
     </div>
   );

--- a/examples/react-polling-playground/src/StockDetail.tsx
+++ b/examples/react-polling-playground/src/StockDetail.tsx
@@ -1,66 +1,219 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { ChannelProvider, SyncMode, useChannel } from '@yorkie-js/react';
 import type { Stock } from './stocks';
+
+export type SubView = 'overview' | 'activity';
+export type ProviderPosition = 'inside' | 'outside';
+
+type AttachState = 'attaching' | 'ok' | 'error';
+
+type LogEntry = {
+  t: number;
+  n: number;
+  state: AttachState;
+  source: SubView;
+  err?: string;
+};
 
 type Props = {
   stock: Stock;
   syncMode: SyncMode;
   heartbeatInterval: number;
   channelKey: string;
+  subView: SubView;
+  providerPosition: ProviderPosition;
+  onChangeSubView: (view: SubView) => void;
   onBack: () => void;
 };
+
+const TABS: ReadonlyArray<SubView> = ['overview', 'activity'];
 
 export default function StockDetail({
   stock,
   syncMode,
   heartbeatInterval,
   channelKey,
+  subView,
+  providerPosition,
+  onChangeSubView,
   onBack,
 }: Props) {
+  const providerKey = `${channelKey}-${syncMode}-${heartbeatInterval}`;
+  const providerProps = {
+    channelKey,
+    syncMode,
+    channelHeartbeatInterval: heartbeatInterval,
+  };
+
+  const [log, setLog] = useState<Array<LogEntry>>([]);
+  const handleSessionEvent = useCallback(
+    (n: number, state: AttachState, source: SubView, err?: string) => {
+      setLog((prev) => {
+        const next = [...prev, { t: Date.now(), n, state, source, err }];
+        return next.length > 24 ? next.slice(-24) : next;
+      });
+    },
+    [],
+  );
+
+  const tabHeader = (
+    <div className="tab-bar">
+      {TABS.map((view) => (
+        <button
+          key={view}
+          className={`tab ${subView === view ? 'tab-active' : ''}`}
+          onClick={() => onChangeSubView(view)}
+        >
+          /{view}
+        </button>
+      ))}
+    </div>
+  );
+
   return (
     <div className="detail">
       <button className="back" onClick={onBack}>
         ← Back to leaderboard
       </button>
-      <ChannelProvider
-        key={`${channelKey}-${syncMode}-${heartbeatInterval}`}
-        channelKey={channelKey}
-        syncMode={syncMode}
-        channelHeartbeatInterval={heartbeatInterval}
-      >
-        <DetailBody stock={stock} />
-      </ChannelProvider>
+
+      {providerPosition === 'outside' ? (
+        // Shared layout owns the ChannelProvider. Sub-routes only swap
+        // children → channel stays attached across path changes.
+        <ChannelProvider key={providerKey} {...providerProps}>
+          {tabHeader}
+          {subView === 'overview' ? (
+            <OverviewBody stock={stock} onSession={handleSessionEvent} />
+          ) : (
+            <ActivityBody stock={stock} onSession={handleSessionEvent} />
+          )}
+        </ChannelProvider>
+      ) : (
+        // Each sub-route mounts its own ChannelProvider. Switching paths
+        // unmounts one provider and mounts another → detach/attach cycle.
+        <>
+          {tabHeader}
+          {subView === 'overview' ? (
+            <ChannelProvider
+              key={`${providerKey}-overview`}
+              {...providerProps}
+            >
+              <OverviewBody stock={stock} onSession={handleSessionEvent} />
+            </ChannelProvider>
+          ) : (
+            <ChannelProvider
+              key={`${providerKey}-activity`}
+              {...providerProps}
+            >
+              <ActivityBody stock={stock} onSession={handleSessionEvent} />
+            </ChannelProvider>
+          )}
+        </>
+      )}
+
+      <SessionLogPanel log={log} onClear={() => setLog([])} />
     </div>
   );
 }
 
-function DetailBody({ stock }: { stock: Stock }) {
+type CardProps = {
+  stock: Stock;
+  onSession: (
+    n: number,
+    state: AttachState,
+    source: SubView,
+    err?: string,
+  ) => void;
+};
+
+function OverviewBody({ stock, onSession }: CardProps) {
+  return (
+    <SessionCountCard stock={stock} subLabel="overview" onSession={onSession} />
+  );
+}
+
+function ActivityBody({ stock, onSession }: CardProps) {
+  return (
+    <SessionCountCard stock={stock} subLabel="activity" onSession={onSession} />
+  );
+}
+
+function SessionCountCard({
+  stock,
+  subLabel,
+  onSession,
+}: {
+  stock: Stock;
+  subLabel: SubView;
+  onSession: CardProps['onSession'];
+}) {
   const { sessionCount, loading, error } = useChannel();
   const flag = stock.market === 'KR' ? '🇰🇷' : '🇺🇸';
+  const state: AttachState = error ? 'error' : loading ? 'attaching' : 'ok';
+
+  const lastRef = useRef<{ n: number; state: AttachState } | null>(null);
+  useEffect(() => {
+    const cur = { n: sessionCount, state };
+    const last = lastRef.current;
+    if (!last || last.n !== cur.n || last.state !== cur.state) {
+      lastRef.current = cur;
+      onSession(sessionCount, state, subLabel, error?.message);
+    }
+  }, [sessionCount, state, error, subLabel, onSession]);
 
   return (
     <div className="detail-card">
       <div className="detail-meta">
         <span className="detail-flag">{flag}</span>
         <span className="detail-name">{stock.name}</span>
+        <span className="detail-sub">/ {subLabel}</span>
       </div>
       <div className="detail-ticker">{stock.ticker}</div>
       <div className="detail-count">
-        {loading ? (
-          <span className="muted">connecting…</span>
-        ) : error ? (
-          <span className="muted">error: {error.message}</span>
-        ) : (
-          <>
-            <span className="big-num">{sessionCount.toLocaleString()}</span>
-            <span className="big-label">people watching right now</span>
-          </>
-        )}
+        <span className="big-num">{sessionCount.toLocaleString()}</span>
+        <span className="big-label">
+          people watching{' '}
+          <span className={`state-badge state-${state}`}>{state}</span>
+        </span>
       </div>
-      <p className="detail-hint">
-        You're one of them. Open another tab on this same stock to see the
-        count tick up; switch one tab to a different stock to see this count
-        drop.
-      </p>
+      {error && <p className="detail-hint">error: {error.message}</p>}
+    </div>
+  );
+}
+
+function SessionLogPanel({
+  log,
+  onClear,
+}: {
+  log: Array<LogEntry>;
+  onClear: () => void;
+}) {
+  return (
+    <div className="session-log">
+      <div className="session-log-header">
+        <span className="session-log-title">session count log</span>
+        <button className="log-clear" onClick={onClear}>
+          clear
+        </button>
+      </div>
+      {log.length === 0 ? (
+        <div className="muted">no events yet</div>
+      ) : (
+        <ul>
+          {log.map((entry, i) => (
+            <li key={i}>
+              <code>
+                {new Date(entry.t).toISOString().substring(11, 23)}
+              </code>{' '}
+              <span className="log-source">/{entry.source}</span>{' '}
+              <span className={`state-badge state-${entry.state}`}>
+                {entry.state}
+              </span>{' '}
+              → <strong>{entry.n}</strong>
+              {entry.err && <span className="muted"> · {entry.err}</span>}
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/examples/react-polling-playground/src/styles.css
+++ b/examples/react-polling-playground/src/styles.css
@@ -216,3 +216,111 @@ footer {
   color: #6e7681;
   line-height: 1.6;
 }
+
+.tab-bar {
+  display: flex;
+  gap: 4px;
+  margin-bottom: 14px;
+  border-bottom: 1px solid #30363d;
+}
+.tab {
+  background: none;
+  border: none;
+  color: #8b949e;
+  cursor: pointer;
+  font: inherit;
+  font-size: 13px;
+  padding: 8px 14px;
+  border-bottom: 2px solid transparent;
+}
+.tab:hover {
+  color: #e6edf3;
+}
+.tab-active {
+  color: #e6edf3;
+  border-bottom-color: #58a6ff;
+}
+
+.detail-sub {
+  color: #6e7681;
+  font-size: 12px;
+}
+
+.session-log {
+  margin-top: 16px;
+  background: #161b22;
+  border: 1px solid #30363d;
+  border-radius: 10px;
+  padding: 14px 18px;
+  text-align: left;
+}
+.session-log-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+.session-log-title {
+  font-size: 11px;
+  color: #8b949e;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+.log-clear {
+  background: none;
+  border: 1px solid #30363d;
+  border-radius: 4px;
+  color: #8b949e;
+  cursor: pointer;
+  font: inherit;
+  font-size: 11px;
+  padding: 2px 8px;
+}
+.log-clear:hover {
+  color: #e6edf3;
+}
+.session-log ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: #8b949e;
+  font-variant-numeric: tabular-nums;
+}
+.session-log strong {
+  color: #ff8c4a;
+  font-weight: 700;
+}
+.log-source {
+  color: #6e7681;
+  font-size: 11px;
+}
+.muted {
+  color: #6e7681;
+}
+
+.state-badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-left: 4px;
+}
+.state-attaching {
+  background: rgba(255, 196, 0, 0.15);
+  color: #f0b429;
+}
+.state-ok {
+  background: rgba(63, 185, 80, 0.15);
+  color: #3fb950;
+}
+.state-error {
+  background: rgba(248, 81, 73, 0.15);
+  color: #f85149;
+}


### PR DESCRIPTION
## Summary
- Adds path-based sub-routes (`/overview`, `/activity`) inside a stock room and a "Provider position" toggle (inside / outside the sub-route) so the session count flicker caused by remounting `ChannelProvider` can be reproduced and compared side-by-side
- Drops the loading guard on the count and adds an `attaching | ok | error` state badge so the transient `sessionCount = 0` shows up visually instead of being hidden by a "connecting…" placeholder
- Hoists a session count event log into `StockDetail` (above `ChannelProvider`) so events survive the inside-mode unmount/remount cycle and the dip is captured in the log even when the ~5 ms attach RPC is too fast to see in the big number

## Why
`ChannelProvider` initializes its store at `{ sessionCount: 0, loading: true }` on every mount. When the provider is mounted *inside* a sub-route, navigating between sibling sub-routes unmounts/remounts it, resetting the store to `0` until the new `attach` RPC completes. The previous example couldn't surface this because each stock used a distinct `channelKey`, so swapping stocks attached a brand-new channel rather than re-attaching to the same one. This change keeps the same channel across sub-routes so the inside-vs-outside placement of the provider is the only variable that changes.

## Test plan
- [x] `pnpm install`
- [x] `docker compose -f docker/docker-compose.yml up -d`
- [x] `pnpm --filter react-polling-playground dev`
- [x] Open two tabs at the same stock with the same `?key=`
- [x] With **Provider position: inside**, toggle `/overview` ↔ `/activity` in one tab — log shows `ATTACHING → 0` followed by `OK → N` per click; outside mode shows no such events

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added tabbed interface for switching between overview and activity views within stock details
  * Provider position selector controlling channel persistence behavior across view changes
  * Session event log displaying attachment state changes with timestamps
  * Enhanced instructional text describing sub-path navigation and provider positioning effects

* **Style**
  * Added styling for tab navigation, session log panel, and status badges

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie-js-sdk/pull/1250)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->