### PR TITLE
Release v0.7.12-rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and Yorkie JS SDK adheres to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+- Export useYorkie from React package by @JOOHOJANG in https://github.com/yorkie-team/yorkie-js-sdk/pull/1276
+
 ## [v0.7.11] - 2026-06-01
 
 ### Added

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/react",
-  "version": "0.7.11",
+  "version": "0.7.12-rc",
   "description": "A set of hooks and providers for Yorkie JS SDK",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/sdk",
-  "version": "0.7.11",
+  "version": "0.7.12-rc",
   "description": "Yorkie JS SDK",
   "main": "./src/yorkie.ts",
   "publishConfig": {


### PR DESCRIPTION
## Summary

- Bump `@yorkie-js/sdk` and `@yorkie-js/react` to `0.7.12-rc`
- CHANGELOG: Export `useYorkie` from React package (#1276)

## Test plan

- [x] CI passes
- [x] After merge, GitHub Action publishes `@yorkie-js/sdk@0.7.12-rc` and `@yorkie-js/react@0.7.12-rc` to npm

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `useYorkie` hook is now exported from the React package

* **Chores**
  * Version bumped to 0.7.12-rc for React and SDK packages

<!-- end of auto-generated comment: release notes by coderabbit.ai -->