### PR TITLE
feat(client): add deactivateOnUnload option

### DIFF
--- a/examples/react-page-view-counter/README.md
+++ b/examples/react-page-view-counter/README.md
@@ -6,6 +6,13 @@ page-view (PV) counter.
 ## Pattern
 
 - `DocumentProvider` with `syncMode={SyncMode.Manual}` and `disableGC`
+- `YorkieProvider` with `deactivateOnUnload={false}` — skips the
+  `beforeunload`/unmount-time `DeactivateClient` round trip. With
+  `disableGC` and no collaboration cleanup needed, the unload-time
+  deactivate is pure overhead and its `fetch({ keepalive: true })`
+  can reject mid-navigation, surfacing as an unhandled
+  `[unknown] ConnectError`. Server housekeeping reaps the stale
+  client after `clientDeactivateThreshold`.
 - Document key follows `pv-{topicId}-{YYYYMMDD}`, so a fresh document is
   used every 24 hours
 - On topic-page mount, the client runs `counter.increase(1)` once and

--- a/examples/react-page-view-counter/src/App.tsx
+++ b/examples/react-page-view-counter/src/App.tsx
@@ -21,7 +21,7 @@ export default function App() {
           hours.
         </p>
       </header>
-      <YorkieProvider {...yorkieOpts}>
+      <YorkieProvider {...yorkieOpts} deactivateOnUnload={false}>
         {topicId === null ? (
           <Home onSelect={setTopicId} />
         ) : (

--- a/packages/react/src/YorkieProvider.tsx
+++ b/packages/react/src/YorkieProvider.tsx
@@ -89,7 +89,7 @@ export function useYorkieClient(opts: ClientOptions, activate: boolean = true) {
     activateClient();
 
     return () => {
-      if (activate && client?.isActive()) {
+      if (activate && client?.isActive() && opts.deactivateOnUnload !== false) {
         client.deactivate({ keepalive: true });
       }
     };

--- a/packages/react/test/unit/YorkieProvider.test.tsx
+++ b/packages/react/test/unit/YorkieProvider.test.tsx
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { YorkieProvider } from '../../src/YorkieProvider';
+
+const mocks = vi.hoisted(() => {
+  const state = { isActive: false };
+  return {
+    state,
+    constructorSpy: vi.fn(),
+    activateSpy: vi.fn().mockResolvedValue(undefined),
+    deactivateSpy: vi.fn().mockResolvedValue(undefined),
+  };
+});
+
+vi.mock('@yorkie-js/sdk', () => ({
+  Client: vi.fn(function MockClient(opts: unknown) {
+    mocks.constructorSpy(opts);
+    return {
+      activate: async () => {
+        mocks.state.isActive = true;
+        await mocks.activateSpy();
+      },
+      deactivate: async (deactivateOpts: unknown) => {
+        await mocks.deactivateSpy(deactivateOpts);
+        mocks.state.isActive = false;
+      },
+      isActive: () => mocks.state.isActive,
+    };
+  }),
+}));
+
+beforeEach(() => {
+  mocks.constructorSpy.mockClear();
+  mocks.activateSpy.mockClear();
+  mocks.deactivateSpy.mockClear();
+  mocks.state.isActive = false;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('YorkieProvider deactivateOnUnload prop', () => {
+  it('forwards deactivateOnUnload:false to the Client constructor', async () => {
+    render(
+      <YorkieProvider
+        apiKey="k"
+        rpcAddr="http://localhost"
+        deactivateOnUnload={false}
+      >
+        <div data-testid="child" />
+      </YorkieProvider>,
+    );
+    await waitFor(() => expect(mocks.constructorSpy).toHaveBeenCalled());
+    expect(mocks.constructorSpy.mock.calls[0][0]).toMatchObject({
+      apiKey: 'k',
+      rpcAddr: 'http://localhost',
+      deactivateOnUnload: false,
+    });
+  });
+
+  it('forwards deactivateOnUnload:true (explicit) to the Client constructor', async () => {
+    render(
+      <YorkieProvider
+        apiKey="k"
+        rpcAddr="http://localhost"
+        deactivateOnUnload={true}
+      >
+        <div />
+      </YorkieProvider>,
+    );
+    await waitFor(() => expect(mocks.constructorSpy).toHaveBeenCalled());
+    expect(mocks.constructorSpy.mock.calls[0][0]).toMatchObject({
+      deactivateOnUnload: true,
+    });
+  });
+
+  it('omits deactivateOnUnload from constructor opts when not provided', async () => {
+    render(
+      <YorkieProvider apiKey="k" rpcAddr="http://localhost">
+        <div />
+      </YorkieProvider>,
+    );
+    await waitFor(() => expect(mocks.constructorSpy).toHaveBeenCalled());
+    expect(mocks.constructorSpy.mock.calls[0][0]).not.toHaveProperty(
+      'deactivateOnUnload',
+    );
+  });
+
+  it('skips unmount-time deactivate when deactivateOnUnload is false', async () => {
+    const { unmount } = render(
+      <YorkieProvider
+        apiKey="k"
+        rpcAddr="http://localhost"
+        deactivateOnUnload={false}
+      >
+        <div />
+      </YorkieProvider>,
+    );
+    await waitFor(() => expect(mocks.activateSpy).toHaveBeenCalled());
+    unmount();
+    expect(mocks.deactivateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -534,8 +534,13 @@ export class Client {
         // NOTE(hackerwins): Set up beforeunload event to deactivate the client
         // when the page is being unloaded.
         if (typeof window !== 'undefined' && this.deactivateOnUnload) {
-          window.addEventListener('beforeunload', async () => {
-            await this.deactivate({ keepalive: true });
+          window.addEventListener('beforeunload', () => {
+            void this.deactivate({ keepalive: true }).catch((err) => {
+              logger.debug(
+                `[DC] c:"${this.getKey()}" beforeunload deactivate failed:`,
+                err,
+              );
+            });
           });
         }
       } catch (err) {

--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -216,6 +216,21 @@ export interface ClientOptions {
    * If false (default), uses Connect Protocol transport.
    */
   useGrpcWebTransport?: boolean;
+
+  /**
+   * `deactivateOnUnload` controls whether the client registers a
+   * `beforeunload` listener during `activate()` that deactivates the client
+   * when the page is unloaded. The default value is `true`.
+   *
+   * Setting this to `false` skips the listener registration. This is useful
+   * for apps that don't need GC or presence cleanup on unload (for example,
+   * `disableGC` documents without collaboration): the unload-time
+   * deactivate becomes pure overhead and its `fetch({ keepalive: true })`
+   * request can reject mid-flight during hard navigation, surfacing as an
+   * unhandled `[unknown]` `ConnectError`. The server reaps the stale
+   * client after its `clientDeactivateThreshold`, so opting out is safe.
+   */
+  deactivateOnUnload?: boolean;
 }
 
 /**
@@ -332,6 +347,7 @@ const DefaultClientOptions = {
   retrySyncLoopDelay: 1000,
   reconnectStreamDelay: 1000,
   channelHeartbeatInterval: DefaultChannelHeartbeatMs,
+  deactivateOnUnload: true,
 };
 
 /**
@@ -362,6 +378,7 @@ export class Client {
   private reconnectStreamDelay: number;
   private retrySyncLoopDelay: number;
   private channelHeartbeatInterval: number;
+  private deactivateOnUnload: boolean;
 
   private rpcClient: ConnectClient<typeof YorkieService>;
   private setAuthToken: (token: string) => void;
@@ -399,6 +416,8 @@ export class Client {
     this.channelHeartbeatInterval =
       opts.channelHeartbeatInterval ??
       DefaultClientOptions.channelHeartbeatInterval;
+    this.deactivateOnUnload =
+      opts.deactivateOnUnload ?? DefaultClientOptions.deactivateOnUnload;
 
     const { authInterceptor, setToken } = createAuthInterceptor(this.apiKey);
     this.setAuthToken = setToken;
@@ -514,7 +533,7 @@ export class Client {
 
         // NOTE(hackerwins): Set up beforeunload event to deactivate the client
         // when the page is being unloaded.
-        if (typeof window !== 'undefined') {
+        if (typeof window !== 'undefined' && this.deactivateOnUnload) {
           window.addEventListener('beforeunload', async () => {
             await this.deactivate({ keepalive: true });
           });

--- a/packages/sdk/test/unit/client_unload_test.ts
+++ b/packages/sdk/test/unit/client_unload_test.ts
@@ -64,4 +64,44 @@ describe('Client beforeunload registration', () => {
 
     expect(client.isActive()).toBe(true);
   });
+
+  it('treats explicit deactivateOnUnload: true the same as the default', async () => {
+    const spy = vi.spyOn(window, 'addEventListener');
+    const client = makeClient({ deactivateOnUnload: true });
+    await client.activate();
+    expect(countBeforeUnloadListeners(spy)).toBe(1);
+  });
+
+  it('invokes deactivate when beforeunload fires under the default', async () => {
+    const client = makeClient();
+    const deactivateSpy = vi
+      .spyOn(client, 'deactivate')
+      .mockResolvedValue(undefined);
+    await client.activate();
+
+    window.dispatchEvent(new Event('beforeunload'));
+
+    expect(deactivateSpy).toHaveBeenCalledTimes(1);
+    expect(deactivateSpy).toHaveBeenCalledWith({ keepalive: true });
+  });
+
+  it('swallows a rejected deactivate from the beforeunload handler', async () => {
+    const client = makeClient();
+    vi.spyOn(client, 'deactivate').mockRejectedValue(
+      new TypeError('Failed to fetch'),
+    );
+
+    const unhandled = vi.fn();
+    window.addEventListener('unhandledrejection', unhandled);
+
+    await client.activate();
+    window.dispatchEvent(new Event('beforeunload'));
+
+    // Flush microtasks so the catch handler attached inside the listener runs.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(unhandled).not.toHaveBeenCalled();
+    window.removeEventListener('unhandledrejection', unhandled);
+  });
 });

--- a/packages/sdk/test/unit/client_unload_test.ts
+++ b/packages/sdk/test/unit/client_unload_test.ts
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// @vitest-environment jsdom
+
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import yorkie, { ClientOptions } from '@yorkie-js/sdk/src/yorkie';
+
+function makeClient(opts: Partial<ClientOptions> = {}) {
+  const client = new yorkie.Client({ rpcAddr: 'http://localhost', ...opts });
+  (client as any).rpcClient = {
+    activateClient: vi.fn().mockResolvedValue({ clientId: 'test-id' }),
+    deactivateClient: vi.fn().mockResolvedValue({}),
+  };
+  // Prevent the sync loop from issuing real RPCs in this unit test.
+  (client as any).runSyncLoop = vi.fn();
+  return client;
+}
+
+function countBeforeUnloadListeners(spy: {
+  mock: { calls: Array<Array<unknown>> };
+}): number {
+  return spy.mock.calls.filter(([event]) => event === 'beforeunload').length;
+}
+
+describe('Client beforeunload registration', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('registers a beforeunload listener by default', async () => {
+    const spy = vi.spyOn(window, 'addEventListener');
+    const client = makeClient();
+    await client.activate();
+    expect(countBeforeUnloadListeners(spy)).toBe(1);
+  });
+
+  it('skips the beforeunload listener when deactivateOnUnload is false', async () => {
+    const spy = vi.spyOn(window, 'addEventListener');
+    const client = makeClient({ deactivateOnUnload: false });
+    await client.activate();
+    expect(countBeforeUnloadListeners(spy)).toBe(0);
+  });
+
+  it('leaves the client active across a beforeunload event when deactivateOnUnload is false', async () => {
+    const client = makeClient({ deactivateOnUnload: false });
+    await client.activate();
+    expect(client.isActive()).toBe(true);
+
+    window.dispatchEvent(new Event('beforeunload'));
+
+    expect(client.isActive()).toBe(true);
+  });
+});


### PR DESCRIPTION
## What

Adds a `deactivateOnUnload` option to `ClientOptions` (default `true`). When set to `false`, the client does **not** auto-deactivate when the page unloads or when the React `YorkieProvider` unmounts.

## Why

On activation the client registers a `beforeunload` listener that fires a `DeactivateClient` request via `fetch({ keepalive: true })`. During a hard navigation the page tears down while that request is in flight, so the fetch rejects with `TypeError: Failed to fetch`, which Connect maps to an `[unknown]` `ConnectError`.

Both the `beforeunload` handler and the `YorkieProvider` unmount cleanup call `deactivate()` fire-and-forget (no `.catch()`), so the rejection bubbles up as an **unhandled error** in global error trackers (e.g. Sentry). A related symptom is a `... is not active` (`ErrClientNotActivated`) thrown when an unmount-time `detach()` runs after the client has already been deactivated.

For use cases that don't need GC or presence cleanup on unload — e.g. `disableGC` documents without collaboration — this unload-time deactivate is pure overhead. The server's housekeeping reaps the stale client after its `clientDeactivateThreshold`, so opting out is safe and removes the navigation noise.

## Changes

- `@yorkie-js/sdk`: add `deactivateOnUnload?: boolean` to `ClientOptions` (default `true`); when `false`, `activate()` skips registering the `beforeunload` listener.
- `@yorkie-js/react`: `YorkieProvider` skips its unmount-time `deactivate()` when the option is `false`. The option flows through provider props via `ClientOptions`.

## Usage

```tsx
<YorkieProvider apiKey={...} deactivateOnUnload={false}>
  <DocumentProvider docKey={...} disableGC>
    ...
```

## Test plan

- [x] Unit (new `client_unload_test.ts`, jsdom)
  - default → `beforeunload` listener registered
  - `deactivateOnUnload: false` → listener not registered
  - `deactivateOnUnload: false` + `beforeunload` event → client remains active
- [x] `pnpm lint` / `pnpm sdk build` / `pnpm sdk test test/unit` (270 passed, 3 new) / `pnpm react build`
- [ ] Browser E2E (React provider + counter, `disableGC`, manual sync) — to verify zero console errors on hard navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `deactivateOnUnload` option to control whether the Yorkie client deactivates during unload (defaults to enabled).

* **Bug Fixes**
  * Unmount/unload deactivation now respects `deactivateOnUnload`, avoiding extra deactivate calls when disabled.
  * Unload deactivation now uses a best-effort request and won’t block on errors.

* **Tests**
  * Added unit tests validating default unload behavior and the `deactivateOnUnload: false` path.

* **Documentation**
  * Updated the React page view counter example to set `deactivateOnUnload={false}` and document the tradeoffs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->