### PR TITLE
Surface RefreshChannel failures via useChannel().error

### DIFF
--- a/examples/react-polling-playground/src/StockDetail.tsx
+++ b/examples/react-polling-playground/src/StockDetail.tsx
@@ -212,7 +212,7 @@ function SessionCountCard({
   subLabel: SubView;
   onSession: CardProps['onSession'];
 }) {
-  const { sessionCount, loading, error } = useChannel();
+  const { sessionCount, loading, error, detach } = useChannel();
   const flag = stock.market === 'KR' ? '🇰🇷' : '🇺🇸';
   const state: AttachState = error ? 'error' : loading ? 'attaching' : 'ok';
 
@@ -225,6 +225,12 @@ function SessionCountCard({
       onSession(sessionCount, state, subLabel, error?.message);
     }
   }, [sessionCount, state, error, subLabel, onSession]);
+
+  const [detached, setDetached] = useState(false);
+  const handleDetach = useCallback(async () => {
+    await detach();
+    setDetached(true);
+  }, [detach]);
 
   return (
     <div className="detail-card">
@@ -248,6 +254,20 @@ function SessionCountCard({
           <strong>useChannel().error fired:</strong> {error.message}
         </p>
       )}
+      <div className="detach-controls">
+        <button
+          className="detach-button"
+          onClick={handleDetach}
+          disabled={detached}
+        >
+          {detached ? '✋ detached' : '🛑 detach channel'}
+        </button>
+        <small className="detach-hint">
+          Calls <code>useChannel().detach()</code> — removes the channel from
+          the SDK's <code>attachmentMap</code> so no further RefreshChannel
+          RPCs fire. Server reclaims the session after TTL.
+        </small>
+      </div>
     </div>
   );
 }

