### PR TITLE
Promote out-of-int32 integers to Long in Primitive

### DIFF
--- a/packages/sdk/src/document/crdt/primitive.ts
+++ b/packages/sdk/src/document/crdt/primitive.ts
@@ -15,6 +15,7 @@
  */
 
 import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
+import { logger } from '@yorkie-js/sdk/src/util/logger';
 import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
 import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
 import { escapeString } from '@yorkie-js/sdk/src/document/json/strings';
@@ -56,7 +57,14 @@ export class Primitive extends CRDTElement {
   constructor(value: PrimitiveValue, createdAt: TimeTicket) {
     super(createdAt);
     this.valueType = Primitive.getPrimitiveType(value)!;
-    this.value = value === undefined ? null : value;
+    if (this.valueType === PrimitiveType.Long && typeof value === 'number') {
+      logger.warn(
+        `number exceeds int32 range and will be stored as Long (bigint): ${value}`,
+      );
+      this.value = BigInt(value);
+    } else {
+      this.value = value === undefined ? null : value;
+    }
   }
 
   /**
@@ -209,10 +217,12 @@ export class Primitive extends CRDTElement {
         return PrimitiveType.Boolean;
       case 'number':
         if (this.isInteger(value)) {
+          if (value > Math.pow(2, 31) - 1 || value < -Math.pow(2, 31)) {
+            return PrimitiveType.Long;
+          }
           return PrimitiveType.Integer;
-        } else {
-          return PrimitiveType.Double;
         }
+        return PrimitiveType.Double;
       case 'bigint':
         return PrimitiveType.Long;
       case 'string':

--- a/packages/sdk/test/integration/primitive_test.ts
+++ b/packages/sdk/test/integration/primitive_test.ts
@@ -73,4 +73,24 @@ describe('Primitive', function () {
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
     }, task.name);
   });
+
+  it('should sync out-of-int32 integers without truncation', async function ({
+    task,
+  }) {
+    await withTwoClientsAndDocuments<{ ts: number | bigint }>(
+      async (c1, d1, c2, d2) => {
+        d1.update((root) => {
+          root['ts'] = Math.pow(2, 31);
+        });
+
+        await c1.sync();
+        await c2.sync();
+
+        assert.equal(d1.toSortedJSON(), '{"ts":2147483648}');
+        assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+        assert.equal(typeof d2.getRoot().ts, 'bigint');
+      },
+      task.name,
+    );
+  });
 });

--- a/packages/sdk/test/unit/document/crdt/primitive_test.ts
+++ b/packages/sdk/test/unit/document/crdt/primitive_test.ts
@@ -83,7 +83,7 @@ describe('Primitive', function () {
   });
 
   it('should create a Long primitive when a number exceeds int32 range', function () {
-    const INT32MAX = 2147483647;
+    const INT32MAX = Math.pow(2, 31) - 1;
     const largeNumber = INT32MAX + 1;
     const primitiveLarge = Primitive.of(largeNumber, InitialTimeTicket);
     assert.equal(primitiveLarge.getType(), PrimitiveType.Long);
@@ -91,7 +91,7 @@ describe('Primitive', function () {
   });
 
   it('should create a Long primitive when a number is less than int32 range', function () {
-    const INT32MIN = -2147483648;
+    const INT32MIN = -Math.pow(2, 31);
     const smallNumber = INT32MIN - 1;
     const primitiveSmall = Primitive.of(smallNumber, InitialTimeTicket);
     assert.equal(primitiveSmall.getType(), PrimitiveType.Long);
@@ -99,7 +99,7 @@ describe('Primitive', function () {
   });
 
   it('should round-trip a promoted Long through toBytes/valueFromBytes', function () {
-    const INT32MAX = 2147483647;
+    const INT32MAX = Math.pow(2, 31) - 1;
     const largeNumber = INT32MAX + 1;
     const primitive = Primitive.of(largeNumber, InitialTimeTicket);
     const restored = Primitive.valueFromBytes(

--- a/packages/sdk/test/unit/document/crdt/primitive_test.ts
+++ b/packages/sdk/test/unit/document/crdt/primitive_test.ts
@@ -81,4 +81,31 @@ describe('Primitive', function () {
     );
     assert.equal(date.toJSON(), '"1995-12-17T03:24:00.000Z"');
   });
+
+  it('should create a Long primitive when a number exceeds int32 range', function () {
+    const INT32MAX = 2147483647;
+    const largeNumber = INT32MAX + 1;
+    const primitiveLarge = Primitive.of(largeNumber, InitialTimeTicket);
+    assert.equal(primitiveLarge.getType(), PrimitiveType.Long);
+    assert.equal(primitiveLarge.getValue(), BigInt(largeNumber));
+  });
+
+  it('should create a Long primitive when a number is less than int32 range', function () {
+    const INT32MIN = -2147483648;
+    const smallNumber = INT32MIN - 1;
+    const primitiveSmall = Primitive.of(smallNumber, InitialTimeTicket);
+    assert.equal(primitiveSmall.getType(), PrimitiveType.Long);
+    assert.equal(primitiveSmall.getValue(), BigInt(smallNumber));
+  });
+
+  it('should round-trip a promoted Long through toBytes/valueFromBytes', function () {
+    const INT32MAX = 2147483647;
+    const largeNumber = INT32MAX + 1;
+    const primitive = Primitive.of(largeNumber, InitialTimeTicket);
+    const restored = Primitive.valueFromBytes(
+      PrimitiveType.Long,
+      primitive.toBytes(),
+    );
+    assert.equal(restored, BigInt(largeNumber));
+  });
 });


### PR DESCRIPTION
#### What this PR does / why we need it?
`Primitive` classifies any integer-valued JS `number` as `PrimitiveType.Integer` with no check that the value actually fits in int32. `toBytes()` for `Integer` uses 32-bit bitwise operators, so integers outside the int32 range (e.g. `Date.now()`) are silently truncated to their low 32 bits on the wire — the writer sees the correct value locally, but remote peers decode a corrupted one.

This PR promotes out-of-int32 integer `number`s to `PrimitiveType.Long` in `getPrimitiveType()`, which already round-trips through 64-bit `bigintToBytesLE`/`bigintFromBytesLE`. The constructor coerces the value to `bigint` when this promotion happens (the `Long` branch of `toBytes()` requires a `bigint`), and logs a `logger.warn` so the type change from `number` to `bigint` on read-back is visible instead of silent.

#### Any background context you want to provide?
This mirrors `CRDTCounter.getCounterType`, which already promotes out-of-int32 numbers to `CounterType.Long`, so `Primitive` and `Counter` now follow the same rule (Option A from the issue discussion, as suggested by the issue author).

---

Separately: `@bufbuild/protobuf` (already a direct dependency here) exports `INT32_MAX`/`INT32_MIN` from its `wire` subpath, which could replace the `Math.pow(2, 31) - 1` / `-Math.pow(2, 31)` magic numbers used here and in the two existing call sites in `counter.ts`. I think it'd be a nice readability improvement, but didn't want to expand this PR's scope.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1249

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved handling of numeric values outside the signed 32-bit integer range.
- Large integers are now preserved without precision loss during storage, serialization, and synchronization.
- Out-of-range integer values are correctly represented as long integers and materialize consistently across clients.
- Added warnings when values exceed the expected 32-bit range.

## Tests
- Added coverage for positive and negative large integers, including round-trip serialization and synchronization scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->