### PR TITLE
Expose document removal through the React SDK

### DIFF
--- a/packages/react/src/DocumentProvider.tsx
+++ b/packages/react/src/DocumentProvider.tsx
@@ -424,6 +424,29 @@ export const useRevisions = <R, P extends Indexable = Indexable>() => {
 };
 
 /**
+ * `useRemoveDocument` returns a function that removes the current document
+ * from the server via `client.remove` (as opposed to `client.detach`).
+ * After it resolves the document is gone for every client and the key can
+ * be reattached as a fresh document. The returned function rejects until
+ * the document is attached, and the removal error is propagated to the
+ * caller. This hook must be used within a `DocumentProvider`.
+ */
+export const useRemoveDocument = <R, P extends Indexable = Indexable>() => {
+  const { client } = useYorkie();
+  const documentStore = useDocumentStore('useRemoveDocument');
+  const doc = useSelector(documentStore, (store) => store.doc) as
+    | Document<R, P>
+    | undefined;
+
+  return useCallback(async (): Promise<void> => {
+    if (!client || !doc) {
+      throw new Error('Client or document is not ready');
+    }
+    await client.remove(doc);
+  }, [client, doc]);
+};
+
+/**
  * `useDocumentStore` is a custom hook that returns the document store.
  * It also ensures that the hook is used within a `DocumentProvider`.
  */

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -31,6 +31,7 @@ import {
   usePresences,
   useConnection,
   useRevisions,
+  useRemoveDocument,
   createDocumentSelector,
 } from './DocumentProvider';
 import {
@@ -58,6 +59,7 @@ export {
   usePresences,
   useConnection,
   useRevisions,
+  useRemoveDocument,
   useYorkieDoc,
   createDocumentSelector,
   ChannelProvider,

--- a/packages/react/test/integration/integration.test.tsx
+++ b/packages/react/test/integration/integration.test.tsx
@@ -20,6 +20,8 @@ import { StreamConnectionStatus } from '@yorkie-js/sdk';
 import {
   createDocumentSelector,
   DocumentProvider,
+  useDocument,
+  useRemoveDocument,
 } from '../../src/DocumentProvider';
 import type { Indexable } from '@yorkie-js/sdk';
 
@@ -114,7 +116,11 @@ const createMockDocument = () => {
 
 const createMockClient = () => {
   const mockClient = {
+    // Rejects by default so existing tests keep their "attach fails →
+    // error state" behavior; the removal tests override it to resolve.
+    attach: vi.fn().mockRejectedValue(new Error('attach not mocked')),
     detach: vi.fn(),
+    remove: vi.fn().mockResolvedValue(undefined),
     has: vi.fn(() => true),
     isActive: vi.fn(() => true),
   };
@@ -444,6 +450,89 @@ describe('Integration Test', () => {
       });
 
       expect(screen.queryByTestId('counter')).toBeNull();
+    });
+  });
+
+  describe('useRemoveDocument', () => {
+    it('removes the document via client.remove and skips the unmount detach', async () => {
+      // A client whose attach resolves, so the store gets the document.
+      // After removal the document is detached internally, so `has`
+      // returns false and the cleanup effect must not detach again.
+      currentMockClient = {
+        ...createMockClient(),
+        attach: vi.fn().mockResolvedValue(undefined),
+        remove: vi.fn().mockResolvedValue(undefined),
+        has: vi.fn(() => false),
+      };
+
+      let removeFn: (() => Promise<void>) | undefined;
+
+      function TestComponent() {
+        const { doc } = useDocument<TestDocumentRoot, TestPresence>();
+        removeFn = useRemoveDocument<TestDocumentRoot, TestPresence>();
+        // The hook reads the doc from the store, so wait for `doc` to be
+        // set before calling remove.
+        return <div data-testid="ready">{doc ? 'ready' : 'loading'}</div>;
+      }
+
+      const { unmount } = render(
+        <DocumentProvider
+          docKey="test-doc"
+          initialRoot={{ counter: 0, user: { name: 'John', age: 25 } }}
+          initialPresence={{ user: { id: 'user1', name: 'John' } }}
+        >
+          <TestComponent />
+        </DocumentProvider>,
+      );
+
+      await waitFor(() => {
+        expect(screen.getByTestId('ready')).toHaveTextContent('ready');
+      });
+
+      await act(async () => {
+        await removeFn!();
+      });
+
+      expect(currentMockClient.remove).toHaveBeenCalledTimes(1);
+      expect(currentMockClient.remove).toHaveBeenCalledWith(
+        currentMockDocument,
+      );
+
+      unmount();
+      expect(currentMockClient.detach).not.toHaveBeenCalled();
+    });
+
+    it('rejects when called before the document is attached', async () => {
+      // attach rejects, so the store never receives a document and the
+      // hook must reject rather than silently issue no removal RPC.
+      currentMockClient = {
+        ...createMockClient(),
+        attach: vi.fn().mockRejectedValue(new Error('attach failed')),
+        remove: vi.fn().mockResolvedValue(undefined),
+      };
+
+      let removeFn: (() => Promise<void>) | undefined;
+
+      function TestComponent() {
+        removeFn = useRemoveDocument<TestDocumentRoot, TestPresence>();
+        return <div data-testid="ready">ready</div>;
+      }
+
+      render(
+        <DocumentProvider
+          docKey="test-doc"
+          initialRoot={{ counter: 0, user: { name: 'John', age: 25 } }}
+          initialPresence={{ user: { id: 'user1', name: 'John' } }}
+        >
+          <TestComponent />
+        </DocumentProvider>,
+      );
+
+      await waitFor(() => {
+        expect(removeFn).toBeTypeOf('function');
+      });
+      await expect(removeFn!()).rejects.toThrow('not ready');
+      expect(currentMockClient.remove).not.toHaveBeenCalled();
     });
   });
 });


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
The core client and Go SDK have `client.remove(doc)`, but `@yorkie-js/react` surfaced no way to delete a document. Add a `useRemoveDocument` hook that binds the current client + document and calls `client.remove`, mirroring how `useRevisions` wraps the client's revision API. The returned function rejects until the document is attached; since `client.remove` already detaches, the provider's unmount cleanup `has` guard skips a second detach.

#### Any background context you want to provide?


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1282 

### Checklist
- [X] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `useRemoveDocument` hook for removing the current document from the server when used within a DocumentProvider context. This hook is now part of the public API.

* **Tests**
  * Added integration tests to verify document removal functionality and error handling, ensuring the hook properly rejects when documents are not yet attached to the server.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->