### PR TITLE
Release v0.7.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and Yorkie JS SDK adheres to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+## [v0.7.15] - 2026-08-13
+
+### Fixed
+
+- Make Tree restore split-aware for concurrent overlapping undo by @harrykim8672 in https://github.com/yorkie-team/yorkie-js-sdk/pull/1315
+- Wrap Int counter result in both increase branches by @hyunji1117 in https://github.com/yorkie-team/yorkie-js-sdk/pull/1312
+
 ## [v0.7.14] - 2026-08-09
 
 ### Added

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yorkie-js/devtools",
   "displayName": "Yorkie Devtools",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "A browser extension that helps you debug Yorkie.",
   "homepage": "https://yorkie.dev/",
   "scripts": {

--- a/packages/prosemirror/package.json
+++ b/packages/prosemirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/prosemirror",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "ProseMirror binding for Yorkie collaborative editing",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/react",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "A set of hooks and providers for Yorkie JS SDK",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/schema",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "Yorkie Schema for Yorkie Document",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/sdk",
-  "version": "0.7.14",
+  "version": "0.7.15",
   "description": "Yorkie JS SDK",
   "main": "./src/yorkie.ts",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Bump the five publishable packages — `sdk`, `react`, `schema`, `prosemirror`,
`devtools` — to `0.7.15`, and add the CHANGELOG entry.

The root `package.json` is private at `0.0.0` and internal dependencies resolve
through `workspace:*`, so neither needs a bump and `pnpm-lock.yaml` is
unchanged.

### CHANGELOG derivation

`v0.7.14..main` is 2 commits, both listed under `Fixed`: #1315 and #1312.
Nothing excluded — both change production code under `packages/sdk/src`.

## Test plan

- `pnpm build:packages` succeeds across all five packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)