### PR TITLE
Archive completed v0.7.10 task

### DIFF
--- a/docs/tasks/README.md
+++ b/docs/tasks/README.md
@@ -1,8 +1,8 @@
 ---
-updated: 2026-04-29
+updated: 2026-05-27
 ---
 
 # Tasks
 
-- [active/](active/README.md) — In-progress tasks
-- [archive/](archive/README.md) — Completed tasks
+- `active/` — In-progress tasks
+- `archive/` — Completed tasks

--- a/docs/tasks/active/README.md
+++ b/docs/tasks/active/README.md
@@ -1,5 +1,5 @@
 ---
-updated: 2026-05-15
+updated: 2026-05-27
 ---
 
 # Active Tasks

--- a/docs/tasks/archive/2026/05/20260527-disable-gc-on-attach-todo.md
+++ b/docs/tasks/archive/2026/05/20260527-disable-gc-on-attach-todo.md
@@ -1,3 +1,5 @@
+**Created**: 2026-05-27
+
 # Disable GC on Attach — JS SDK
 
 **Goal:** Mirror the server-side `disable_gc` opt-out (yorkie PR #1822)
@@ -27,7 +29,7 @@ RPCs and surface the option to user code.
   - mixed opt-in / opt-out clients converge on Counter value
   - re-attach without the option restores normal behavior
 - [x] Verify `pnpm sdk build` clean.
-- [ ] Verify `pnpm sdk test` against a yorkie server with the
+- [x] Verify `pnpm sdk test` against a yorkie server with the
       matching wire contract (released after the Go PR merges).
 
 ## Notes

--- a/docs/tasks/archive/README.md
+++ b/docs/tasks/archive/README.md
@@ -1,23 +1,24 @@
 ---
-updated: 2026-05-15
+updated: 2026-05-27
 ---
 
 # Archived Tasks
 
 ## 2026-05
 
-- [20260515-webhook-test-fast-fail-todo](2026/05/20260515-webhook-test-fast-fail-todo.md) / [lessons](2026/05/20260515-webhook-test-fast-fail-lessons.md) — Webhook Test Fast Fail Plan
-- [20260504-polling-sync-mode-todo](2026/05/20260504-polling-sync-mode-todo.md) / [lessons](2026/05/20260504-polling-sync-mode-lessons.md) — Polling Sync Mode Implementation Plan
+- [[20260504-polling-sync-mode-todo]] — Polling Sync Mode Implementation Plan
+- [[20260515-webhook-test-fast-fail-todo]] — Webhook Test Fast Fail Plan
+- [[20260527-disable-gc-on-attach-todo]] — **Created**: 2026-05-27
 
 ## 2026-04
 
-- [20260327-epoch-mismatch-todo](2026/04/20260327-epoch-mismatch-todo.md) — Epoch Mismatch Handling in JS SDK
-- [20260402-style-by-path-range-todo](2026/04/20260402-style-by-path-range-todo.md) / [lessons](2026/04/20260402-style-by-path-range-lessons.md) — **Created**: 2026-04-02
-- [20260409-prosemirror-native-split-merge-todo](2026/04/20260409-prosemirror-native-split-merge-todo.md) — **Created**: 2026-04-09
-- [20260410-merged-fields-snapshot-todo](2026/04/20260410-merged-fields-snapshot-todo.md) — **Created**: 2026-04-10
-- [20260415-tree-split-undo-redo-todo](2026/04/20260415-tree-split-undo-redo-todo.md) — **Created**: 2026-04-15
-- [20260422-fix-detach-sync-race-todo](2026/04/20260422-fix-detach-sync-race-todo.md) — Fix Detach/Sync Race Condition Implementation Plan
-- [20260422-presence-event-reconciliation-todo](2026/04/20260422-presence-event-reconciliation-todo.md) — Presence Event Reconciliation Implementation Plan
-- [20260425-tree-split-l2-undo-redo-todo](2026/04/20260425-tree-split-l2-undo-redo-todo.md) — **Created**: 2026-04-25
-- [20260428-tree-reverseop-pretombstoned-filter-todo](2026/04/20260428-tree-reverseop-pretombstoned-filter-todo.md) / [lessons](2026/04/20260428-tree-reverseop-pretombstoned-filter-lessons.md) — **Created**: 2026-04-28
+- [[20260327-epoch-mismatch-todo]] — Epoch Mismatch Handling in JS SDK
+- [[20260402-style-by-path-range-todo]] — **Created**: 2026-04-02
+- [[20260409-prosemirror-native-split-merge-todo]] — **Created**: 2026-04-09
+- [[20260410-merged-fields-snapshot-todo]] — **Created**: 2026-04-10
+- [[20260415-tree-split-undo-redo-todo]] — **Created**: 2026-04-15
+- [[20260422-fix-detach-sync-race-todo]] — Fix Detach/Sync Race Condition Implementation Plan
+- [[20260422-presence-event-reconciliation-todo]] — Presence Event Reconciliation Implementation Plan
+- [[20260425-tree-split-l2-undo-redo-todo]] — **Created**: 2026-04-25
+- [[20260428-tree-reverseop-pretombstoned-filter-todo]] — **Created**: 2026-04-28
 


### PR DESCRIPTION
## Summary

Archive the disable-gc-on-attach task — shipped in v0.7.10 via #1265.

Adds the missing `**Created**:` line so the archive script can parse the date.

## Test plan

- [x] `bash scripts/tasks-archive.sh`
- [x] `bash scripts/tasks-index.sh` regenerates indexes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated task tracking documentation with current timestamps across multiple sections
  * Added comprehensive documentation for new JS SDK feature enabling garbage collection control during document attachment
  * Improved documentation organization and formatting for better navigation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie-js-sdk/pull/1267?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->