### PR TITLE
Move tombstones with merge to preserve tree RGA anchors

### DIFF
--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -1628,7 +1628,11 @@ export class CRDTTree extends CRDTElement implements GCParent {
           // not an intentional merge.
           if (ticketKnown(versionVector, node.id.getCreatedAt())) {
             toBeMergedNodes.push(node);
-            for (const child of node.children) {
+            // Include removed children (allChildren) so tombstones move
+            // with the merge and survive as RGA anchors; a concurrent
+            // insert referencing one then resolves in the merge target
+            // and orders via the RGA tie-break.
+            for (const child of node.allChildren) {
               toBeMovedToFromParents.push(child);
             }
           }
@@ -1720,23 +1724,21 @@ export class CRDTTree extends CRDTElement implements GCParent {
     // time) because the source's `removedAt` is mutated by LWW when a
     // later concurrent tombstone targets the same node.
     for (const node of toBeMovedToFromParents) {
-      if (!node.removedAt) {
-        if (node.parent) {
-          node.mergedFrom = node.parent.id;
-          node.mergedAt = editedAt;
-        }
-        // Detach from old parent to prevent ghost references.
-        // Use try-catch because the child may already have been detached
-        // by a concurrent operation (e.g., cascade delete of split sibling).
-        if (node.parent) {
-          try {
-            node.parent.detachChild(node);
-          } catch {
-            // Child already detached from parent, skip.
-          }
-        }
-        fromParent.append(node);
+      // A moved child must have a source parent to record; skip otherwise
+      // rather than append an untracked node (a node without `mergedFrom`
+      // is invisible to the merge-delete propagation and rebuild logic).
+      if (!node.parent) {
+        continue;
       }
+      // Tombstoned children are moved too (kept removed): they stay as RGA
+      // anchors so a concurrent insert referencing one resolves in the
+      // merge target and orders via the RGA tie-break, converging with the
+      // replica that inserted before the merge. `moveChild` keeps the size
+      // accounting correct for both live and tombstoned children
+      // (visible-neutral for the latter), so index positions stay correct.
+      node.mergedFrom = node.parent.id;
+      node.mergedAt = editedAt;
+      fromParent.moveChild(node);
     }
     // Set forwarding pointer on merge-source nodes. This is a runtime
     // cache rebuilt from `mergedFrom` on snapshot load.

--- a/packages/sdk/src/util/index_tree.ts
+++ b/packages/sdk/src/util/index_tree.ts
@@ -484,6 +484,46 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
   }
 
   /**
+   * `moveChild` detaches the given child from its current parent (if any)
+   * and appends it to this node, preserving both size dimensions on both
+   * parents. Unlike `detachChild` followed by `append`, it is correct for
+   * tombstoned children: a removed node contributes no visibleSize to
+   * either parent (removal already excluded it from its ancestors), so only
+   * the include-removed totalSize is relocated. It is used by merge to move
+   * tombstones as RGA anchors without corrupting index positions.
+   */
+  moveChild(child: T): void {
+    if (this.isText) {
+      throw new YorkieError(Code.ErrRefused, 'Text node cannot have children');
+    }
+
+    const removed = child.isRemoved;
+
+    if (child.parent) {
+      const offset = child.parent._children.indexOf(child);
+      // The child may already have been spliced out of its parent's list
+      // by a concurrent operation (e.g. cascade delete of a split
+      // sibling), which already reconciled the old ancestors' size. In
+      // that case only re-parent; otherwise detach with size accounting.
+      if (offset !== -1) {
+        child.parent._children.splice(offset, 1);
+        if (!removed) {
+          child.updateAncestorsSize(-child.paddedSize());
+        }
+        child.updateAncestorsSize(-child.paddedSize(true), true);
+      }
+      child.parent = undefined;
+    }
+
+    this._children.push(child);
+    child.parent = this as any;
+    if (!removed) {
+      child.updateAncestorsSize(child.paddedSize());
+    }
+    child.updateAncestorsSize(child.paddedSize(true), true);
+  }
+
+  /**
    * `splitElement` splits the given element at the given offset.
    */
   splitElement(

--- a/packages/sdk/test/integration/tree_merge_anchor_test.ts
+++ b/packages/sdk/test/integration/tree_merge_anchor_test.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, assert } from 'vitest';
+import yorkie, { Tree, SyncMode } from '@yorkie-js/sdk/src/yorkie';
+import {
+  testRPCAddr,
+  toDocKey,
+  withTwoClientsAndDocuments,
+} from '@yorkie-js/sdk/test/integration/integration_helper';
+
+describe('Tree.Edit concurrent insert into a merged range', () => {
+  it('converges when inserting into a concurrently removed range', async ({
+    task,
+  }) => {
+    await withTwoClientsAndDocuments<{ tree: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+
+      d1.update((root) => root.tree.edit(6, 6, { type: 'p', children: [] }));
+      d2.update((root) => root.tree.edit(0, 6));
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(d1.getRoot().tree.toXML(), '<r><p></p>d</r>');
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, task.name);
+  });
+
+  it('converges with two inserts at the same anchor in a removed range', async ({
+    task,
+  }) => {
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c3 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    await c1.activate();
+    await c2.activate();
+    await c3.activate();
+
+    const docKey = `${toDocKey(task.name)}-${new Date().getTime()}`;
+    const d1 = new yorkie.Document<{ tree: Tree }>(docKey);
+    const d2 = new yorkie.Document<{ tree: Tree }>(docKey);
+    const d3 = new yorkie.Document<{ tree: Tree }>(docKey);
+    await c1.attach(d1, { syncMode: SyncMode.Manual });
+    await c2.attach(d2, { syncMode: SyncMode.Manual });
+    await c3.attach(d3, { syncMode: SyncMode.Manual });
+
+    d1.update((root) => {
+      root.tree = new Tree({
+        type: 'r',
+        children: [
+          { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+          { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+        ],
+      });
+    });
+    await c1.sync();
+    await c2.sync();
+    await c3.sync();
+
+    // c1 and c2 insert distinct elements at the same index 6; c3 removes
+    // the range [0, 6) that the inserts anchor into.
+    d1.update((root) => root.tree.edit(6, 6, { type: 'i', children: [] }));
+    d2.update((root) => root.tree.edit(6, 6, { type: 'b', children: [] }));
+    d3.update((root) => root.tree.edit(0, 6));
+
+    // Full sync so every replica sees every operation.
+    for (let i = 0; i < 3; i++) {
+      await c1.sync();
+      await c2.sync();
+      await c3.sync();
+    }
+
+    assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    assert.equal(d2.toSortedJSON(), d3.toSortedJSON());
+
+    await c1.detach(d1);
+    await c2.detach(d2);
+    await c3.detach(d3);
+    await c1.deactivate();
+    await c2.deactivate();
+    await c3.deactivate();
+  });
+});

--- a/packages/sdk/test/integration/tree_merge_anchor_test.ts
+++ b/packages/sdk/test/integration/tree_merge_anchor_test.ts
@@ -82,27 +82,29 @@ describe('Tree.Edit concurrent insert into a merged range', () => {
     await c2.sync();
     await c3.sync();
 
-    // c1 and c2 insert distinct elements at the same index 6; c3 removes
-    // the range [0, 6) that the inserts anchor into.
-    d1.update((root) => root.tree.edit(6, 6, { type: 'i', children: [] }));
-    d2.update((root) => root.tree.edit(6, 6, { type: 'b', children: [] }));
-    d3.update((root) => root.tree.edit(0, 6));
+    try {
+      // c1 and c2 insert distinct elements at the same index 6; c3 removes
+      // the range [0, 6) that the inserts anchor into.
+      d1.update((root) => root.tree.edit(6, 6, { type: 'i', children: [] }));
+      d2.update((root) => root.tree.edit(6, 6, { type: 'b', children: [] }));
+      d3.update((root) => root.tree.edit(0, 6));
 
-    // Full sync so every replica sees every operation.
-    for (let i = 0; i < 3; i++) {
-      await c1.sync();
-      await c2.sync();
-      await c3.sync();
+      // Full sync so every replica sees every operation.
+      for (let i = 0; i < 3; i++) {
+        await c1.sync();
+        await c2.sync();
+        await c3.sync();
+      }
+
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+      assert.equal(d2.toSortedJSON(), d3.toSortedJSON());
+    } finally {
+      await c1.detach(d1);
+      await c2.detach(d2);
+      await c3.detach(d3);
+      await c1.deactivate();
+      await c2.deactivate();
+      await c3.deactivate();
     }
-
-    assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-    assert.equal(d2.toSortedJSON(), d3.toSortedJSON());
-
-    await c1.detach(d1);
-    await c2.detach(d2);
-    await c3.detach(d3);
-    await c1.deactivate();
-    await c2.deactivate();
-    await c3.deactivate();
   });
 });

--- a/packages/sdk/test/unit/document/crdt/tree_test.ts
+++ b/packages/sdk/test/unit/document/crdt/tree_test.ts
@@ -600,6 +600,42 @@ describe('CRDTTree.Edit', function () {
     assert.equal(treeNode.children![0].children![0].visibleSize, 2);
   });
 
+  it('merge moves an element tombstone with correct length accounting', function () {
+    // 01. Create <root><p>ab</p><p><b></b>cd</p></root>.
+    //       0   1 2 3    4   5   6    7 8 9    10
+    // <root> <p> a b </p> <p> <b> </b> c d </p>  </root>
+    const tree = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
+    tree.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    tree.editT(
+      [1, 1],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
+    tree.editT([4, 4], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    tree.editT([5, 5], [new CRDTTreeNode(posT(), 'b')], 0, timeT(), timeT);
+    tree.editT(
+      [7, 7],
+      [new CRDTTreeNode(posT(), 'text', 'cd')],
+      0,
+      timeT(),
+      timeT,
+    );
+    assert.deepEqual(tree.toXML(), `<root><p>ab</p><p><b></b>cd</p></root>`);
+
+    // 02. Delete b, the second paragraph's open tag, the <b></b> element and
+    // c, merging the paragraph. The <b></b> element becomes a tombstone moved
+    // into the first paragraph. Its padding must not inflate the visible size
+    // of the (surviving) first paragraph.
+    tree.editT([2, 8], undefined, 0, timeT(), timeT);
+    assert.deepEqual(tree.toXML(), `<root><p>ad</p></root>`);
+
+    const treeNode = tree.toTestTreeNode();
+    assert.equal(treeNode.visibleSize, 4);
+    assert.equal(treeNode.children![0].visibleSize, 2);
+  });
+
   it('Can find the closest TreePos when parentNode or leftSiblingNode does not exist', function () {
     const t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
 


### PR DESCRIPTION
## What this PR does

Fixes #1302: a concurrent `Tree.Edit` that inserts into a range concurrently
removed by a merge diverged between replicas.

From `<r><p>ab</p><p>cd</p></r>`, with client A inserting an empty `<p>` at
index 6 and client B removing `[0,6)`:

- A (insert then remove): `<r><p></p>d</r>`
- B (remove then insert): `<r>d</r>` — the inserted node is dropped

**Root cause:** the merge moved only the *live* children of the merged
paragraph to the target and left the insert's RGA anchor (`c`) behind as a
tombstone in the removed parent. A late concurrent insert then resolved
against the removed parent and was dropped by the insert guard. With several
clients inserting at the same anchor, even the survivors ordered
inconsistently, because the merging replica never ran the RGA `createdAt`
tie-break for them.

**Fix (in the merge, not the resolver):** move tombstoned children with the
merge too, in child order, so the source's full RGA sequence is preserved in
the target. A late insert then resolves in the target through the normal path
and is ordered by the existing RGA tie-break, converging with the replica
that applied the insert before the merge — including the multi-client
same-anchor case.

The relocation uses a new `IndexTreeNode.moveChild` that keeps both size
dimensions correct on both parents: a tombstone occupies no visible index
positions, so only `totalSize` moves for a removed node and `visibleSize` is
left untouched on source and target alike. (Reusing the alive-node
`detachChild`/`append` pair double-counts a tombstone's visible size.)

This is the JavaScript port of yorkie-team/yorkie#1905; the design is
documented there in `docs/design/concurrent-merge-split.md` (Fix 19).

## How to test it

New and existing tests, all green:

- `test/integration/tree_merge_anchor_test.ts` (new):
  - converges when inserting into a concurrently removed range (the filed
    2-client case)
  - converges with two inserts at the same anchor in a removed range
    (3 clients)
- `test/unit/document/crdt/tree_test.ts` (new case): "merge moves an element
  tombstone with correct length accounting" — guards the element-padding
  accounting of the move
- Regression: `tree_test.ts`, `tree_concurrency_test.ts`,
  `history_tree_test.ts` and the crdt unit tests all pass; `pnpm sdk build`
  and `pnpm lint` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document consistency during concurrent edits involving removed content.
  * Preserved insertion anchors within deleted ranges so later edits appear in the correct location.
  * Corrected tree size calculations so hidden or removed content does not affect visible document sizes.
  * Improved handling of edits spanning paragraphs and removed ranges.

* **Tests**
  * Added coverage for concurrent insertions and removals across synchronized documents.
  * Added regression coverage for deletions spanning paragraphs and tombstoned content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->