### PR TITLE
Silence post-success cleanup AbortError from connect-rpc unary calls

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -395,10 +395,65 @@ export class Client {
       baseUrl: rpcAddr,
       interceptors: [authInterceptor, createMetricInterceptor(opts?.userAgent)],
       fetch: (input: RequestInfo | URL, init?: RequestInit) => {
+        const url =
+          typeof input === 'string'
+            ? input
+            : input instanceof URL
+              ? input.toString()
+              : input.url;
+
+        // Server-streaming RPCs (Watch/WatchDocument/WatchChannel) need the
+        // caller's signal active for the response body's full lifetime so
+        // user-initiated cancellation can reach the underlying connection.
+        if (/\/yorkie\.v1\.YorkieService\/Watch/.test(url)) {
+          return fetch(input as RequestInfo, {
+            ...init,
+            keepalive: this.keepalive,
+          });
+        }
+
+        // For unary RPCs, @connectrpc/connect calls AbortController.abort()
+        // on its per-call signal as cleanup after the call completes — even
+        // on success. In browsers that stray abort surfaces as an
+        // "Uncaught (in promise) AbortError: The user aborted a request."
+        // tied to the (already-finished) fetch's body stream and gets picked
+        // up by global error trackers once per call. Decouple our underlying
+        // fetch from the caller's signal once the response is in hand so the
+        // post-success cleanup abort does not propagate. Aborts that arrive
+        // before the response settles still cancel the fetch via the
+        // forwarding listener.
+        const callerSignal =
+          init?.signal ?? (input instanceof Request ? input.signal : undefined);
+        const innerAC = new AbortController();
+        let onCallerAbort: (() => void) | undefined;
+        if (callerSignal) {
+          if (callerSignal.aborted) {
+            innerAC.abort(callerSignal.reason);
+          } else {
+            onCallerAbort = () => innerAC.abort(callerSignal.reason);
+            callerSignal.addEventListener('abort', onCallerAbort);
+          }
+        }
+        const detach = () => {
+          if (callerSignal && onCallerAbort) {
+            callerSignal.removeEventListener('abort', onCallerAbort);
+          }
+        };
+
         return fetch(input as RequestInfo, {
           ...init,
+          signal: innerAC.signal,
           keepalive: this.keepalive,
-        });
+        }).then(
+          (res) => {
+            detach();
+            return res;
+          },
+          (err) => {
+            detach();
+            throw err;
+          },
+        );
       },
     };
 


### PR DESCRIPTION
## Summary

- Decouple the underlying fetch from the caller's `AbortSignal` once the response is received for unary RPCs, so the post-success cleanup `abort()` that `@connectrpc/connect` fires unconditionally no longer leaks as an `Uncaught (in promise) AbortError: The user aborted a request.`
- Server-streaming RPCs (`Watch` / `WatchDocument` / `WatchChannel`) are exempt — their response body lives long after `fetch` resolves and must remain cancellable via the caller's signal.

## Background

After every successful unary call, `@connectrpc/connect` calls `AbortController.abort()` on its per-call signal as cleanup. In browsers, that stray abort surfaces as an `AbortError` rejected promise tied to the (already finished) fetch body stream that nobody catches → unhandled rejection. Global error trackers (Sentry, vConsole) capture it once per call.

For channel-only apps using polling mode (`<YorkieProvider activate={false}>` + `SyncMode.Polling`), this fires every `channelHeartbeatInterval` tick (default 5s) on `RefreshChannel`, producing a constant stream of false-positive errors despite every request returning `200 OK`.

### Evidence

Captured against a live polling-only deployment via Playwright:

| measurement | value |
| --- | --- |
| abort cadence | 5034 / 5041 / 5043 / 5069 ms — matches `DefaultChannelHeartbeatMs = 5000` |
| abort caller | `Object.unary` inside `@connectrpc/connect` (not yorkie code) |
| abort vs fetch end | within ±1 ms of `RefreshChannel` 200 OK response |
| HTTP outcome | every `RefreshChannel` returns `200`; no functional failure |

This matches the long-known browser behavior captured upstream:
- [Mozilla bug 1583815](https://bugzilla.mozilla.org/show_bug.cgi?id=1583815)
- [WebKit bug 215771](https://bugs.webkit.org/show_bug.cgi?id=215771)

## How the fix works

```text
caller (connect-rpc)            our wrapper                  underlying fetch
─────────────────────          ──────────────────           ──────────────────
init.signal = callerAC.signal
                       ──────►  innerAC = new AC
                                forward: callerAC.abort ─► innerAC.abort
                                signal = innerAC.signal  ─────►  fetch(...)
                                                                        │
                                            ◄──── 200 OK response ──────┘
                                detach forwarder              (body owned by fetch
                                return res ───►                tied to innerAC)
read body, parse...
callerAC.abort()  (cleanup)
                                forwarder gone → innerAC unaffected
                                → fetch body sees no abort
                                → no stray AbortError
```

- Abort arriving **before** the response settles still propagates through the forwarder → fetch is cancelled → connect-rpc surfaces a `ConnectError` with code `Canceled`. Real cancellation semantics are preserved.
- Network errors, HTTP errors, and body parsing errors are unaffected — they were already being raised through the normal promise rejection path, which still runs.
- Only the post-success cleanup `abort()` (the false-positive case) is silenced.

## Why not blanket-decouple for streaming too

Server-streaming RPCs resolve `fetch` after headers, then iterate the response body long after that. If we detached the caller signal at fetch-resolve time, the SDK's own `attachment.cancelWatchStream()` → `AbortController.abort()` would no longer reach the underlying fetch, leaking watch connections. The URL-prefix check (`/yorkie.v1.YorkieService/Watch`) routes streaming calls down the plain pass-through path so their cancellation still works end-to-end.

## Test plan

- [x] `pnpm lint` — no new errors (baseline on `main` is identical)
- [x] `pnpm sdk build` — succeeds
- [ ] Verify on a live polling deployment that the 5s `AbortError` console noise is gone after consuming the new SDK build
- [ ] Verify on a Realtime channel deployment that watch streams still cancel correctly on unmount / detach (no leaked connections)
- [ ] Verify that genuine network failures still surface as `SyncError` events to channel subscribers

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request cancellation handling to distinguish between streaming and unary RPCs, preventing spurious abort errors after successful responses
  * Enhanced lifecycle management for request abort signals to ensure proper cleanup without surfacing false cancellation errors

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie-js-sdk/pull/1263?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->