### PR TITLE
Skip bare position nodes in RGATreeList.getLast

### DIFF
--- a/packages/sdk/src/document/crdt/rga_tree_list.ts
+++ b/packages/sdk/src/document/crdt/rga_tree_list.ts
@@ -661,10 +661,15 @@ export class RGATreeList implements GCParent {
   }
 
   /**
-   * `getLast` returns the value of last elements.
+   * `getLast` returns the value of last elements. Skips bare position nodes
+   * (created by moveAfter/addDeadPosition) that have no element.
    */
   public getLast(): CRDTElement {
-    return this.last.getValue();
+    let node: RGATreeListNode = this.last;
+    while (!node.getElementEntry() && node !== this.dummyHead) {
+      node = node.getPrev()!;
+    }
+    return node.getValue();
   }
 
   /**


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
After the SplayTree-to-TreeList migration, snapshot restoration via addDeadPosition can leave this.last pointing at a bare position node (no element entry). RGATreeListNode.getValue uses a non-null assertion on _elementEntry, so getLast() crashed with "Cannot read properties of undefined" in that state.

Walk back to the nearest position node that carries an element, falling back to dummyHead, so getLast always returns a valid CRDTElement.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

### Checklist
- [X] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where list operations could incorrectly return internal state nodes instead of actual list elements, ensuring data integrity during complex document operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/yorkie-team/yorkie-js-sdk/pull/1272?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->