### PR TITLE
Wrap Int counter result in both increase branches

### DIFF
--- a/packages/sdk/src/document/crdt/counter.ts
+++ b/packages/sdk/src/document/crdt/counter.ts
@@ -368,8 +368,9 @@ export class CRDTCounter extends CRDTElement {
       this.value = BigInt.asIntN(64, (this.value as bigint) + delta);
     } else {
       if (v.getType() === PrimitiveType.Long) {
-        this.value =
-          (this.value as number) + bigintToInt32(v.getValue() as bigint);
+        this.value = bigintToInt32(
+          BigInt(this.value as number) + (v.getValue() as bigint),
+        );
       } else {
         this.value = bigintToInt32(
           BigInt(

--- a/packages/sdk/test/integration/counter_test.ts
+++ b/packages/sdk/test/integration/counter_test.ts
@@ -125,6 +125,30 @@ describe('Counter', function () {
     assert.equal(`{"age":-9223372036854775808}`, doc.toSortedJSON());
   });
 
+  it('Can handle increase operation with out-of-int32 Long', async function ({
+    task,
+  }) {
+    type TestDoc = { age: Counter };
+    await withTwoClientsAndDocuments<TestDoc>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.age = new Counter(1);
+      });
+      await c1.sync();
+      await c2.sync();
+
+      d1.update((root) => {
+        root.age.increase(5_000_000_000n);
+      });
+      await c1.sync();
+      await c2.sync();
+
+      // 1 + 5_000_000_000 wraps to 705032705 under int32 arithmetic,
+      // which is what the Go SDK computes.
+      assert.equal(`{"age":705032705}`, d1.toSortedJSON());
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, task.name);
+  });
+
   it('can get proper reverse operations', function ({ task }) {
     const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
     const doc = new Document<{ cnt: Counter; longCnt: Counter }>(docKey);

--- a/packages/sdk/test/unit/document/crdt/counter_test.ts
+++ b/packages/sdk/test/unit/document/crdt/counter_test.ts
@@ -79,13 +79,14 @@ describe('Counter', function () {
 });
 
 it('Can wrap around Int counter when increased by an out-of-int32 Long', function () {
-  // int32 최대값은 2147483647. 그 경계를 넘는 Long을 더하면
-  // Go SDK의 int32 산술과 동일하게 wrap 되어야 한다.
+  // Adding a Long beyond int32 range must wrap, like the Go SDK.
   const counter = CRDTCounter.create(CounterType.Int, 0, InitialTimeTicket);
   const outOfInt32 = Primitive.of(BigInt(2147483648), InitialTimeTicket); // 2^31
-
   counter.increase(outOfInt32);
-
-  // wrap 되어 -2147483648이 되어야 한다 (수정 전에는 2147483648로 발산)
   assert.equal(counter.getValue(), -2147483648);
+
+  // Nonzero base: old behavior returns -2147483649, fixed returns 2147483647.
+  const counter2 = CRDTCounter.create(CounterType.Int, -1, InitialTimeTicket);
+  counter2.increase(Primitive.of(BigInt(2147483648), InitialTimeTicket));
+  assert.equal(counter2.getValue(), 2147483647);
 });

--- a/packages/sdk/test/unit/document/crdt/counter_test.ts
+++ b/packages/sdk/test/unit/document/crdt/counter_test.ts
@@ -77,3 +77,15 @@ describe('Counter', function () {
     assert.equal(long.getValue(), 60);
   });
 });
+
+it('Can wrap around Int counter when increased by an out-of-int32 Long', function () {
+  // int32 최대값은 2147483647. 그 경계를 넘는 Long을 더하면
+  // Go SDK의 int32 산술과 동일하게 wrap 되어야 한다.
+  const counter = CRDTCounter.create(CounterType.Int, 0, InitialTimeTicket);
+  const outOfInt32 = Primitive.of(BigInt(2147483648), InitialTimeTicket); // 2^31
+
+  counter.increase(outOfInt32);
+
+  // wrap 되어 -2147483648이 되어야 한다 (수정 전에는 2147483648로 발산)
+  assert.equal(counter.getValue(), -2147483648);
+});


### PR DESCRIPTION
#### What this PR does / why we need it?
The Long-delta branch of `increase()` on an `Int` counter only truncated
the delta, not the result, so a delta pushing the value beyond the int32
range did not wrap. The number-delta branch already wrapped the result, so
the two branches behaved differently for the same counter type.

This diverged from the Go SDK's int32 arithmetic and broke convergence:
replicas applying the same increases could reach different values,
violating the counter's strong eventual consistency.

#### Any background context you want to provide?
Fix: sum the current value and the delta as `bigint` first, then apply
`bigintToInt32` to the result, matching the number-delta branch and the
Go SDK.

#### What are the relevant tickets?
Fixes #1307

#### Test plan
- Added a unit test in `counter_test.ts` that increases an `Int` counter by
  an out-of-int32 `Long` (2^31) and asserts it wraps to -2147483648.
  The test fails before the change and passes after.
- `pnpm --filter @yorkie-js/sdk test unit/document/crdt/counter` — 2/2 pass.
- `pnpm --filter @yorkie-js/sdk lint` — clean.
- Integration tests that require a running Yorkie server were not run
  locally; CI covers those.

### Checklist
- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed integer counter increases involving large long values so they wrap correctly within the signed 32-bit range.
  * Prevented incorrect results when values exceed the maximum supported integer limit.
  * Ensured corrected counter values synchronize consistently between clients.

* **Tests**
  * Added unit and integration coverage for overflow behavior with large long values and different starting values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->