### PR TITLE
Keep style ranges from crossing a concurrent merge anchor

### DIFF
--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -1156,10 +1156,17 @@ export class CRDTTree extends CRDTElement implements GCParent {
    *
    * If `editedAt` is given, then it is used to find the appropriate left node
    * for concurrent insertion.
+   *
+   * `boundary` selects how a position inside a merged-away parent resolves:
+   * `insert` places it at the insertion boundary in the merge target (before
+   * the first moved child, so RGA ordering breaks ties), while `range` places
+   * it right after the merge-source tombstone so a style range neither grows
+   * over nor shrinks past nodes concurrently inserted at that anchor.
    */
   public findNodesAndSplitText(
     pos: CRDTTreePos,
     editedAt?: TimeTicket,
+    boundary: 'insert' | 'range' = 'insert',
   ): [TreeNodePair, DataSize] {
     let diff = { data: 0, meta: 0 };
 
@@ -1179,6 +1186,16 @@ export class CRDTTree extends CRDTElement implements GCParent {
     // points back at the tombstoned parent (i.e. the first child moved
     // by the merge, in target child order).
     if (realParent.isRemoved && isLeftMost && realParent.mergedInto) {
+      // §9.3 Range Boundary at Merged-Away Anchors: a range boundary
+      // resolves to the position right after the merge-source tombstone,
+      // not the insertion boundary below. The insertion boundary sits
+      // before the first moved child, so it would extend a style range
+      // over nodes concurrently inserted between the tombstone and the
+      // moved children — nodes the styling client saw outside its range
+      // (after the then-live parent).
+      if (boundary === 'range' && realParent.parent) {
+        return [[realParent.parent as CRDTTreeNode, realParent], diff];
+      }
       const mergeTarget = this.findFloorNode(realParent.mergedInto);
       if (mergeTarget && !mergeTarget.isRemoved) {
         const allCh = mergeTarget.allChildren;
@@ -1249,10 +1266,12 @@ export class CRDTTree extends CRDTElement implements GCParent {
     const [[fromParent, fromLeftRaw], diffFrom] = this.findNodesAndSplitText(
       range[0],
       editedAt,
+      'range',
     );
     const [[toParent, toLeftRaw], diffTo] = this.findNodesAndSplitText(
       range[1],
       editedAt,
+      'range',
     );
 
     addDataSizes(diff, diffTo, diffFrom);
@@ -1427,10 +1446,12 @@ export class CRDTTree extends CRDTElement implements GCParent {
     const [[fromParent, fromLeft], diffFrom] = this.findNodesAndSplitText(
       range[0],
       editedAt,
+      'range',
     );
     const [[toParent, toLeft], diffTo] = this.findNodesAndSplitText(
       range[1],
       editedAt,
+      'range',
     );
 
     addDataSizes(diff, diffTo, diffFrom);

--- a/packages/sdk/test/integration/tree_style_anchor_test.ts
+++ b/packages/sdk/test/integration/tree_style_anchor_test.ts
@@ -1,0 +1,152 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, assert } from 'vitest';
+import { Tree } from '@yorkie-js/sdk/src/yorkie';
+import { withTwoClientsAndDocuments } from '@yorkie-js/sdk/test/integration/integration_helper';
+
+describe('Tree.Style concurrent with a merge-removing edit', () => {
+  it('does not style a node concurrently inserted at the merged anchor', async ({
+    task,
+  }) => {
+    await withTwoClientsAndDocuments<{ tree: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+
+      // d1 inserts an empty <p> after the second paragraph, then styles a
+      // range that ends inside the second paragraph. The inserted <p> is
+      // outside the styled range on d1's view.
+      d1.update((root) => root.tree.edit(8, 8, { type: 'p', children: [] }));
+      d1.update((root) => root.tree.style(0, 5, { bold: 'x' }));
+      // d2 concurrently removes the range, merging across the paragraphs.
+      d2.update((root) => root.tree.edit(0, 5));
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(d1.getRoot().tree.toXML(), '<r><p></p>cd</r>');
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, task.name);
+  });
+
+  it('does not leave attributes from removeStyle on a concurrently inserted node', async ({
+    task,
+  }) => {
+    await withTwoClientsAndDocuments<{ tree: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+
+      d1.update((root) => root.tree.edit(8, 8, { type: 'p', children: [] }));
+      d1.update((root) => root.tree.removeStyle(0, 5, ['bold']));
+      d2.update((root) => root.tree.edit(0, 5));
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(d1.getRoot().tree.toXML(), '<r><p></p>cd</r>');
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, task.name);
+  });
+
+  it('converges when the range ends inside a chain-merged paragraph', async ({
+    task,
+  }) => {
+    await withTwoClientsAndDocuments<{ tree: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+            { type: 'p', children: [{ type: 'text', value: 'ef' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+
+      // d1: insert an empty <p> at the end, then style a range ending at
+      // the leftmost position inside the third paragraph. d2 concurrently
+      // chain-merges: p3 into p2, then p2 into p1, so the range boundary
+      // resolves through a merge-source whose target is itself removed.
+      d1.update((root) => root.tree.edit(12, 12, { type: 'p', children: [] }));
+      d1.update((root) => root.tree.style(0, 9, { bold: 'x' }));
+      d2.update((root) => root.tree.edit(7, 9));
+      d2.update((root) => root.tree.edit(3, 5));
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(
+        d1.getRoot().tree.toXML(),
+        '<r><p bold="x">abcdef</p><p></p></r>',
+      );
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, task.name);
+  });
+
+  it('still styles the merged content when the range covers it', async ({
+    task,
+  }) => {
+    await withTwoClientsAndDocuments<{ tree: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+
+      // The styled range covers the second paragraph entirely, so the
+      // style lands on it regardless of the concurrent merge removing
+      // the first paragraph.
+      d1.update((root) => root.tree.style(4, 8, { bold: 'x' }));
+      d2.update((root) => root.tree.edit(0, 4));
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(d1.getRoot().tree.toXML(), '<r><p bold="x">cd</p></r>');
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, task.name);
+  });
+});

--- a/packages/sdk/test/unit/document/crdt/tree_test.ts
+++ b/packages/sdk/test/unit/document/crdt/tree_test.ts
@@ -636,6 +636,53 @@ describe('CRDTTree.Edit', function () {
     assert.equal(treeNode.children![0].visibleSize, 2);
   });
 
+  it('resolves a range boundary right after the merge-source tombstone', function () {
+    // 01. Create <root><p>ab</p><p>cd</p></root>.
+    //       0   1 2 3    4   5 6 7     8
+    // <root> <p> a b </p> <p> c d </p>  </root>
+    const tree = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
+    tree.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    tree.editT(
+      [1, 1],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
+    tree.editT([4, 4], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    tree.editT(
+      [5, 5],
+      [new CRDTTreeNode(posT(), 'text', 'cd')],
+      0,
+      timeT(),
+      timeT,
+    );
+    assert.deepEqual(tree.toXML(), `<root><p>ab</p><p>cd</p></root>`);
+
+    // 02. Capture the leftmost position inside the second paragraph, then
+    // merge the second paragraph into the first.
+    const pos = tree.findPos(5);
+    tree.editT([3, 5], undefined, 0, timeT(), timeT);
+    assert.deepEqual(tree.toXML(), `<root><p>abcd</p></root>`);
+
+    // 03. An insert boundary resolves into the merge target before the
+    // moved children, while a range boundary resolves right after the
+    // merge-source tombstone, leaving the moved children outside.
+    const [[insertParent, insertLeft]] = tree.findNodesAndSplitText(
+      pos,
+      timeT(),
+    );
+    assert.equal(tree.toIndex(insertParent, insertLeft), 3);
+
+    const [[rangeParent, rangeLeft]] = tree.findNodesAndSplitText(
+      pos,
+      timeT(),
+      'range',
+    );
+    assert.equal(rangeLeft.isRemoved, true);
+    assert.equal(tree.toIndex(rangeParent, rangeLeft), 6);
+  });
+
   it('Can find the closest TreePos when parentNode or leftSiblingNode does not exist', function () {
     const t = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
Fixes a Tree attribute-divergence bug: a concurrent `Tree.Style`/`Tree.RemoveStyle` whose range ends inside an element removed by a merge styled a node concurrently inserted at the merged anchor on only one replica.

From `<r><p>ab</p><p>cd</p></r>`, with client A inserting an empty `<p>` at index 8 and then styling `[0,5)` with `bold=x`, and client B concurrently removing `[0,5)`:

- A: the surviving inserted `<p>` has no attributes
- B: the same `<p>` carries `bold="x"` - the replicas diverge on attributes (the structure itself converges since #1303/#1305)

This happens because `findNodesAndSplitText` redirects a position inside a merged-away parent to the insertion boundary in the merge target, which sits before the first moved child. For an inserting edit this is intentional (the RGA `createdAt` tie-break needs that position), but for a style range end it extends the range over nodes concurrently inserted between the merge-source tombstone and the moved children - nodes the styling client saw outside its range, after the then-live parent.

This PR adds a `boundary` mode to `findNodesAndSplitText`. The default `insert` keeps the existing behavior for edits; `range`, used by `style`/`removeStyle`, resolves the position right after the merge-source tombstone - before both the concurrent inserts and the moved children in visible coordinates, so a range end excludes them and a range start includes them, matching the styling replica in both directions. Ranges that genuinely cover the merged content still style it.

Tests:

- `test/integration/tree_style_anchor_test.ts` (new):
  - does not style a node concurrently inserted at the merged anchor (the filed case)
  - does not leave attributes from `removeStyle` on a concurrently inserted node
  - converges when the range ends inside a chain-merged paragraph (asserts the exact converged value)
  - still styles the merged content when the range covers it
- `test/unit/document/crdt/tree_test.ts` (new case): "resolves a range boundary right after the merge-source tombstone" - pins the boundary indexes for both modes
- Regression: `tree_test.ts`, `tree_concurrency_test.ts`, `tree_merge_anchor_test.ts`, `history_tree_test.ts`, `history_tree_split_test.ts` and the crdt unit tests all pass; `pnpm sdk build` and `pnpm lint` are clean.


#### Any background context you want to provide?

Found by the property-based Tree test for #1298 as the pinned seed's next shrunk counterexample after #1303/#1305 landed. This mirrors the same fix in yorkie-team/yorkie#1909; the design is documented there in `docs/design/concurrent-merge-split.md` §9.3 (Fix 21). A range end anchored after a moved child (a non-leftmost position in the merged parent) does not go through the redirect and remains a separate follow-up; the #1298 property-based test shrinks to it once this fix lands.


#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1308

### Checklist
- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved styling and style removal across merged paragraphs and concurrently edited content.
  * Corrected range positioning after paragraph merges, preserving expected formatting boundaries.
  * Prevented styles from applying to inserted content outside the selected range.
* **Tests**
  * Added coverage for concurrent styling, paragraph insertion, merge operations, and consistent document state across clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->