### PR TITLE
Expose disableGC attach option in React package

### DIFF
--- a/packages/react/src/DocumentProvider.tsx
+++ b/packages/react/src/DocumentProvider.tsx
@@ -59,6 +59,7 @@ export function useYorkieDocument<R, P extends Indexable = Indexable>(
   enableDevtools: boolean,
   syncMode: SyncMode | undefined,
   documentPollInterval: number | undefined,
+  disableGC: boolean | undefined,
   docStore: Store<DocumentContextType<R, P>>,
 ) {
   const initialRootRef = useRef(initialRoot);
@@ -136,6 +137,7 @@ export function useYorkieDocument<R, P extends Indexable = Indexable>(
           initialPresence: initialPresenceRef.current,
           syncMode,
           documentPollInterval,
+          disableGC,
         });
 
         const update = (callback: (root: R, presence: Presence<P>) => void) => {
@@ -193,6 +195,7 @@ export function useYorkieDocument<R, P extends Indexable = Indexable>(
     didMount,
     syncMode,
     documentPollInterval,
+    disableGC,
   ]);
 }
 
@@ -222,6 +225,7 @@ export const DocumentProvider = <R, P extends Indexable = Indexable>({
   enableDevtools = false,
   syncMode,
   documentPollInterval,
+  disableGC,
   children,
 }: {
   docKey: string;
@@ -238,6 +242,13 @@ export const DocumentProvider = <R, P extends Indexable = Indexable>({
    * Default: 3000. Applied at attach time.
    */
   documentPollInterval?: number;
+  /**
+   * `disableGC` declares that this attachment will not produce or consume
+   * tombstones. Use only with Counter or primitive workloads; misuse on a
+   * document that uses Tree, Text, or Array deletions leads to undefined
+   * GC behavior on this client.
+   */
+  disableGC?: boolean;
   children?: React.ReactNode;
 }) => {
   const { client, loading: clientLoading, error: clientError } = useYorkie();
@@ -274,6 +285,7 @@ export const DocumentProvider = <R, P extends Indexable = Indexable>({
     enableDevtools,
     syncMode,
     documentPollInterval,
+    disableGC,
     documentStore,
   );
 

--- a/packages/react/src/useYorkieDoc.ts
+++ b/packages/react/src/useYorkieDoc.ts
@@ -41,6 +41,13 @@ export function useYorkieDoc<R, P extends Indexable = Indexable>(
     enableDevtools?: boolean;
     syncMode?: SyncMode;
     documentPollInterval?: number;
+    /**
+     * `disableGC` declares that this attachment will not produce or consume
+     * tombstones. Use only with Counter or primitive workloads; misuse on a
+     * document that uses Tree, Text, or Array deletions leads to undefined
+     * GC behavior on this client.
+     */
+    disableGC?: boolean;
   },
 ): {
   root: R;
@@ -95,6 +102,7 @@ export function useYorkieDoc<R, P extends Indexable = Indexable>(
     opts?.enableDevtools ?? false,
     opts?.syncMode,
     opts?.documentPollInterval,
+    opts?.disableGC,
     documentStore,
   );
 

--- a/packages/react/test/unit/useYorkieDoc.test.ts
+++ b/packages/react/test/unit/useYorkieDoc.test.ts
@@ -175,6 +175,7 @@ describe('useYorkieDoc', () => {
         false,
         undefined,
         undefined,
+        undefined,
         mockDocumentStore,
       );
     });


### PR DESCRIPTION
## Summary

Mirrors the SDK's `disableGC` attach option (added in #1265) on the React layer. `DocumentProvider` and `useYorkieDoc` now accept `disableGC?: boolean`, which is plumbed through `useYorkieDocument` to the underlying `client.attach()` call.

Default is `undefined`, so existing callers are unaffected. The same caveat as the SDK option applies: misuse on a document that uses Tree, Text, or Array deletions leads to undefined GC behavior on this client.

## Usage

```tsx
<DocumentProvider docKey="counter" disableGC>{...}</DocumentProvider>

useYorkieDoc(apiKey, docKey, { disableGC: true });
```

## Test plan

- [x] `pnpm react build` — passes
- [x] `pnpm --filter=@yorkie-js/react test` — 88/88 passing (updated the `useYorkieDocument` call-args assertion in `useYorkieDoc.test.ts` to include the new arg)
- [x] `pnpm lint` — no new errors introduced (pre-existing count unchanged)
- [x] Manual smoke test with a Counter workload setting `disableGC: true` via `useYorkieDoc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)