### PR TITLE
Release v0.7.11-rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and Yorkie JS SDK adheres to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+- Expose disableGC attach option in React package by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1268
+- Stop accumulating per-Change VV under disableGC by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1270
+
 ## [v0.7.10] - 2026-05-27
 
 ### Added

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/react",
-  "version": "0.7.10",
+  "version": "0.7.11-rc",
   "description": "A set of hooks and providers for Yorkie JS SDK",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/sdk",
-  "version": "0.7.10",
+  "version": "0.7.11-rc",
   "description": "Yorkie JS SDK",
   "main": "./src/yorkie.ts",
   "publishConfig": {


### PR DESCRIPTION
## Summary

- Bump `@yorkie-js/sdk` and `@yorkie-js/react` to `0.7.11-rc`
- Add #1268 and #1270 to CHANGELOG `[Unreleased]`

Only `@yorkie-js/sdk` and `@yorkie-js/react` need new builds for this rc. `@yorkie-js/schema` and `@yorkie-js/prosemirror` have no changes since `0.7.10`, so their package.json versions are intentionally left unchanged.

## Notes

The npm-publish workflow runs all four publish steps sequentially. Steps for `schema` and `prosemirror` will fail with a version-already-published error after `sdk` and `react` publish successfully. End state is correct; workflow run will show red on the unchanged packages.

## Test plan

- [x] `git diff` confirms only sdk + react version bumps and two CHANGELOG lines
- [x] After merge, cut GitHub Release `v0.7.11-rc` and verify `@yorkie-js/sdk@0.7.11-rc` and `@yorkie-js/react@0.7.11-rc` appear on npm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Exposed the `disableGC` attach option in the React package for improved control over garbage collection.
  * Stopped accumulation of version vectors when garbage collection is disabled, enhancing stability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie-js-sdk/pull/1271?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->