### PR TITLE
Export useYorkie hook from @yorkie-js/react

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -23,7 +23,7 @@ import type {
 import { Tree, Text, Counter, SyncMode } from '@yorkie-js/sdk';
 
 import { useYorkieDoc } from './useYorkieDoc';
-import { YorkieProvider } from './YorkieProvider';
+import { YorkieProvider, useYorkie } from './YorkieProvider';
 import {
   DocumentProvider,
   useDocument,
@@ -51,6 +51,7 @@ export {
   Counter,
   SyncMode,
   YorkieProvider,
+  useYorkie,
   DocumentProvider,
   useDocument,
   useRoot,


### PR DESCRIPTION
## Summary

- `useYorkie` is defined in `YorkieProvider.tsx` and used internally by `DocumentProvider` / `ChannelProvider`, but it was never added to the package's public exports in `packages/react/src/index.ts`.
- As a result, consumers who set up `YorkieProvider` + `DocumentProvider` (rather than `useYorkieDoc`) have no supported way to reach the underlying `Client`. This blocks workflows that need direct client access — most notably calling `client.sync(doc)` under `SyncMode.Manual`.
- This PR adds the missing re-export. No behavior change; the hook itself is untouched.

## Test plan

- [x] `pnpm lint` (zero warnings)
- [x] `pnpm react build` — `useYorkie` appears in `dist/yorkie-js-react.d.ts` with the expected `{ client, loading, error }` signature
- [x] `pnpm react test` — 88/88 pass
- [ ] Consumer can now `import { useYorkie } from '@yorkie-js/react'` and call `client.sync(doc)` from inside a `DocumentProvider`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `useYorkie` hook is now publicly exported from the package root, making it directly accessible to package consumers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->