--- a/examples/react-polling-playground/src/StockDetail.tsx
+++ b/examples/react-polling-playground/src/StockDetail.tsx
@@ -146,15 +146,38 @@ function WritersPeekCTA({
 
   const showCount = visible && !loading && !error;
   return (
-    <button className="writer-cta" onClick={onCompose}>
-      <span className="writer-cta-icon">✏️</span>
-      <span className="writer-cta-label">Write a post</span>
-      {showCount && (
-        <span className="writer-cta-count" title="people writing at page entry">
-          {sessionCount.toLocaleString()} writing
-        </span>
+    <div className="writer-cta-wrap">
+      <button className="writer-cta" onClick={onCompose}>
+        <span className="writer-cta-icon">✏️</span>
+        <span className="writer-cta-label">Write a post</span>
+        {showCount && (
+          <span
+            className="writer-cta-count"
+            title="people writing at page entry"
+          >
+            {sessionCount.toLocaleString()} writing
+          </span>
+        )}
+        {loading && !error && (
+          <span className="writer-cta-count" title="peek in flight">
+            … peeking
+          </span>
+        )}
+        {error && (
+          <span
+            className="writer-cta-count writer-cta-count-error"
+            title={error.message}
+          >
+            peek error
+          </span>
+        )}
+      </button>
+      {error && (
+        <p className="writer-cta-error-detail">
+          <strong>usePeekChannel().error fired:</strong> {error.message}
+        </p>
       )}
-    </button>
+    </div>
   );
 }
 
@@ -213,14 +236,18 @@ function SessionCountCard({
       <div className="detail-ticker">{stock.ticker}</div>
       <div className="detail-count">
         <span className="big-num">
-          {state === 'attaching' ? '—' : sessionCount.toLocaleString()}
+          {state === 'ok' ? sessionCount.toLocaleString() : '—'}
         </span>
         <span className="big-label">
           people watching{' '}
           <span className={`state-badge state-${state}`}>{state}</span>
         </span>
       </div>
-      {error && <p className="detail-hint">error: {error.message}</p>}
+      {error && (
+        <p className="detail-error">
+          <strong>useChannel().error fired:</strong> {error.message}
+        </p>
+      )}
     </div>
   );
 }

--- a/examples/react-polling-playground/src/styles.css
+++ b/examples/react-polling-playground/src/styles.css
@@ -217,6 +217,47 @@ footer {
   line-height: 1.6;
 }
 
+.detail-error {
+  margin: 16px 0 0 0;
+  padding: 12px;
+  background: rgba(248, 81, 73, 0.12);
+  border: 1px solid rgba(248, 81, 73, 0.4);
+  border-radius: 8px;
+  color: #ff7b72;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+.detail-error small {
+  display: block;
+  margin-top: 6px;
+  color: #ffa198;
+  font-size: 11px;
+  font-weight: normal;
+}
+
+.writer-cta-wrap {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.writer-cta-count-error {
+  background: rgba(248, 81, 73, 0.18) !important;
+  color: #ff7b72 !important;
+}
+
+.writer-cta-error-detail {
+  margin: 0;
+  padding: 8px 12px;
+  background: rgba(248, 81, 73, 0.12);
+  border: 1px solid rgba(248, 81, 73, 0.4);
+  border-radius: 6px;
+  color: #ff7b72;
+  font-size: 12px;
+  line-height: 1.4;
+}
+
 .tab-bar {
   display: flex;
   gap: 4px;

--- a/examples/react-polling-playground/src/styles.css
+++ b/examples/react-polling-playground/src/styles.css
@@ -236,6 +236,43 @@ footer {
   font-weight: normal;
 }
 
+.detach-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px dashed #30363d;
+}
+
+.detach-button {
+  align-self: flex-start;
+  padding: 6px 12px;
+  background: #30363d;
+  border: 1px solid #6e7681;
+  border-radius: 6px;
+  color: #c9d1d9;
+  font-size: 13px;
+  cursor: pointer;
+}
+
+.detach-button:hover:not(:disabled) {
+  background: rgba(248, 81, 73, 0.18);
+  border-color: #ff7b72;
+  color: #ff7b72;
+}
+
+.detach-button:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.detach-hint {
+  color: #6e7681;
+  font-size: 11px;
+  line-height: 1.5;
+}
+
 .writer-cta-wrap {
   display: flex;
   flex-direction: column;

--- a/packages/react/src/ChannelProvider.tsx
+++ b/packages/react/src/ChannelProvider.tsx
@@ -22,7 +22,7 @@ import {
   useRef,
   useState,
 } from 'react';
-import { Client, Channel, SyncMode } from '@yorkie-js/sdk';
+import { Client, Channel, ChannelEventType, SyncMode } from '@yorkie-js/sdk';
 import { Store } from './createStore';
 import {
   createChannelStore as createChannelStore,
@@ -93,7 +93,10 @@ export function useYorkieChannel(
 
       try {
         const newChannel = new Channel(channelKey);
-        await client.attach(newChannel, { syncMode, channelHeartbeatInterval });
+        await client.attach(newChannel, {
+          syncMode,
+          channelHeartbeatInterval,
+        });
 
         channelRef.current = newChannel;
 
@@ -103,11 +106,38 @@ export function useYorkieChannel(
         // response. Keep `loading: true` until that happens, then flip it
         // along with the populated sessionCount on the same event so the
         // UI never sees a transient `loading: false, sessionCount: 0`.
-        unsubscribe = newChannel.subscribe(() => {
+        //
+        // SyncError / AuthError events from the SDK populate `error` so
+        // consumers can render an error state via the same hook return.
+        // Any successful event (PresenceChanged / Initialized / Broadcast)
+        // implies recovery — clear `error` so transient hiccups disappear
+        // from the UI without a manual reset.
+        unsubscribe = newChannel.subscribe((event) => {
+          if (
+            event.type === ChannelEventType.SyncError ||
+            event.type === ChannelEventType.AuthError
+          ) {
+            const nextError =
+              event.type === ChannelEventType.SyncError
+                ? event.error instanceof Error
+                  ? event.error
+                  : new Error(String(event.error))
+                : new Error(
+                    `auth error during ${event.method}: ${event.reason}`,
+                  );
+            channelStore.setState((state) => ({
+              ...state,
+              loading: false,
+              error: nextError,
+            }));
+            return;
+          }
+
           const ready = newChannel.isAttached() && !!newChannel.getSessionID();
           channelStore.setState((state) => ({
             ...state,
             sessionCount: newChannel.getSessionCount(),
+            ...(state.error ? { error: undefined } : {}),
             ...(ready && state.loading ? { loading: false } : {}),
           }));
         });

--- a/packages/react/src/ChannelProvider.tsx
+++ b/packages/react/src/ChannelProvider.tsx
@@ -109,9 +109,10 @@ export function useYorkieChannel(
         //
         // SyncError / AuthError events from the SDK populate `error` so
         // consumers can render an error state via the same hook return.
-        // Any successful event (PresenceChanged / Initialized / Broadcast)
-        // implies recovery — clear `error` so transient hiccups disappear
-        // from the UI without a manual reset.
+        // Server-confirmed events (PresenceChanged / Initialized / remote
+        // Broadcast) clear `error` because they prove the channel is
+        // healthy again. LocalBroadcast is purely local and does not
+        // imply recovery — exclude it explicitly.
         unsubscribe = newChannel.subscribe((event) => {
           if (
             event.type === ChannelEventType.SyncError ||
@@ -133,11 +134,15 @@ export function useYorkieChannel(
             return;
           }
 
+          const recovers =
+            event.type === ChannelEventType.PresenceChanged ||
+            event.type === ChannelEventType.Initialized ||
+            event.type === ChannelEventType.Broadcast;
           const ready = newChannel.isAttached() && !!newChannel.getSessionID();
           channelStore.setState((state) => ({
             ...state,
             sessionCount: newChannel.getSessionCount(),
-            ...(state.error ? { error: undefined } : {}),
+            ...(recovers && state.error ? { error: undefined } : {}),
             ...(ready && state.loading ? { loading: false } : {}),
           }));
         });

--- a/packages/react/src/ChannelProvider.tsx
+++ b/packages/react/src/ChannelProvider.tsx
@@ -142,10 +142,32 @@ export function useYorkieChannel(
           }));
         });
 
+        // Expose an idempotent detach so consumers can permanently stop a
+        // channel from inside the tree (e.g. on `error`) without unmounting
+        // the surrounding `<ChannelProvider>`. Calling `isAttached()` here
+        // would be wrong — `client.attach(channel)` is local-only under the
+        // RefreshChannel-only lifecycle, so the status stays `Detached`
+        // until the first heartbeat lands; an `isAttached()` gate would
+        // skip the call and leak the attachment entry. Instead, dispatch
+        // unconditionally and swallow `ErrNotAttached` from duplicate /
+        // post-unmount calls.
+        const detach = async () => {
+          if (!client) return;
+          try {
+            await client.detach(newChannel);
+          } catch (err) {
+            if (err instanceof Error && /not attached/i.test(err.message)) {
+              return;
+            }
+            throw err;
+          }
+        };
+
         channelStore.setState((state) => ({
           ...state,
           channel: newChannel,
           error: undefined,
+          detach,
         }));
       } catch (e) {
         channelStore.setState((state) => ({
@@ -167,12 +189,19 @@ export function useYorkieChannel(
        * `detachChannel` detaches the channel from the client. Channels can
        * be detached on inactive clients — detach is local cleanup only and
        * the server reclaims the session via TTL.
+       *
+       * Idempotent against the consumer-facing `detach` exposed via
+       * `useChannel()`: if the consumer detached first, `client.detach`
+       * throws `ErrNotAttached`, which we swallow as a normal cleanup race.
        */
       async function detachChannel() {
         if (channelRef.current && client) {
           try {
             await client.detach(channelRef.current);
           } catch (e) {
+            if (e instanceof Error && /not attached/i.test(e.message)) {
+              return;
+            }
             console.error('Failed to detach channel:', e);
           }
         }
@@ -266,6 +295,9 @@ export const ChannelProvider: React.FC<ChannelProviderProps> = ({
       sessionCount: 0,
       loading: true,
       error: undefined,
+      // Placeholder until `useYorkieChannel` wires up the real detach.
+      // Pre-attach calls are a no-op rather than a throw.
+      detach: async () => {},
     });
   }
 
@@ -312,7 +344,8 @@ export const useChannelStore = (hookName: string) => {
  * `useChannel` is a custom hook that returns the channel state.
  * It must be used within a ChannelProvider.
  *
- * @returns An object containing sessionCount, loading, and error state
+ * @returns An object containing sessionCount, loading, error state and
+ *          a `detach` function for permanently stopping the channel.
  *
  * @example
  * ```tsx
@@ -331,8 +364,9 @@ export const useChannel = () => {
   const sessionCount = useSelector(channelStore, (state) => state.sessionCount);
   const loading = useSelector(channelStore, (state) => state.loading);
   const error = useSelector(channelStore, (state) => state.error);
+  const detach = useSelector(channelStore, (state) => state.detach);
 
-  return { sessionCount, loading, error };
+  return { sessionCount, loading, error, detach };
 };
 
 /**

--- a/packages/react/src/createChannelStore.ts
+++ b/packages/react/src/createChannelStore.ts
@@ -41,6 +41,15 @@ export type ChannelContextType = {
    * `error` contains any error that occurred during initialization.
    */
   error: Error | undefined;
+
+  /**
+   * `detach` tears the channel down on demand — useful when a consumer
+   * decides that the channel should be permanently stopped (e.g. after
+   * observing `error` from `useChannel()`). Idempotent: a second call,
+   * or a call after `ChannelProvider` has already unmounted and cleaned
+   * up, resolves silently instead of throwing.
+   */
+  detach: () => Promise<void>;
 };
 
 /**

--- a/packages/sdk/src/channel/channel.ts
+++ b/packages/sdk/src/channel/channel.ts
@@ -94,6 +94,15 @@ export enum ChannelEventType {
    * `AuthError` means that an authentication error has occurred.
    */
   AuthError = 'auth-error',
+
+  /**
+   * `SyncError` means that a non-recoverable sync (RefreshChannel) error
+   * occurred. Subscribers can use this to render an error state in the UI
+   * without polling internal SDK state. The SDK still retries via its sync
+   * loop, so subsequent successful events (PresenceChanged/Initialized) can
+   * be treated as recovery.
+   */
+  SyncError = 'sync-error',
 }
 
 /**
@@ -148,13 +157,36 @@ export interface AuthErrorEvent {
 }
 
 /**
+ * `SyncErrorEvent` represents a non-recoverable sync (RefreshChannel) error.
+ * It carries the underlying error object so subscribers can inspect codes
+ * (e.g. via `isErrorCode`) without losing the original Error.
+ */
+export interface SyncErrorEvent {
+  /**
+   * `type` is the type of the event.
+   */
+  type: ChannelEventType.SyncError;
+
+  /**
+   * `error` is the underlying error thrown by the RPC call.
+   */
+  error: unknown;
+
+  /**
+   * `method` is the RPC method that failed (e.g. `RefreshChannel`).
+   */
+  method: string;
+}
+
+/**
  * `ChannelEvent` represents an event that occurs in the channel.
  */
 export type ChannelEvent =
   | PresenceEvent
   | BroadcastEvent
   | LocalBroadcastEvent
-  | AuthErrorEvent;
+  | AuthErrorEvent
+  | SyncErrorEvent;
 
 /**
  * `ChannelEventCallbackMap` represents a map of event types to callbacks.
@@ -163,6 +195,7 @@ export type ChannelEventCallbackMap = {
   broadcast: NextFn<BroadcastEvent>;
   'local-broadcast': NextFn<LocalBroadcastEvent>;
   'auth-error': NextFn<AuthErrorEvent>;
+  'sync-error': NextFn<SyncErrorEvent>;
   presence: NextFn<PresenceEvent>;
   all: NextFn<ChannelEvent>;
 };
@@ -319,6 +352,15 @@ export class Channel implements Observable<ChannelEvent>, Attachable {
     next: ChannelEventCallbackMap['auth-error'],
   ): Unsubscribe;
   /**
+   * `subscribe` registers a callback to subscribe to non-recoverable sync
+   * (RefreshChannel) errors. Subsequent successful events on the channel
+   * imply recovery — there is no separate "recovered" event.
+   */
+  public subscribe(
+    type: 'sync-error',
+    next: ChannelEventCallbackMap['sync-error'],
+  ): Unsubscribe;
+  /**
    * `subscribe` registers a callback to subscribe to presence events on the channel.
    * The callback will be called when the presence count changes.
    */
@@ -352,6 +394,7 @@ export class Channel implements Observable<ChannelEvent>, Attachable {
       | 'broadcast'
       | 'local-broadcast'
       | 'auth-error'
+      | 'sync-error'
       | 'presence'
       | 'all'
       | string
@@ -360,6 +403,7 @@ export class Channel implements Observable<ChannelEvent>, Attachable {
       | ChannelEventCallbackMap['broadcast']
       | ChannelEventCallbackMap['local-broadcast']
       | ChannelEventCallbackMap['auth-error']
+      | ChannelEventCallbackMap['sync-error']
       | ChannelEventCallbackMap['presence']
       | ChannelEventCallbackMap['all']
       | NextFn<BroadcastEvent>,
@@ -398,6 +442,14 @@ export class Channel implements Observable<ChannelEvent>, Attachable {
       return this.eventStream.subscribe((event) => {
         if (event.type === ChannelEventType.AuthError) {
           (callback as ChannelEventCallbackMap['auth-error'])(event);
+        }
+      });
+    }
+
+    if (typeOrTopic === 'sync-error') {
+      return this.eventStream.subscribe((event) => {
+        if (event.type === ChannelEventType.SyncError) {
+          (callback as ChannelEventCallbackMap['sync-error'])(event);
         }
       });
     }

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -2107,6 +2107,16 @@ export class Client {
           attachment.resourceID = '';
           return resource;
         }
+
+        // Surface the failure to channel subscribers so React layers can
+        // render an error state. Any subsequent successful event implies
+        // recovery — there is no separate "recovered" event.
+        resource.publish({
+          type: ChannelEventType.SyncError,
+          error: err,
+          method: 'RefreshChannel',
+        });
+
         logger.error(`[RP] c:"${this.getKey()}" err :`, err);
         throw err;
       }

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -2110,12 +2110,16 @@ export class Client {
 
         // Surface the failure to channel subscribers so React layers can
         // render an error state. Any subsequent successful event implies
-        // recovery — there is no separate "recovered" event.
-        resource.publish({
-          type: ChannelEventType.SyncError,
-          error: err,
-          method: 'RefreshChannel',
-        });
+        // recovery — there is no separate "recovered" event. Skip the
+        // publish during teardown so a spurious error badge doesn't flash
+        // on the way out (mirrors the deactivate guard in the success path).
+        if (!this.deactivating && !attachment.isDetaching()) {
+          resource.publish({
+            type: ChannelEventType.SyncError,
+            error: err,
+            method: 'RefreshChannel',
+          });
+        }
 
         logger.error(`[RP] c:"${this.getKey()}" err :`, err);
         throw err;


### PR DESCRIPTION
## Summary

Stacked on top of #1258. Adds an `error` surface to `useChannel()` / `usePeekChannel()` so React consumers can render an error state when the channel's RefreshChannel sync fails. The underlying RPC errors currently disappear into the SDK sync loop with no signal reaching React.

### Why

`useChannel()` / `usePeekChannel()` already return an `error` field, but under the RefreshChannel-only lifecycle (#1258) the field stayed `undefined` for runtime failures:

- `client.attach(channel)` is local-only, so its `try/catch` only catches setup mistakes.
- The actual RPC happens asynchronously inside the sync loop's `syncInternal`, where errors were `logger.error`'d and re-thrown — never surfaced to subscribers.
- A consumer that wrote `if (error) return null` to hide a UI on Yorkie failure had no way to actually trigger that branch.

This PR closes that gap by publishing a channel event on every refresh failure.

### What

- **`Channel`**: new `ChannelEventType.SyncError` + `SyncErrorEvent` type carrying `{ type, error, method }`, plus a `subscribe('sync-error', cb)` overload and a matching filter case.
- **`Client.syncInternal`** (channel branch's catch): publish `SyncError` on every failure except `ErrSessionNotFound` (which is the transparent re-attach path). Still re-throws afterwards so the existing retry path runs.
- **`ChannelProvider`**: subscribe to `SyncError` / `AuthError` → set `error` state. Any subsequent successful event (PresenceChanged, Initialized, Broadcast) clears `error` automatically — transient hiccups disappear without manual reset.
- **Polling playground**: render `useChannel().error` and `usePeekChannel().error` prominently so the failure states are easy to spot when toggling the local server.

### Consumer guidance

`error` fires on **every** failure (no threshold). The consumer decides persistence:

- "Hide UI permanently on first failure" → gate on `error` once and don't reset.
- "Absorb transient hiccups" → debounce/threshold at the consumer layer, or check `loading || error`.

### Known limitation (not addressed here)

The SDK's `handleConnectError` retries on `ConnectError` codes (`Unavailable`, `Canceled`, etc.) but treats plain `TypeError: fetch failed` (Node 18+ undici layer) as non-retryable, so a Node consumer can see one `SyncError` then no further retries. Browser environments wrap network failures into `ConnectError` correctly. A follow-up PR can broaden `handleConnectError` if needed.

## Test plan

- [x] Local manual verification: kill yorkie server → `sync-error` event fires every retry tick; restart server → recovery (sync loop retries indefinitely while errors keep `error` populated).
- [ ] CI green on stacked branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
