### PR TITLE
Prevent panic when splitLevel walks past the tree root

### DIFF
--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -1755,6 +1755,10 @@ export class CRDTTree extends CRDTElement implements GCParent {
           }
         }
 
+        if (!parent.parent) {
+          break;
+        }
+
         parent.split(
           this,
           left !== parent ? parent.findOffset(left, true) + 1 : 0,

--- a/packages/sdk/test/integration/tree_test.ts
+++ b/packages/sdk/test/integration/tree_test.ts
@@ -5393,7 +5393,6 @@ describe('Tree(edge cases)', () => {
     task,
   }) {
     const key = toDocKey(`${task.name}-${new Date().getTime()}`);
-    const doc = new yorkie.Document<{ t: Tree }>(key);
 
     type Seed = { name: string; tree: any; length: number };
     const seeds: Array<Seed> = [
@@ -5451,15 +5450,20 @@ describe('Tree(edge cases)', () => {
           step.update((root) => {
             root.t = new Tree(seed.tree);
           });
+          const sizeBefore = step.getRoot().t.getSize();
           step.update((root) =>
             root.t.edit(pos, pos, { type: 'text', value: 'a' }, sl),
           );
+
+          // The edit must not just avoid throwing — it must produce a valid
+          // tree that actually contains the inserted text.
+          const label = `${seed.name} pos=${pos} sl=${sl}`;
+          const tree = step.getRoot().t;
+          assert.isAbove(tree.getSize(), sizeBefore, label);
+          assert.include(tree.toXML(), 'a', label);
         }
       }
     }
-    doc.update((root) => {
-      root.t = new Tree({ type: 'doc', children: [] });
-    });
   });
 });
 

--- a/packages/sdk/test/integration/tree_test.ts
+++ b/packages/sdk/test/integration/tree_test.ts
@@ -5388,6 +5388,79 @@ describe('Tree(edge cases)', () => {
       assert.equal(d1.getRoot().t.toXML(), d2.getRoot().t.toXML());
     }, task.name);
   });
+
+  it('Can edit with splitLevel walking past root without throwing', function ({
+    task,
+  }) {
+    const key = toDocKey(`${task.name}-${new Date().getTime()}`);
+    const doc = new yorkie.Document<{ t: Tree }>(key);
+
+    type Seed = { name: string; tree: any; length: number };
+    const seeds: Array<Seed> = [
+      // <doc><p>x</p></doc>
+      {
+        name: 'shallow',
+        tree: {
+          type: 'doc',
+          children: [{ type: 'p', children: [{ type: 'text', value: 'x' }] }],
+        },
+        length: 3,
+      },
+      // <doc><p>x</p><p>y</p></doc>
+      {
+        name: 'twoP',
+        tree: {
+          type: 'doc',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'x' }] },
+            { type: 'p', children: [{ type: 'text', value: 'y' }] },
+          ],
+        },
+        length: 6,
+      },
+      // <doc><p><b>x</b></p></doc>
+      {
+        name: 'deep',
+        tree: {
+          type: 'doc',
+          children: [
+            {
+              type: 'p',
+              children: [
+                { type: 'b', children: [{ type: 'text', value: 'x' }] },
+              ],
+            },
+          ],
+        },
+        length: 5,
+      },
+      // <doc><p></p></doc>
+      {
+        name: 'emptyP',
+        tree: { type: 'doc', children: [{ type: 'p', children: [] }] },
+        length: 2,
+      },
+    ];
+
+    for (const seed of seeds) {
+      for (let pos = 0; pos <= seed.length; pos++) {
+        for (const sl of [1, 2]) {
+          const step = new yorkie.Document<{ t: Tree }>(
+            `${key}-${seed.name}-${pos}-${sl}`,
+          );
+          step.update((root) => {
+            root.t = new Tree(seed.tree);
+          });
+          step.update((root) =>
+            root.t.edit(pos, pos, { type: 'text', value: 'a' }, sl),
+          );
+        }
+      }
+    }
+    doc.update((root) => {
+      root.t = new Tree({ type: 'doc', children: [] });
+    });
+  });
 });
 
 describe('TreeChange', () => {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
CRDTTree.edit walked up to the root and split it, dereferencing the root's undefined parent. Stop the walk once the node to split has no parent.

#### Any background context you want to provide?

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes https://github.com/yorkie-team/yorkie/issues/1865

### Checklist
- [X] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [X] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where split-level edits could incorrectly traverse past the document root and trigger an error.
  * Split-level editing now completes safely across deeply nested and complex document structures.

* **Tests**
  * Added an integration test covering split-level edits when traversal moves past the root, across multiple seed tree shapes and insertion positions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->