### PR TITLE
Release v0.7.13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and Yorkie JS SDK adheres to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+## [v0.7.13] - 2026-07-23
+
+### Added
+
+- Identity-preserving restore for Text undo/redo by @harrykim8672 in https://github.com/yorkie-team/yorkie-js-sdk/pull/1293
+
+### Fixed
+
+- Register GC pairs for pieces split off tombstoned nodes by @harrykim8672 in https://github.com/yorkie-team/yorkie-js-sdk/pull/1292
+- Prevent panic when splitLevel walks past the tree root by @ggyuchive in https://github.com/yorkie-team/yorkie-js-sdk/pull/1289
+
 ## [v0.7.12] - 2026-06-18
 
 ### Added

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yorkie-js/devtools",
   "displayName": "Yorkie Devtools",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "A browser extension that helps you debug Yorkie.",
   "homepage": "https://yorkie.dev/",
   "scripts": {

--- a/packages/prosemirror/package.json
+++ b/packages/prosemirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/prosemirror",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "ProseMirror binding for Yorkie collaborative editing",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/react",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "A set of hooks and providers for Yorkie JS SDK",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/schema",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "Yorkie Schema for Yorkie Document",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/sdk",
-  "version": "0.7.12",
+  "version": "0.7.13",
   "description": "Yorkie JS SDK",
   "main": "./src/yorkie.ts",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Bump all publishable packages to v0.7.13.

- `packages/{sdk,react,schema,prosemirror,devtools}/package.json`: version 0.7.13
- `CHANGELOG.md`: v0.7.13 entry (Added / Fixed)

## Test plan

- CI green