### PR TITLE
Stop disableGC clients from accumulating per-Change VV

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -682,6 +682,10 @@ export class Client {
         }
 
         const pack = converter.fromChangePack<P>(res.changePack!);
+        // Record the opt-out decision before applying the attach response
+        // so the first applyChangePack already routes remote changes
+        // through the lamport-only sync path.
+        doc.setDisableGC(opts.disableGC ?? false);
         doc.applyChangePack(pack);
 
         if (doc.getStatus() === DocStatus.Removed) {

--- a/packages/sdk/src/document/change/change_id.ts
+++ b/packages/sdk/src/document/change/change_id.ts
@@ -130,6 +130,30 @@ export class ChangeID {
   }
 
   /**
+   * `syncLamport` advances the lamport clock against the given ID without
+   * merging its version vector into the receiver's. It is the counterpart
+   * of `syncClocks` for attachments that have opted out of GC participation
+   * (see docs/design/disable-gc-on-attach.md in the server repo): the
+   * receiver does not need other actors' entries in its VV because it
+   * never produces or consumes tombstones, and dropping them keeps each
+   * subsequent local Change's VV at O(1) instead of O(num_actors).
+   * Lamport must still advance so that TimeTickets produced locally
+   * remain ordered against remote operations.
+   */
+  public syncLamport(other: ChangeID): ChangeID {
+    if (!other.hasClocks()) {
+      return this;
+    }
+
+    const lamport =
+      other.lamport > this.lamport ? other.lamport + 1n : this.lamport + 1n;
+
+    const vector = this.versionVector.deepcopy();
+    vector.set(this.actor, lamport);
+    return new ChangeID(this.clientSeq, lamport, this.actor, vector);
+  }
+
+  /**
    * `setClocks` sets the given clocks to this ID. This is used when the snapshot
    * is given from the server.
    */

--- a/packages/sdk/src/document/document.ts
+++ b/packages/sdk/src/document/document.ts
@@ -553,6 +553,13 @@ export class Document<
   private eventStream: Observable<DocEvents<P>>;
   private eventStreamObserver!: Observer<DocEvents<P>>;
 
+  // `disableGC`, when true, declares that this document does not produce or
+  // consume tombstones (see disable-gc-on-attach in the server repo). It is
+  // set by the client on Attach and consumed by applyChange to skip merging
+  // remote actors' version vectors into changeID, keeping each subsequent
+  // local Change's VV at O(1) for high-fan-out Counter workloads.
+  private disableGC: boolean;
+
   /**
    * `history` is exposed to the user to manage undo/redo operations.
    */
@@ -568,6 +575,7 @@ export class Document<
     this.changeID = InitialChangeID;
     this.checkpoint = InitialCheckpoint;
     this.localChanges = [];
+    this.disableGC = false;
 
     this.root = CRDTRoot.create();
     this.presences = new Map();
@@ -1191,6 +1199,15 @@ export class Document<
   }
 
   /**
+   * `setDisableGC` records whether this document participates in GC. The
+   * client calls this on attach so subsequent applyChange runs use the
+   * lamport-only sync path.
+   */
+  public setDisableGC(disableGC: boolean): void {
+    this.disableGC = disableGC;
+  }
+
+  /**
    * `isEnableDevtools` returns whether devtools is enabled or not.
    */
   public isEnableDevtools(): boolean {
@@ -1487,7 +1504,9 @@ export class Document<
         );
       }
     }
