### PR TITLE
Register GC pairs for pieces split off tombstoned nodes

### DIFF
--- a/packages/sdk/src/document/crdt/gc.ts
+++ b/packages/sdk/src/document/crdt/gc.ts
@@ -24,6 +24,17 @@ import { DataSize } from '@yorkie-js/sdk/src/util/resource';
 export type GCPair = {
   parent: GCParent;
   child: GCChild;
+
+  /**
+   * `gcOnlySize` is set when the child's size was never counted in
+   * `docSize.live`: a piece born removed by splitting an already-tombstoned
+   * node, or a tombstone registered by the full scan when a root is built
+   * from a snapshot (live only counts visible nodes there). When present,
+   * `registerGCPair` adds this size to `docSize.gc` and leaves
+   * `docSize.live` untouched, instead of moving the child's size from live
+   * to gc.
+   */
+  gcOnlySize?: DataSize;
 };
 
 /**

--- a/packages/sdk/src/document/crdt/rga_tree_split.ts
+++ b/packages/sdk/src/document/crdt/rga_tree_split.ts
@@ -572,10 +572,21 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
   private treeByIndex: SplayTree<T>;
   private treeByID: LLRBTree<RGATreeSplitNodeID, RGATreeSplitNode<T>>;
 
+  /**
+   * `pendingGCPairs` buffers GC pairs for nodes that were created
+   * already-tombstoned by splitting a removed node. Such pieces inherit
+   * `removedAt` without ever passing through `remove()`, so they would
+   * otherwise never be registered for GC. Callers that split nodes
+   * (`edit`, `CRDTText.setStyle`, `CRDTText.removeStyle`) drain this
+   * buffer into their returned GC pairs.
+   */
+  private pendingGCPairs: Array<GCPair>;
+
   constructor() {
     this.head = RGATreeSplitNode.create(InitialRGATreeSplitNodeID);
     this.treeByIndex = new SplayTree();
     this.treeByID = new LLRBTree(RGATreeSplitNode.createComparator());
+    this.pendingGCPairs = [];
 
     this.treeByIndex.insert(this.head);
     this.treeByID.put(this.head.getID(), this.head);
@@ -627,7 +638,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
 
     // 02. delete between from and to
     const nodesToDelete = this.findBetween(fromRight, toRight);
-    const [changes, removedNodes] = this.deleteNodes(
+    const [changes, removedNodes, alreadyRemovedIDs] = this.deleteNodes(
       nodesToDelete,
       editedAt,
       versionVector,
@@ -666,10 +677,17 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
     // 04. add removed node
     const pairs: Array<GCPair> = [];
     const removedValues: Array<T> = [];
-    for (const [, removedNode] of removedNodes) {
-      pairs.push({ parent: this, child: removedNode });
+    for (const [id, removedNode] of removedNodes) {
+      // NOTE: Nodes that were already tombstoned keep their existing GC
+      // pair (the pair reads `removedAt` from the node at collection
+      // time); re-registering would toggle the pair off and leak the node.
+      if (!alreadyRemovedIDs.has(id)) {
+        pairs.push({ parent: this, child: removedNode });
+      }
       removedValues.push(removedNode.getValue());
     }
+
+    pairs.push(...this.drainPendingGCPairs());
 
     return [caretPos, pairs, diff, changes, removedValues];
   }
@@ -1008,6 +1026,14 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
     this.treeByIndex.updateWeight(splitNode);
     this.insertAfter(node, splitNode);
 
+    // NOTE: A piece split off an already-tombstoned node inherits
+    // `removedAt` without going through `remove()`, so no GC pair is
+    // created for it in the normal deletion path. Buffer one here so it
+    // can be purged; otherwise it stays in the list forever.
+    if (splitNode.isRemoved()) {
+      this.pendingGCPairs.push({ parent: this, child: splitNode });
+    }
+
     const insNext = node.getInsNext();
     if (insNext) {
       insNext.setInsPrev(splitNode);
@@ -1024,13 +1050,23 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
     return [splitNode, diff];
   }
 
+  /**
+   * `drainPendingGCPairs` returns the GC pairs buffered for born-tombstoned
+   * split pieces and clears the buffer.
+   */
+  public drainPendingGCPairs(): Array<GCPair> {
+    const pairs = this.pendingGCPairs;
+    this.pendingGCPairs = [];
+    return pairs;
+  }
+
   private deleteNodes(
     candidates: Array<RGATreeSplitNode<T>>,
     editedAt: TimeTicket,
     vector?: VersionVector,
-  ): [Array<ValueChange<T>>, Map<string, RGATreeSplitNode<T>>] {
+  ): [Array<ValueChange<T>>, Map<string, RGATreeSplitNode<T>>, Set<string>] {
     if (!candidates.length) {
-      return [[], new Map()];
+      return [[], new Map(), new Set()];
     }
 
     const isLocal = vector === undefined || vector.size() === 0;
@@ -1075,17 +1111,25 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
     // 02. Create value changes with previous indexes before deletion.
     const changes = this.makeChanges(nodesToKeep, editedAt);
 
-    // 03. Mark tombstones for removal.
+    // 03. Mark tombstones for removal. Nodes that were already removed
+    // (concurrent LWW overwrite of an existing tombstone) are tracked
+    // separately: they already have a registered GC pair, and registering
+    // a second one would toggle-unregister the first.
     const removedNodes = new Map();
+    const alreadyRemovedIDs = new Set<string>();
     for (const node of nodesToRemove) {
-      removedNodes.set(node.getID().toIDString(), node);
+      const id = node.getID().toIDString();
+      if (node.isRemoved()) {
+        alreadyRemovedIDs.add(id);
+      }
+      removedNodes.set(id, node);
       node.remove(editedAt);
     }
 
     // 04. Clear the index tree of the given deletion boundaries.
     this.deleteIndexNodes(nodesToKeep);
 
-    return [changes, removedNodes];
+    return [changes, removedNodes, alreadyRemovedIDs];
   }
 
   /**

--- a/packages/sdk/src/document/crdt/rga_tree_split.ts
+++ b/packages/sdk/src/document/crdt/rga_tree_split.ts
@@ -1026,14 +1026,6 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
     this.treeByIndex.updateWeight(splitNode);
     this.insertAfter(node, splitNode);
 
-    // NOTE: A piece split off an already-tombstoned node inherits
-    // `removedAt` without going through `remove()`, so no GC pair is
-    // created for it in the normal deletion path. Buffer one here so it
-    // can be purged; otherwise it stays in the list forever.
-    if (splitNode.isRemoved()) {
-      this.pendingGCPairs.push({ parent: this, child: splitNode });
-    }
-
     const insNext = node.getInsNext();
     if (insNext) {
       insNext.setInsPrev(splitNode);
@@ -1046,6 +1038,22 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
     // the split operation.
     addDataSizes(diff, node.getDataSize(), splitNode.getDataSize());
     subDataSize(diff, prvSize);
+
+    // NOTE: A piece split off an already-tombstoned node inherits
+    // `removedAt` without going through `remove()`, so no GC pair is
+    // created for it in the normal deletion path. Buffer one here so it
+    // can be purged; otherwise it stays in the list forever. The piece
+    // was never live, so the net-new size created by the split goes
+    // straight to docSize.gc when the pair is registered; report a zero
+    // diff to the caller (which accounts diffs to docSize.live).
+    if (splitNode.isRemoved()) {
+      this.pendingGCPairs.push({
+        parent: this,
+        child: splitNode,
+        gcOnlySize: diff,
+      });
+      return [splitNode, { data: 0, meta: 0 }];
+    }
 
     return [splitNode, diff];
   }

--- a/packages/sdk/src/document/crdt/root.ts
+++ b/packages/sdk/src/document/crdt/root.ts
@@ -276,6 +276,16 @@ export class CRDTRoot {
 
     this.gcPairMap.set(pair.child.toIDString(), pair);
 
+    if (pair.gcOnlySize) {
+      // NOTE: The child's size was never counted in docSize.live (it was
+      // born removed, or it was registered by the snapshot-load scan where
+      // live only counts visible nodes), so there is nothing to move out
+      // of live. Only the given size is added to gc; purge subtracts the
+      // child's size from gc as usual.
+      addDataSizes(this.docSize.gc, pair.gcOnlySize);
+      return;
+    }
+
     const size = this.gcPairMap
       .get(pair.child.toIDString())!
       .child.getDataSize();

--- a/packages/sdk/src/document/crdt/text.ts
+++ b/packages/sdk/src/document/crdt/text.ts
@@ -376,6 +376,8 @@ export class CRDTText<A extends Indexable = Indexable> extends CRDTElement {
       }
     }
 
+    pairs.push(...this.rgaTreeSplit.drainPendingGCPairs());
+
     return [pairs, diff, changes, prevAttributes, attributesToRemove];
   }
 
@@ -468,6 +470,8 @@ export class CRDTText<A extends Indexable = Indexable> extends CRDTElement {
         }
       }
     }
+
+    pairs.push(...this.rgaTreeSplit.drainPendingGCPairs());
 
     return [pairs, diff, changes, prevAttributes];
   }

--- a/packages/sdk/src/document/crdt/text.ts
+++ b/packages/sdk/src/document/crdt/text.ts
@@ -658,14 +658,26 @@ export class CRDTText<A extends Indexable = Indexable> extends CRDTElement {
    * `getGCPairs` returns the pairs of GC.
    */
   public getGCPairs(): Array<GCPair> {
-    const pairs = [];
+    const pairs: Array<GCPair> = [];
+    // NOTE: Only called when a root is built from a snapshot, where
+    // docSize.live counted visible nodes only. Tombstoned nodes (and the
+    // attribute tombstones inside them) were never part of live, so their
+    // pairs carry `gcOnlySize`. Attribute tombstones of visible nodes ARE
+    // counted in live (getDataSize does not skip them), so their pairs use
+    // the normal live→gc accounting.
     for (const node of this.rgaTreeSplit) {
       if (node.getRemovedAt()) {
-        pairs.push({ parent: this.rgaTreeSplit, child: node });
+        pairs.push({
+          parent: this.rgaTreeSplit,
+          child: node,
+          gcOnlySize: node.getDataSize(),
+        });
       }
 
       for (const p of node.getValue().getGCPairs()) {
-        pairs.push(p);
+        pairs.push(
+          node.getRemovedAt() ? { ...p, gcOnlySize: p.child.getDataSize() } : p,
+        );
       }
     }
 

--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -674,6 +674,14 @@ export class CRDTTreeNode
       }
       this.insNextID = split.id;
       tree.registerNode(split);
+
+      // NOTE: A piece split off an already-tombstoned node inherits
+      // `removedAt` without going through `remove()`, so no GC pair is
+      // created for it in the normal deletion path. Register it here so
+      // it can be purged; otherwise it stays in the tree forever.
+      if (split.removedAt) {
+        tree.registerPendingGCPair(split);
+      }
     }
     return [split, diff];
   }
@@ -914,10 +922,20 @@ export class CRDTTree extends CRDTElement implements GCParent {
   private indexTree: IndexTree<CRDTTreeNode>;
   private nodeMapByID: LLRBTree<CRDTTreeNodeID, CRDTTreeNode>;
 
+  /**
+   * `pendingGCPairs` buffers GC pairs for nodes that were created
+   * already-tombstoned by splitting a removed node. Such pieces inherit
+   * `removedAt` without ever passing through `remove()`, so they would
+   * otherwise never be registered for GC. `edit` and `style` drain this
+   * buffer into their returned GC pairs.
+   */
+  private pendingGCPairs: Array<GCPair>;
+
   constructor(root: CRDTTreeNode, createdAt: TimeTicket) {
     super(createdAt);
     this.indexTree = new IndexTree<CRDTTreeNode>(root);
     this.nodeMapByID = new LLRBTree(CRDTTreeNodeID.createComparator());
+    this.pendingGCPairs = [];
 
     this.indexTree.traverseAll((node) => {
       this.nodeMapByID.put(node.id, node);
@@ -1070,6 +1088,25 @@ export class CRDTTree extends CRDTElement implements GCParent {
    */
   public registerNode(node: CRDTTreeNode): void {
     this.nodeMapByID.put(node.id, node);
+  }
+
+  /**
+   * `registerPendingGCPair` buffers a GC pair for a node that was born
+   * tombstoned (split off an already-removed node). The pair is picked up
+   * by the next `edit` or `style` call via `drainPendingGCPairs`.
+   */
+  public registerPendingGCPair(node: CRDTTreeNode): void {
+    this.pendingGCPairs.push({ parent: this, child: node });
+  }
+
+  /**
+   * `drainPendingGCPairs` returns the buffered GC pairs and clears the
+   * buffer.
+   */
+  public drainPendingGCPairs(): Array<GCPair> {
+    const pairs = this.pendingGCPairs;
+    this.pendingGCPairs = [];
+    return pairs;
   }
 
   /**
@@ -1334,6 +1371,8 @@ export class CRDTTree extends CRDTElement implements GCParent {
       },
     );
 
+    pairs.push(...this.drainPendingGCPairs());
+
     return [pairs, changes, diff, prevAttributes, newAttrKeys];
   }
 
@@ -1467,6 +1506,8 @@ export class CRDTTree extends CRDTElement implements GCParent {
         }
       },
     );
+
+    pairs.push(...this.drainPendingGCPairs());
 
     return [pairs, changes, diff, prevAttributes];
   }
@@ -1827,6 +1868,8 @@ export class CRDTTree extends CRDTElement implements GCParent {
       }
     }
 
+    pairs.push(...this.drainPendingGCPairs());
+
     return [
       changes,
       pairs,
@@ -1921,7 +1964,10 @@ export class CRDTTree extends CRDTElement implements GCParent {
    */
   public getGCPairs(): Array<GCPair> {
     const pairs: Array<GCPair> = [];
-    this.indexTree.traverse((node) => {
+    // NOTE: `traverse` only visits visible children, which never includes
+    // removed nodes. `traverseAll` is required to register tombstones
+    // (including pieces split off a tombstoned node) after snapshot load.
+    this.indexTree.traverseAll((node) => {
       if (node.getRemovedAt()) {
         pairs.push({ parent: this, child: node });
       }

--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -679,8 +679,12 @@ export class CRDTTreeNode
       // `removedAt` without going through `remove()`, so no GC pair is
       // created for it in the normal deletion path. Register it here so
       // it can be purged; otherwise it stays in the tree forever.
+      // The piece was never live, so its size goes straight to docSize.gc
+      // when the pair is registered; report a zero diff to the caller
+      // (which accounts diffs to docSize.live).
       if (split.removedAt) {
-        tree.registerPendingGCPair(split);
+        tree.registerPendingGCPair(split, diff);
+        return [split, { data: 0, meta: 0 }];
       }
     }
     return [split, diff];
@@ -811,9 +815,16 @@ export class CRDTTreeNode
       return pairs;
     }
 
+    // NOTE: Only called when a root is built from a snapshot. Removed
+    // attribute nodes are skipped by `getDataSize`, so they were never
+    // counted into docSize.live — hence `gcOnlySize`.
     for (const node of this.attrs) {
       if (node.getRemovedAt()) {
-        pairs.push({ parent: this, child: node });
+        pairs.push({
+          parent: this,
+          child: node,
+          gcOnlySize: node.getDataSize(),
+        });
       }
     }
 
@@ -1093,10 +1104,12 @@ export class CRDTTree extends CRDTElement implements GCParent {
   /**
    * `registerPendingGCPair` buffers a GC pair for a node that was born
    * tombstoned (split off an already-removed node). The pair is picked up
-   * by the next `edit` or `style` call via `drainPendingGCPairs`.
+   * by the next `edit` or `style` call via `drainPendingGCPairs`. `size`
+   * is the net-new size created by the split; it is accounted to
+   * docSize.gc at registration since the node was never live.
    */
-  public registerPendingGCPair(node: CRDTTreeNode): void {
-    this.pendingGCPairs.push({ parent: this, child: node });
+  public registerPendingGCPair(node: CRDTTreeNode, size: DataSize): void {
+    this.pendingGCPairs.push({ parent: this, child: node, gcOnlySize: size });
   }
 
   /**
@@ -1967,9 +1980,15 @@ export class CRDTTree extends CRDTElement implements GCParent {
     // NOTE: `traverse` only visits visible children, which never includes
     // removed nodes. `traverseAll` is required to register tombstones
     // (including pieces split off a tombstoned node) after snapshot load.
+    // These pairs carry `gcOnlySize` because `getDataSize` of the freshly
+    // built root only counted visible nodes into docSize.live.
     this.indexTree.traverseAll((node) => {
       if (node.getRemovedAt()) {
-        pairs.push({ parent: this, child: node });
+        pairs.push({
+          parent: this,
+          child: node,
+          gcOnlySize: node.getDataSize(),
+        });
       }
 
       for (const p of node.getGCPairs()) {

--- a/packages/sdk/src/document/json/tree.ts
+++ b/packages/sdk/src/document/json/tree.ts
@@ -1092,7 +1092,9 @@ export class Tree {
       CRDTTreePos.fromStruct(range[1]),
     ];
 
-    return this.tree.posRangeToIndexRange(posRange);
+    const indexRange = this.tree.posRangeToIndexRange(posRange);
+    this.registerPendingGCPairs();
+    return indexRange;
   }
 
   /**
@@ -1113,6 +1115,23 @@ export class Tree {
       CRDTTreePos.fromStruct(range[1]),
     ];
 
-    return this.tree.posRangeToPathRange(posRange);
+    const pathRange = this.tree.posRangeToPathRange(posRange);
+    this.registerPendingGCPairs();
+    return pathRange;
+  }
+
+  /**
+   * `registerPendingGCPairs` registers with the root any GC pairs the tree
+   * buffered while resolving a position. `posRangeToIndexRange` and
+   * `posRangeToPathRange` split text nodes to locate a position; when the
+   * position lands inside a tombstoned node the split produces a
+   * born-removed piece. Unlike edit/style/removeStyle, these read-path
+   * conversions emit no operation, so the buffered pairs would otherwise
+   * never reach the root and the piece would leak (invisible to GC).
+   */
+  private registerPendingGCPairs(): void {
+    for (const pair of this.tree!.drainPendingGCPairs()) {
+      this.context!.registerGCPair(pair);
+    }
   }
 }

--- a/packages/sdk/test/unit/document/gc_split_leak_test.ts
+++ b/packages/sdk/test/unit/document/gc_split_leak_test.ts
@@ -6,6 +6,8 @@ import { Tree } from '@yorkie-js/sdk/src/yorkie';
 import { ChangePack } from '@yorkie-js/sdk/src/document/change/change_pack';
 import { Checkpoint } from '@yorkie-js/sdk/src/document/change/checkpoint';
 import { InitialVersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
+import { converter } from '@yorkie-js/sdk/src/api/converter';
 
 /**
  * Exchanges pending local changes between two in-process documents,
@@ -57,56 +59,85 @@ function crossSync<T>(d1: Document<T>, d2: Document<T>): void {
   d2.applyChangePack(ack(p2));
 }
 
-// Reproduction of suspected GC leak: pieces split off an already-tombstoned
-// node never receive GC pairs, so incremental GC cannot purge them.
-// Runs against unmodified src/ — the crossSync helper below is test-only
-// plumbing to exchange changes between two in-process documents.
+const A1 = '000000000000000000000001';
+const A2 = '000000000000000000000002';
+
+/**
+ * Builds two replicas where d1 deletes "el" (splitting the text node) and
+ * d2 concurrently deletes the whole <p> (tombstoning it unsplit). When
+ * d1's delete arrives at d2, it splits d2's tombstoned text node, creating
+ * pieces that are born already-removed.
+ */
+function buildTombstoneSplitReplicas(): [
+  Document<{ t: Tree }>,
+  Document<{ t: Tree }>,
+] {
+  const d1 = new Document<{ t: Tree }>('test-doc');
+  const d2 = new Document<{ t: Tree }>('test-doc');
+  d1.setActor(A1);
+  d2.setActor(A2);
+
+  d1.update((root) => {
+    root.t = new Tree({
+      type: 'doc',
+      children: [{ type: 'p', children: [{ type: 'text', value: 'hello' }] }],
+    });
+  });
+  crossSync(d1, d2);
+
+  d1.update((root) => root.t.edit(2, 4));
+  d2.update((root) => root.t.edit(0, 7));
+  crossSync(d1, d2);
+
+  return [d1, d2];
+}
+
+// Regression tests for tombstone-split GC leaks: a piece split off an
+// already-tombstoned node inherits `removedAt` without passing through
+// `remove()`, so it used to miss GC pair registration and stay in the
+// tree forever.
 
 describe('GC tombstone-split leak', () => {
-  it('purges fewer nodes on the replica whose tombstone was split remotely', () => {
-    const A1 = '000000000000000000000001';
-    const A2 = '000000000000000000000002';
-    const d1 = new Document<{ t: Tree }>('test-doc');
-    const d2 = new Document<{ t: Tree }>('test-doc');
-    d1.setActor(A1);
-    d2.setActor(A2);
-
-    d1.update((root) => {
-      root.t = new Tree({
-        type: 'doc',
-        children: [{ type: 'p', children: [{ type: 'text', value: 'hello' }] }],
-      });
-    });
-    crossSync(d1, d2);
-
-    // Concurrent: d1 deletes "el" (splits the text live, at d1);
-    // d2 deletes the whole <p> (tombstones it unsplit, at d2).
-    // When d1's delete arrives at d2, it must split d2's TOMBSTONE —
-    // creating born-dead pieces that never get GC pairs.
-    d1.update((root) => root.t.edit(2, 4));
-    d2.update((root) => root.t.edit(0, 7));
-    crossSync(d1, d2);
+  it('purges the same nodes on both replicas when a tombstone is split remotely', () => {
+    const [d1, d2] = buildTombstoneSplitReplicas();
 
     // Identical converged state on both replicas:
     assert.equal(d1.getRoot().t.toXML(), '<doc></doc>');
     assert.equal(d2.getRoot().t.toXML(), d1.getRoot().t.toXML());
 
-    // Same full vector, same logical tombstones → purge counts should match.
+    // Same full vector, same logical tombstones → purge counts must match.
+    // Before the fix, the replica whose tombstone was split by the remote
+    // delete leaked the born-dead pieces (d1=4, d2=2).
     const purged1 = d1.garbageCollect(maxVectorOf([A1, A2]));
     const purged2 = d2.garbageCollect(maxVectorOf([A1, A2]));
-
-    // BUG (documents current behavior, not desired behavior):
-    // identical logical state purges asymmetrically — the replica whose
-    // tombstone was split by a concurrent remote delete leaks node(s)
-    // that never received GC pairs. Observed: d1=4, d2=3.
     assert.equal(
       purged1,
       purged2,
       `asymmetric purge for identical state: d1=${purged1} d2=${purged2}`,
     );
 
-    // Incremental GC believes it is done on both:
     assert.equal(d1.getGarbageLen(), 0);
     assert.equal(d2.getGarbageLen(), 0);
+  });
+
+  it('registers GC pairs for tree tombstones after snapshot round-trip', () => {
+    const [, d2] = buildTombstoneSplitReplicas();
+
+    // Snapshot-encode d2's root (tombstones included) and rebuild a root
+    // from it, as a client receiving a snapshot would. The rebuilt root
+    // must see and purge the same garbage as the live one — including the
+    // pieces split off the tombstoned text node. Before the fix,
+    // `CRDTTree.getGCPairs` traversed only visible nodes, so a
+    // snapshot-loaded root registered no tree tombstones at all.
+    const bytes = converter.objectToBytes(d2.getRootObject());
+    const rebuilt = new CRDTRoot(converter.bytesToObject(bytes));
+
+    assert.isAbove(d2.getGarbageLen(), 0);
+    assert.equal(rebuilt.getGarbageLen(), d2.getGarbageLen());
+
+    const purgedLive = d2.garbageCollect(maxVectorOf([A1, A2]));
+    const purgedRebuilt = rebuilt.garbageCollect(maxVectorOf([A1, A2]));
+    assert.equal(purgedRebuilt, purgedLive);
+    assert.equal(rebuilt.getGarbageLen(), 0);
   });
 });

--- a/packages/sdk/test/unit/document/gc_split_leak_test.ts
+++ b/packages/sdk/test/unit/document/gc_split_leak_test.ts
@@ -1,0 +1,112 @@
+import { describe, it, assert } from 'vitest';
+import { maxVectorOf } from '@yorkie-js/sdk/test/helper/helper';
+
+import { Document } from '@yorkie-js/sdk/src/document/document';
+import { Tree } from '@yorkie-js/sdk/src/yorkie';
+import { ChangePack } from '@yorkie-js/sdk/src/document/change/change_pack';
+import { Checkpoint } from '@yorkie-js/sdk/src/document/change/checkpoint';
+import { InitialVersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
+
+/**
+ * Exchanges pending local changes between two in-process documents,
+ * mimicking a server round-trip without serialization (so prototype-only
+ * fields like restoreSpans survive).
+ */
+function crossSync<T>(d1: Document<T>, d2: Document<T>): void {
+  const p1 = d1.createChangePack();
+  const p2 = d2.createChangePack();
+
+  // Deliver with a neutral checkpoint (clientSeq 0) so the receiver's own
+  // pending local changes are not dropped. Empty version vector keeps GC
+  // out of the exchange (GC interaction is tested separately, e.g. E4).
+  d2.applyChangePack(
+    ChangePack.create(
+      p1.getDocumentKey(),
+      Checkpoint.of(0n, 0),
+      false,
+      p1.getChanges(),
+      InitialVersionVector,
+    ),
+  );
+  d1.applyChangePack(
+    ChangePack.create(
+      p2.getDocumentKey(),
+      Checkpoint.of(0n, 0),
+      false,
+      p2.getChanges(),
+      InitialVersionVector,
+    ),
+  );
+  // Self-ack: drop exactly the delivered changes from each sender's local
+  // queue so the next crossSync doesn't re-send them (re-applying a change
+  // twice corrupts state).
+  const ack = (pack: ReturnType<Document<T>['createChangePack']>) => {
+    const changes = pack.getChanges();
+    const lastSeq = changes.length
+      ? changes[changes.length - 1].getID().getClientSeq()
+      : 0;
+    return ChangePack.create(
+      pack.getDocumentKey(),
+      Checkpoint.of(0n, lastSeq),
+      false,
+      [],
+      InitialVersionVector,
+    );
+  };
+  d1.applyChangePack(ack(p1));
+  d2.applyChangePack(ack(p2));
+}
+
+// Reproduction of suspected GC leak: pieces split off an already-tombstoned
+// node never receive GC pairs, so incremental GC cannot purge them.
+// Runs against unmodified src/ — the crossSync helper below is test-only
+// plumbing to exchange changes between two in-process documents.
+
+describe('GC tombstone-split leak', () => {
+  it('purges fewer nodes on the replica whose tombstone was split remotely', () => {
+    const A1 = '000000000000000000000001';
+    const A2 = '000000000000000000000002';
+    const d1 = new Document<{ t: Tree }>('test-doc');
+    const d2 = new Document<{ t: Tree }>('test-doc');
+    d1.setActor(A1);
+    d2.setActor(A2);
+
+    d1.update((root) => {
+      root.t = new Tree({
+        type: 'doc',
+        children: [{ type: 'p', children: [{ type: 'text', value: 'hello' }] }],
+      });
+    });
+    crossSync(d1, d2);
+
+    // Concurrent: d1 deletes "el" (splits the text live, at d1);
+    // d2 deletes the whole <p> (tombstones it unsplit, at d2).
+    // When d1's delete arrives at d2, it must split d2's TOMBSTONE —
+    // creating born-dead pieces that never get GC pairs.
+    d1.update((root) => root.t.edit(2, 4));
+    d2.update((root) => root.t.edit(0, 7));
+    crossSync(d1, d2);
+
+    // Identical converged state on both replicas:
+    assert.equal(d1.getRoot().t.toXML(), '<doc></doc>');
+    assert.equal(d2.getRoot().t.toXML(), d1.getRoot().t.toXML());
+
+    // Same full vector, same logical tombstones → purge counts should match.
+    const purged1 = d1.garbageCollect(maxVectorOf([A1, A2]));
+    const purged2 = d2.garbageCollect(maxVectorOf([A1, A2]));
+
+    // BUG (documents current behavior, not desired behavior):
+    // identical logical state purges asymmetrically — the replica whose
+    // tombstone was split by a concurrent remote delete leaks node(s)
+    // that never received GC pairs. Observed: d1=4, d2=3.
+    assert.equal(
+      purged1,
+      purged2,
+      `asymmetric purge for identical state: d1=${purged1} d2=${purged2}`,
+    );
+
+    // Incremental GC believes it is done on both:
+    assert.equal(d1.getGarbageLen(), 0);
+    assert.equal(d2.getGarbageLen(), 0);
+  });
+});

--- a/packages/sdk/test/unit/document/gc_split_leak_test.ts
+++ b/packages/sdk/test/unit/document/gc_split_leak_test.ts
@@ -155,45 +155,59 @@ describe('GC tombstone-split leak', () => {
     assert.deepEqual(rebuilt.getDocSize().live, d2.getDocSize().live);
   });
 
-  it('registers GC pairs for pieces split off a tombstone during a read-path range conversion', () => {
-    const d1 = new Document<{ t: Tree }>('test-doc');
-    const d2 = new Document<{ t: Tree }>('test-doc');
-    d1.setActor(A1);
-    d2.setActor(A2);
+  // Each range-conversion wrapper must independently drain the pending GC
+  // pairs. Run every method against its own freshly tombstoned tree — the
+  // first conversion splits the tombstone, so sharing one tree would leave
+  // later conversions with nothing to split and never exercise their drain.
+  const conversions: Array<
+    (tree: Tree, range: ReturnType<Tree['indexRangeToPosRange']>) => void
+  > = [
+    (tree, range) => tree.posRangeToIndexRange(range),
+    (tree, range) => tree.posRangeToPathRange(range),
+  ];
 
-    d1.update((root) => {
-      root.t = new Tree({
-        type: 'doc',
-        children: [{ type: 'p', children: [{ type: 'text', value: 'hello' }] }],
+  for (const [i, convert] of conversions.entries()) {
+    it(`registers GC pairs split during read-path range conversion #${i}`, () => {
+      const d1 = new Document<{ t: Tree }>('test-doc');
+      const d2 = new Document<{ t: Tree }>('test-doc');
+      d1.setActor(A1);
+      d2.setActor(A2);
+
+      d1.update((root) => {
+        root.t = new Tree({
+          type: 'doc',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'hello' }] },
+          ],
+        });
       });
+      crossSync(d1, d2);
+
+      // Capture a selection that points into the middle of "hello", as a
+      // stored cursor/selection would.
+      const selection = d1.getRoot().t.indexRangeToPosRange([2, 4]);
+
+      // A peer deletes the whole <p>, tombstoning "hello" on d1.
+      d2.update((root) => root.t.edit(0, 7));
+      crossSync(d1, d2);
+
+      // Resolving the stored selection now lands inside the tombstoned text
+      // and splits it — a read path that emits no operation. The born-removed
+      // pieces must still be registered so a later GC can purge them.
+      convert(d1.getRoot().t, selection);
+
+      d1.garbageCollect(maxVectorOf([A1, A2]));
+
+      // After GC the clone tree (mutated by the read-path split) and the
+      // document root must hold the same physical nodes. A born-removed piece
+      // that never registered a GC pair would linger in the clone's node map,
+      // making it larger. Before the fix the clone kept the leaked piece(s).
+      const cloneTree = d1.getCloneRoot()!.get('t') as unknown as CRDTTree;
+      const rootTree = d1.getRootObject().get('t') as unknown as CRDTTree;
+      assert.equal(cloneTree.getNodeSize(), rootTree.getNodeSize());
+      assert.equal(d1.getGarbageLenFromClone(), 0);
     });
-    crossSync(d1, d2);
-
-    // Capture a selection that points into the middle of "hello", as a
-    // stored cursor/selection would.
-    const selection = d1.getRoot().t.indexRangeToPosRange([2, 4]);
-
-    // A peer deletes the whole <p>, tombstoning "hello" on d1.
-    d2.update((root) => root.t.edit(0, 7));
-    crossSync(d1, d2);
-
-    // Resolving the stored selection now lands inside the tombstoned text
-    // and splits it — a read path that emits no operation. The born-removed
-    // pieces must still be registered so a later GC can purge them.
-    d1.getRoot().t.posRangeToIndexRange(selection);
-    d1.getRoot().t.posRangeToPathRange(selection);
-
-    d1.garbageCollect(maxVectorOf([A1, A2]));
-
-    // After GC the clone tree (mutated by the read-path split) and the
-    // document root must hold the same physical nodes. A born-removed piece
-    // that never registered a GC pair would linger in the clone's node map,
-    // making it larger. Before the fix the clone kept the leaked piece(s).
-    const cloneTree = d1.getCloneRoot()!.get('t') as unknown as CRDTTree;
-    const rootTree = d1.getRootObject().get('t') as unknown as CRDTTree;
-    assert.equal(cloneTree.getNodeSize(), rootTree.getNodeSize());
-    assert.equal(d1.getGarbageLenFromClone(), 0);
-  });
+  }
 });
 
 type TextDoc = { k: Text };

--- a/packages/sdk/test/unit/document/gc_split_leak_test.ts
+++ b/packages/sdk/test/unit/document/gc_split_leak_test.ts
@@ -4,6 +4,7 @@ import { maxVectorOf } from '@yorkie-js/sdk/test/helper/helper';
 import { Document } from '@yorkie-js/sdk/src/document/document';
 import { Text, Tree } from '@yorkie-js/sdk/src/yorkie';
 import { CRDTText } from '@yorkie-js/sdk/src/document/crdt/text';
+import { CRDTTree } from '@yorkie-js/sdk/src/document/crdt/tree';
 import { ChangePack } from '@yorkie-js/sdk/src/document/change/change_pack';
 import { Checkpoint } from '@yorkie-js/sdk/src/document/change/checkpoint';
 import { InitialVersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
@@ -153,6 +154,46 @@ describe('GC tombstone-split leak', () => {
     assert.deepEqual(rebuilt.getDocSize().gc, { data: 0, meta: 0 });
     assert.deepEqual(rebuilt.getDocSize().live, d2.getDocSize().live);
   });
+
+  it('registers GC pairs for pieces split off a tombstone during a read-path range conversion', () => {
+    const d1 = new Document<{ t: Tree }>('test-doc');
+    const d2 = new Document<{ t: Tree }>('test-doc');
+    d1.setActor(A1);
+    d2.setActor(A2);
+
+    d1.update((root) => {
+      root.t = new Tree({
+        type: 'doc',
+        children: [{ type: 'p', children: [{ type: 'text', value: 'hello' }] }],
+      });
+    });
+    crossSync(d1, d2);
+
+    // Capture a selection that points into the middle of "hello", as a
+    // stored cursor/selection would.
+    const selection = d1.getRoot().t.indexRangeToPosRange([2, 4]);
+
+    // A peer deletes the whole <p>, tombstoning "hello" on d1.
+    d2.update((root) => root.t.edit(0, 7));
+    crossSync(d1, d2);
+
+    // Resolving the stored selection now lands inside the tombstoned text
+    // and splits it — a read path that emits no operation. The born-removed
+    // pieces must still be registered so a later GC can purge them.
+    d1.getRoot().t.posRangeToIndexRange(selection);
+    d1.getRoot().t.posRangeToPathRange(selection);
+
+    d1.garbageCollect(maxVectorOf([A1, A2]));
+
+    // After GC the clone tree (mutated by the read-path split) and the
+    // document root must hold the same physical nodes. A born-removed piece
+    // that never registered a GC pair would linger in the clone's node map,
+    // making it larger. Before the fix the clone kept the leaked piece(s).
+    const cloneTree = d1.getCloneRoot()!.get('t') as unknown as CRDTTree;
+    const rootTree = d1.getRootObject().get('t') as unknown as CRDTTree;
+    assert.equal(cloneTree.getNodeSize(), rootTree.getNodeSize());
+    assert.equal(d1.getGarbageLenFromClone(), 0);
+  });
 });
 
 type TextDoc = { k: Text };
@@ -173,6 +214,10 @@ function countTextTombstones(doc: Document<TextDoc>): number {
   return count;
 }
 
+/**
+ * `buildTextReplicas` creates two in-process replicas that share a Text
+ * field seeded with "abcdef" and already converged.
+ */
 function buildTextReplicas(): [Document<TextDoc>, Document<TextDoc>] {
   const d1 = new Document<TextDoc>('test-doc');
   const d2 = new Document<TextDoc>('test-doc');

--- a/packages/sdk/test/unit/document/gc_split_leak_test.ts
+++ b/packages/sdk/test/unit/document/gc_split_leak_test.ts
@@ -119,6 +119,12 @@ describe('GC tombstone-split leak', () => {
 
     assert.equal(d1.getGarbageLen(), 0);
     assert.equal(d2.getGarbageLen(), 0);
+
+    // docSize must also stay symmetric: born-dead pieces were never live,
+    // so registering them must not move sizes out of docSize.live, and a
+    // full GC must drain docSize.gc to zero on both replicas.
+    assert.deepEqual(d2.getDocSize(), d1.getDocSize());
+    assert.deepEqual(d1.getDocSize().gc, { data: 0, meta: 0 });
   });
 
   it('registers GC pairs for tree tombstones after snapshot round-trip', () => {
@@ -140,6 +146,12 @@ describe('GC tombstone-split leak', () => {
     const purgedRebuilt = rebuilt.garbageCollect(maxVectorOf([A1, A2]));
     assert.equal(purgedRebuilt, purgedLive);
     assert.equal(rebuilt.getGarbageLen(), 0);
+
+    // The rebuilt root counts tombstones straight into docSize.gc (they
+    // were never in its docSize.live), so a full GC must drain gc to zero
+    // without pushing live negative.
+    assert.deepEqual(rebuilt.getDocSize().gc, { data: 0, meta: 0 });
+    assert.deepEqual(rebuilt.getDocSize().live, d2.getDocSize().live);
   });
 });
 
@@ -209,6 +221,10 @@ describe('GC tombstone-split leak (Text)', () => {
     assert.equal(countTextTombstones(d2), 0);
     assert.equal(d1.getGarbageLen(), 0);
     assert.equal(d2.getGarbageLen(), 0);
+
+    // Same docSize invariants as the tree case.
+    assert.deepEqual(d2.getDocSize(), d1.getDocSize());
+    assert.deepEqual(d1.getDocSize().gc, { data: 0, meta: 0 });
   });
 
   it('keeps GC registration when a newer concurrent delete overwrites a tombstone', () => {

--- a/packages/sdk/test/unit/document/gc_split_leak_test.ts
+++ b/packages/sdk/test/unit/document/gc_split_leak_test.ts
@@ -2,7 +2,8 @@ import { describe, it, assert } from 'vitest';
 import { maxVectorOf } from '@yorkie-js/sdk/test/helper/helper';
 
 import { Document } from '@yorkie-js/sdk/src/document/document';
-import { Tree } from '@yorkie-js/sdk/src/yorkie';
+import { Text, Tree } from '@yorkie-js/sdk/src/yorkie';
+import { CRDTText } from '@yorkie-js/sdk/src/document/crdt/text';
 import { ChangePack } from '@yorkie-js/sdk/src/document/change/change_pack';
 import { Checkpoint } from '@yorkie-js/sdk/src/document/change/checkpoint';
 import { InitialVersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
@@ -139,5 +140,102 @@ describe('GC tombstone-split leak', () => {
     const purgedRebuilt = rebuilt.garbageCollect(maxVectorOf([A1, A2]));
     assert.equal(purgedRebuilt, purgedLive);
     assert.equal(rebuilt.getGarbageLen(), 0);
+  });
+});
+
+type TextDoc = { k: Text };
+
+/**
+ * Counts tombstoned nodes still physically present in the text's RGATreeSplit.
+ * After a full-vector garbage collection this must be zero; any remainder is
+ * a node that was never registered (or was toggle-unregistered) for GC.
+ */
+function countTextTombstones(doc: Document<TextDoc>): number {
+  const text = doc.getRootObject().get('k') as CRDTText;
+  let count = 0;
+  for (const node of text.getRGATreeSplit()) {
+    if (node.isRemoved()) {
+      count += 1;
+    }
+  }
+  return count;
+}
+
+function buildTextReplicas(): [Document<TextDoc>, Document<TextDoc>] {
+  const d1 = new Document<TextDoc>('test-doc');
+  const d2 = new Document<TextDoc>('test-doc');
+  d1.setActor(A1);
+  d2.setActor(A2);
+
+  d1.update((root) => {
+    root.k = new Text();
+    root.k.edit(0, 0, 'abcdef');
+  });
+  crossSync(d1, d2);
+
+  return [d1, d2];
+}
+
+// Same class of leak in the Text CRDT: RGATreeSplitNode.split() copies
+// `removedAt` into the new piece, so pieces split off an already-tombstoned
+// text node are born removed without passing through remove() and miss GC
+// pair registration. Additionally, a concurrent delete that overwrites an
+// existing tombstone (LWW) used to re-push a GC pair for it, and
+// CRDTRoot.registerGCPair's toggle semantics then deleted the existing
+// registration.
+describe('GC tombstone-split leak (Text)', () => {
+  it('purges pieces split off a tombstoned text node', () => {
+    const [d1, d2] = buildTextReplicas();
+
+    // d1 tombstones the whole node; d2 concurrently deletes a middle slice.
+    // When d2's delete arrives at d1, it splits d1's tombstone into three
+    // pieces; the piece after the deleted range is born dead and used to
+    // get no GC pair.
+    d1.update((root) => root.k.edit(0, 6, ''));
+    d2.update((root) => root.k.edit(2, 4, ''));
+    crossSync(d1, d2);
+
+    assert.equal(d1.getRoot().k.toString(), '');
+    assert.equal(d2.getRoot().k.toString(), '');
+
+    const purged1 = d1.garbageCollect(maxVectorOf([A1, A2]));
+    const purged2 = d2.garbageCollect(maxVectorOf([A1, A2]));
+    assert.equal(
+      purged1,
+      purged2,
+      `asymmetric purge for identical state: d1=${purged1} d2=${purged2}`,
+    );
+    assert.equal(countTextTombstones(d1), 0);
+    assert.equal(countTextTombstones(d2), 0);
+    assert.equal(d1.getGarbageLen(), 0);
+    assert.equal(d2.getGarbageLen(), 0);
+  });
+
+  it('keeps GC registration when a newer concurrent delete overwrites a tombstone', () => {
+    const [d1, d2] = buildTextReplicas();
+
+    // Bump d1's lamport so its whole-range delete is newer than d2's slice
+    // delete. When d1's delete arrives at d2, canRemove() allows the LWW
+    // overwrite of d2's own tombstone; re-pushing a GC pair for that node
+    // used to toggle-unregister it.
+    d1.update((root) => root.k.edit(6, 6, '!'));
+    d1.update((root) => root.k.edit(0, 7, ''));
+    d2.update((root) => root.k.edit(2, 4, ''));
+    crossSync(d1, d2);
+
+    assert.equal(d1.getRoot().k.toString(), '');
+    assert.equal(d2.getRoot().k.toString(), '');
+
+    const purged1 = d1.garbageCollect(maxVectorOf([A1, A2]));
+    const purged2 = d2.garbageCollect(maxVectorOf([A1, A2]));
+    assert.equal(
+      purged1,
+      purged2,
+      `asymmetric purge for identical state: d1=${purged1} d2=${purged2}`,
+    );
+    assert.equal(countTextTombstones(d1), 0);
+    assert.equal(countTextTombstones(d2), 0);
+    assert.equal(d1.getGarbageLen(), 0);
+    assert.equal(d2.getGarbageLen(), 0);
   });
 });


### PR DESCRIPTION
#### What this PR does / why we need it?

Fixes a family of garbage-collection leaks around **tombstone splits**. When a node is split, the new piece is cloned from the original — including its `removedAt`. So a piece split off an already-tombstoned node is *born dead* without ever passing through `remove()`, and since GC pairs are only registered on the live→dead transition, no pair is ever created for it. Incremental GC can never purge such pieces: they linger in the tree / RGA list forever, invisible to `getGarbageLen()`, and replicas that split a tombstone purge asymmetrically from replicas that don't.

Three commits:

1. **Tree** — `CRDTTreeNode.split()` buffers a GC pair when the split piece is born dead; `edit`/`style`/`removeStyle` drain the buffer into the pairs they already return. Covers both text and element splits (shared `split()` path). Also switches `getGCPairs()` from `traverse` to `traverseAll` — the visible-only traversal skipped tombstones entirely, so a snapshot-loaded root registered none of them.
2. **Text** — same born-dead-split fix in `RGATreeSplit.splitNode`, plus a Text-only leak: on an LWW overwrite of an existing tombstone, `edit()` re-pushed a GC pair for an already-registered node, and `registerGCPair`'s toggle semantics then *unregistered* it. `deleteNodes()` now reports already-removed nodes so `edit()` can skip re-registering them.
3. **docSize** — `registerGCPair` moves a child's size `live`→`gc`, which double-counts children that were never in `live` (born-dead pieces, and snapshot-scan tombstones). This drove `docSize.live` negative and left `gc` residue after a full GC. `GCPair` gains an optional `gcOnlySize`; when set, registration adds only to `gc` and leaves `live` untouched.

#### Any background context you want to provide?

Repro (Tree): from `<p>hello</p>`, client A deletes `"el"` (splits the text node while live) while client B deletes the whole `<p>` (tombstones it unsplit). When A's edit reaches B it splits B's *tombstone*, creating born-dead pieces. Both replicas converge to `<doc></doc>`, but A purges 4 nodes and B purges 2, while both report `getGarbageLen() === 0`. Regression tests in `test/unit/document/gc_split_leak_test.ts` (4 tests) cover the Tree split, the snapshot round-trip, the Text split, and the Text LWW toggle case; each asserts symmetric purge, zero tombstone remainder, and `docSize.gc === {0,0}` after GC, and each was verified to fail with its fix reverted.

Out of scope: the Go server has the same born-dead-split shape (`SplitText`/`SplitElement` and the RGA `split` all copy `removedAt`), so it needs the same fix — I'll file a follow-up issue on `yorkie-team/yorkie`. The toggle-unregistration bug is JS-only (Go guards pair pushes on `Remove()` returning true).

#### Special notes for your reviewer

The docSize accounting (commit 3) is the fiddly part. The invariant: `docSize.gc` must hold exactly the sum of what purge will later subtract per registered pair. `gcOnlySize` is set only for children that were never counted in `live`; the doc comment in `gc.ts` and `registerGCPair` in `root.ts` spell this out.

#### What are the relevant tickets?

Fixes #1873

### Checklist
- [x] Added relevant tests or not required
- [x] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed garbage-collection pair generation and purge behavior for tombstone-split scenarios, including when triggered via position/range resolution.
  * Added “GC-only” size accounting so removed/tombstoned node sizes don’t incorrectly affect live document sizing (improves symmetry after snapshot restores).
  * Prevented GC registration toggling/leaks when concurrent deletes create or overwrite tombstones.
* **Tests**
  * Added regression tests covering replica cross-sync, full-vector garbage collection, and snapshot round-trips for both tree and text cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->