### PR TITLE
Recreate purged text runs in order on restore, not reversed

### DIFF
--- a/packages/sdk/src/document/crdt/rga_tree_split.ts
+++ b/packages/sdk/src/document/crdt/rga_tree_split.ts
@@ -756,6 +756,13 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
     const recreated: Array<RGATreeSplitNode<T>> = [];
     const liveDiff = { data: 0, meta: 0 };
 
+    // The last node placed at the current cursor (un-tombstoned or recreated),
+    // in document order. When a recreated fragment has no surviving same-
+    // insertion anchor, chaining after this keeps a multi-fragment run in
+    // left-to-right order instead of each fragment prepending at the same fixed
+    // fallback anchor — which would rebuild the run reversed. Spans arrive in
+    // document order, so this is always the recreated fragment's left neighbour.
+    let chainAnchor: RGATreeSplitNode<T> | undefined;
     for (const span of spans) {
       const pieces = this.findPiecesOverlapping(
         span.createdAt,
@@ -781,6 +788,9 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
             // Repair splay weights on the path to root (length 0 → len).
             this.treeByIndex.splayNode(target);
             untombstoned.push(target);
+            chainAnchor = target;
+          } else {
+            chainAnchor = piece;
           }
           cursor = overlapEnd;
           if (overlapEnd >= pieceEnd) {
@@ -804,9 +814,11 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
             gapEnd,
             executedAt,
             fallbackAnchor,
+            chainAnchor,
           );
           this.insertAfter(prev, newNode);
           recreated.push(newNode);
+          chainAnchor = newNode;
           cursor = gapEnd;
         }
       }
@@ -965,9 +977,12 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
    *      → directly after it
    *  (c) rightmost surviving piece of the same insertion (must be right
    *      of the gap) → directly before it
-   *  (d) the operation's fallback anchor (refined) — same exposure as the
+   *  (d) chain anchor: the previously placed fragment of this same restore
+   *      (document order) → after it, so a purged multi-fragment run is
+   *      rebuilt left-to-right rather than reversed
+   *  (e) the operation's fallback anchor (refined) — same exposure as the
    *      current implementation's fromPos; see design-doc caveat
