### PR TITLE
Release v0.7.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,19 @@ and Yorkie JS SDK adheres to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+## [v0.7.10] - 2026-05-27
+
+### Added
+
+- Add disableGC attach option by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1265
+
+### Changed
+
 - Channel lifecycle via RefreshChannel only by @JOOHOJANG in https://github.com/yorkie-team/yorkie-js-sdk/pull/1258
-- Silence post-success cleanup AbortError from connect-rpc unary calls by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1263
+
+### Fixed
+
+- Silence post-success cleanup AbortError from connect-rpc unary calls by @JOOHOJANG in https://github.com/yorkie-team/yorkie-js-sdk/pull/1263
 
 ## [v0.7.9] - 2026-05-14
 

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yorkie-js/devtools",
   "displayName": "Yorkie Devtools",
-  "version": "0.7.9",
+  "version": "0.7.10",
   "description": "A browser extension that helps you debug Yorkie.",
   "homepage": "https://yorkie.dev/",
   "scripts": {

--- a/packages/prosemirror/package.json
+++ b/packages/prosemirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/prosemirror",
-  "version": "0.7.10-rc",
+  "version": "0.7.10",
   "description": "ProseMirror binding for Yorkie collaborative editing",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/react",
-  "version": "0.7.10-rc2",
+  "version": "0.7.10",
   "description": "A set of hooks and providers for Yorkie JS SDK",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/schema",
-  "version": "0.7.10-rc",
+  "version": "0.7.10",
   "description": "Yorkie Schema for Yorkie Document",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/sdk",
-  "version": "0.7.10-rc2",
+  "version": "0.7.10",
   "description": "Yorkie JS SDK",
   "main": "./src/yorkie.ts",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release v0.7.10.

### Added

- Add disableGC attach option by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1265

### Changed

- Channel lifecycle via RefreshChannel only by @JOOHOJANG in https://github.com/yorkie-team/yorkie-js-sdk/pull/1258

### Fixed

- Silence post-success cleanup AbortError from connect-rpc unary calls by @JOOHOJANG in https://github.com/yorkie-team/yorkie-js-sdk/pull/1263

## Test plan

- [x] CI green
- [x] All publishable packages bumped to 0.7.10