-    this.changeID = this.changeID.syncClocks(change.getID());
+    this.changeID = this.disableGC
+      ? this.changeID.syncLamport(change.getID())
+      : this.changeID.syncClocks(change.getID());
     if (opInfos.length) {
       const rawChange = this.isEnableDevtools() ? change.toStruct() : undefined;
       events.push(

--- a/packages/sdk/test/integration/disable_gc_test.ts
+++ b/packages/sdk/test/integration/disable_gc_test.ts
@@ -92,6 +92,128 @@ describe('disableGC attach option', function () {
     }
   });
 
+  it('Opt-out clients keep per-Change VV at size 1 under multi-actor fanout', async function ({
+    task,
+  }) {
+    // Regression for the bug where Change.ID.versionVector accumulated
+    // O(num_actors) entries on every opt-out client because applyChange
+    // -> syncClocks merged every remote actor into the local VV. After
+    // the syncLamport fix the per-Change VV must stay at size 1 so the
+    // on-the-wire savings the opt-out promises actually materialize.
+    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
+    const d1 = new yorkie.Document<{ counter: Counter }>(docKey);
+    const d2 = new yorkie.Document<{ counter: Counter }>(docKey);
+    const d3 = new yorkie.Document<{ counter: Counter }>(docKey);
+
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c3 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    await c1.activate();
+    await c2.activate();
+    await c3.activate();
+    try {
+      await c1.attach(d1, { syncMode: SyncMode.Manual, disableGC: true });
+      await c2.attach(d2, { syncMode: SyncMode.Manual, disableGC: true });
+      await c3.attach(d3, { syncMode: SyncMode.Manual, disableGC: true });
+
+      d1.update((root) => {
+        root.counter = new Counter(0);
+      });
+      await c1.sync();
+      await c2.sync();
+      await c3.sync();
+
+      for (let round = 0; round < 3; round++) {
+        d1.update((root) => root.counter.increase(1));
+        d2.update((root) => root.counter.increase(1));
+        d3.update((root) => root.counter.increase(1));
+        await c1.sync();
+        await c2.sync();
+        await c3.sync();
+      }
+      // Drain remaining pushed changes so every client sees them.
+      await c1.sync();
+      await c2.sync();
+      await c3.sync();
+      await c1.sync();
+
+      assert.equal(d1.getRoot().counter.getValue(), 9);
+      assert.equal(d2.getRoot().counter.getValue(), 9);
+      assert.equal(d3.getRoot().counter.getValue(), 9);
+
+      // The contract assertion: every opt-out doc's VV stays at size 1.
+      for (const [i, d] of [d1, d2, d3].entries()) {
+        assert.equal(
+          d.getVersionVector().size(),
+          1,
+          `opt-out doc[${i}].versionVector must stay at size 1`,
+        );
+      }
+    } finally {
+      await c1.deactivate();
+      await c2.deactivate();
+      await c3.deactivate();
+    }
+  });
+
+  it('Opt-out client picks up server lamport when attach returns a snapshot', async function ({
+    task,
+  }) {
+    // Latent issue: server/packs/pushpull.go used to nil the response
+    // VV for opt-out clients even on snapshot pulls, which prevented the
+    // client's change clock from catching up to the server's actual
+    // state. With the server fix (single-entry VV for opt-out snapshot
+    // responses), the lamport must advance to at least the server's max.
+    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
+
+    // SnapshotThreshold is project-wide; default in the dev server is
+    // small enough that this many writes will trigger a snapshot.
+    const docA = new yorkie.Document<Record<string, number>>(docKey);
+    const cA = new yorkie.Client({ rpcAddr: testRPCAddr });
+    await cA.activate();
+    try {
+      await cA.attach(docA, { syncMode: SyncMode.Manual });
+      for (let i = 0; i < 30; i++) {
+        docA.update((root) => {
+          root[`k${i}`] = i;
+        });
+      }
+      await cA.sync();
+
+      // docB attaches with opt-out; the pull crosses the snapshot
+      // threshold so the response is a snapshot.
+      const docB = new yorkie.Document<{ counter: Counter }>(docKey);
+      const cB = new yorkie.Client({ rpcAddr: testRPCAddr });
+      await cB.activate();
+      try {
+        await cB.attach(docB, {
+          syncMode: SyncMode.Manual,
+          disableGC: true,
+        });
+
+        // After a snapshot pull on an opt-out client, lamport must be
+        // at least the count of remote operations the snapshot subsumed.
+        // We use 30 as a conservative lower bound for the 30 updates
+        // docA pushed; if the lamport bug were still present, docB's
+        // lamport would be 1.
+        assert.isAtLeast(
+          Number(docB.getChangeID().getLamport()),
+          30,
+          'opt-out client must catch up to server lamport via snapshot',
+        );
+        assert.equal(
+          docB.getVersionVector().size(),
+          1,
+          'opt-out doc.VV must stay size 1 after snapshot pull',
+        );
+      } finally {
+        await cB.deactivate();
+      }
+    } finally {
+      await cA.deactivate();
+    }
+  });
+
   it('Re-attach without disableGC restores normal sync behavior', async function ({
     task,
   }) {


### PR DESCRIPTION
## Summary

Mirrors yorkie-team/yorkie#1826. The wire-side opt-out shipped in [#1265](https://github.com/yorkie-team/yorkie-js-sdk/pull/1265) (mirroring [yorkie-team/yorkie#1822](https://github.com/yorkie-team/yorkie/pull/1822)) was meant to remove the per-actor VersionVector overhead for high-fan-out Counter workloads. On the server side it does. But on the client side every remote change still bumps the local doc's VV via \`syncClocks\` -> \`versionVector.max\`, so after one fanout round every opt-out client emits Changes carrying an O(num_actors)-sized VV. The per-pack savings the design promised are erased once the doc has more than a handful of writers.

This PR adds the missing client-side branch:

- New \`ChangeID.syncLamport(other)\` — advances the lamport clock (still required for TimeTicket ordering) but does not merge the other actor's VV into ours. Deep-copies the receiver's VV before \`set\` so the returned ID does not share its map with prior IDs that live on in the doc's \`localChanges\`.
- New \`Document.setDisableGC(boolean)\` — set by \`client.attachDocument\` before the first \`applyChangePack\` so even the initial attach response is processed via the lamport-only path.
- \`Document.applyChange\` routes through \`syncLamport\` when \`disableGC\` is set, \`syncClocks\` otherwise.

## Server side

A companion fix in yorkie-team/yorkie#1826 truncates the response VV to a single \`{client_actor: max_lamport}\` entry on opt-out **snapshot** responses so the client's change clock catches up via \`setClocks\`. This PR's \`Document.applySnapshot\` is unchanged — the existing \`setClocks\` path already handles the truncated VV correctly.

## Test plan

- [x] \`pnpm lint\` clean
- [x] \`pnpm sdk build\`
- [x] \`pnpm sdk test test/unit/\` — 254 passed
- [x] \`pnpm sdk test test/integration/disable_gc_test.ts\` — 5 passed (2 new)
- [x] \`pnpm sdk test test/integration/gc_test.ts test/integration/snapshot_test.ts\` — 21 passed
- [x] \`pnpm sdk test test/integration/client_test.ts test/integration/presence_test.ts test/integration/primitive_test.ts\` — 28 passed
- [x] New integration regressions:
  - "Opt-out clients keep per-Change VV at size 1 under multi-actor fanout" — 3 actors × 3 fanout rounds, every opt-out doc.versionVector stays at size 1
  - "Opt-out client picks up server lamport when attach returns a snapshot" — writes past the snapshot threshold then attaches opt-out, asserts lamport catches up

## Coordination

This PR needs yorkie-team/yorkie#1826 merged and the test image rebuilt before the snapshot catch-up subtest will pass against \`yorkieteam/yorkie:latest\`. The first regression (per-Change VV size 1) is purely client-side and passes against any server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an option to disable garbage collection in document synchronization for improved performance in scenarios with multiple actors.
  * Introduced new synchronization capabilities for clock management.

* **Tests**
  * Added integration tests for garbage collection opt-out behavior across multiple clients and snapshot scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie-js-sdk/pull/1270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->