-   *  (e) head (deterministic last resort)
+   *  (f) head (deterministic last resort)
    */
   private findRestoreAnchor(
     createdAt: TimeTicket,
@@ -975,6 +990,7 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
     gapEnd: number,
     executedAt: TimeTicket,
     fallbackAnchor?: RGATreeSplitPos,
+    chainAnchor?: RGATreeSplitNode<T>,
   ): RGATreeSplitNode<T> {
     const succ = this.findPieceCovering(createdAt, gapEnd);
     if (succ) {
@@ -1000,6 +1016,13 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
       rightmost.value.getID().getOffset() >= gapEnd
     ) {
       return rightmost.value.getPrev()!;
+    }
+
+    // (d) No surviving piece of this insertion anchors the fragment. When the
+    // whole run was purged, every fragment lands here; anchoring after the
+    // fragment placed just before it (document order) keeps the run forward.
+    if (chainAnchor) {
+      return chainAnchor;
     }
 
     if (fallbackAnchor) {

--- a/packages/sdk/test/unit/document/text_restore_after_gc_test.ts
+++ b/packages/sdk/test/unit/document/text_restore_after_gc_test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Yorkie Authors. All rights reserved.
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/sdk/test/unit/document/text_restore_after_gc_test.ts
+++ b/packages/sdk/test/unit/document/text_restore_after_gc_test.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2024 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, assert } from 'vitest';
+import { maxVectorOf } from '@yorkie-js/sdk/test/helper/helper';
+import { Document } from '@yorkie-js/sdk/src/document/document';
+import { Text } from '@yorkie-js/sdk/src/yorkie';
+
+const ACTOR = '000000000000000000000001';
+
+/**
+ * Regression for the reversed-text undo (wafflebase#629). Typing character by
+ * character makes each character its own single-char insertion. Deleting a
+ * contiguous run and then undoing AFTER the tombstones were GC-purged forces
+ * every character down restore's recreate path. Because no character shares an
+ * insertion with any other, none of the same-insertion anchor rungs fire; each
+ * recreated fragment must chain after the one placed just before it, or the run
+ * comes back reversed ("my name" -> "eman ym"). Un-tombstoning (no GC) already
+ * preserved order, which is why this only reproduced once the run was purged.
+ */
+describe('Text restore after GC', () => {
+  it('recreates a purged multi-insertion run in document order on undo', () => {
+    const doc = new Document<{ t: Text }>('text-restore-after-gc');
+    doc.setActor(ACTOR);
+    doc.update((r) => {
+      r.t = new Text();
+    });
+
+    const s = 'hello my name is';
+    for (let i = 0; i < s.length; i++) {
+      doc.update((r) => r.t.edit(i, i, s[i]));
+    }
+    assert.equal(doc.getRoot().t.toString(), s);
+
+    doc.update((r) => r.t.edit(6, 13, '')); // delete "my name"
+    assert.equal(doc.getRoot().t.toString(), 'hello  is');
+
+    // Purge the tombstones (as happens once the delete is synced/acked), so
+    // undo cannot un-tombstone in place and must recreate from the spans.
+    const purged = doc.garbageCollect(maxVectorOf([ACTOR]));
+    assert.isAbove(purged, 0, 'the deleted run should be purged');
+
+    doc.history.undo();
+    assert.equal(
+      doc.getRoot().t.toString(),
+      s,
+      'a purged run must be recreated in document order, not reversed',
+    );
+  });
+
+  it('single-insertion run is unaffected (one recreate)', () => {
+    const doc = new Document<{ t: Text }>('text-restore-after-gc-single');
+    doc.setActor(ACTOR);
+    doc.update((r) => {
+      r.t = new Text();
+    });
+    doc.update((r) => r.t.edit(0, 0, 'hello my name is'));
+    doc.update((r) => r.t.edit(6, 13, ''));
+    doc.garbageCollect(maxVectorOf([ACTOR]));
+    doc.history.undo();
+    assert.equal(doc.getRoot().t.toString(), 'hello my name is');
+  });
+});


### PR DESCRIPTION
## Summary

Undoing a text deletion **after the deleted run's tombstones were GC-purged** brings the run back reversed. Reported via wafflebase notes undo (wafflebase/wafflebase#629): type "hello my name is", delete "my name", undo → "hello **eman ym** is". A page refresh showed the correct text — the server still held the tombstones and un-tombstoned them, while the client had already GC'd and took the recreate path.

**Root cause.** Typing character-by-character makes each character its own single-character insertion (distinct `createdAt`, offset 0). When the run is purged, `RGATreeSplit.restore` must recreate each fragment. In `findRestoreAnchor` the same-insertion rungs (a/b/c) never fire — no character shares another's `createdAt`, and `gapStart` is always 0 — so every fragment fell through to the same fixed fallback anchor, and `insertAfter(sameLeft, node)` repeatedly *prepended*, rebuilding the run backwards. Un-tombstoning in place (no GC) always preserved order, which is why it only surfaced post-GC. A single-insertion run (one recreate) is unaffected.

## Changes

- `findRestoreAnchor` now takes a **chain anchor** — the fragment placed just before this one in the same restore (spans arrive in document order) — and anchors after it when no same-insertion piece survives, so a purged run is rebuilt left-to-right. The existing `fromPos` fallback still anchors the first fragment.
- Rung order is now: (a/b/c) same-insertion identity → (d) chain anchor → (e) `fromPos` → (f) head.

## Test plan

- Added `test/unit/document/text_restore_after_gc_test.ts` (char-by-char type → delete → GC → undo asserts document order; plus the single-insertion control).
- `pnpm sdk test test/unit` green (308); `history_text` + text/gc integration suites green against a server built from the companion Go branch; eslint clean.

Companion PR: yorkie-team/yorkie#1913 (server-side fix). The recreate anchoring is kept byte-identical across the two so server snapshots converge with clients.
Fixes the client side of wafflebase/wafflebase#629.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text restoration after garbage collection so recreated content preserves the original document order.
  * Improved undo behavior for deleted text, including runs made from individual character insertions and single insertions.

* **Tests**
  * Added regression coverage for restoring text after deleted content has been purged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->