### PR TITLE
Stamp merge-bound inserts and filter style-range interlopers

### DIFF
--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -472,9 +472,11 @@ export class CRDTTreeNode
   insNextID?: CRDTTreeNodeID;
 
   /**
-   * `mergedFrom` records the source parent's ID when this node was moved
-   * by a concurrent merge. Persisted in the snapshot encoding as the
-   * witness of the merge relationship.
+   * `mergedFrom` records the parent this node logically belongs to when
+   * a merge relocated it into the merge target: the source parent it was
+   * moved out of, or the declared parent of an insert redirected by the
+   * §9.4 intended-parent stamp. Persisted in the snapshot encoding as
+   * the witness of the merge relationship.
    */
   mergedFrom?: CRDTTreeNodeID;
 
@@ -659,13 +661,18 @@ export class CRDTTreeNode
    * `cloneElement` clones this element node with the given issueTimeTicket function.
    */
   cloneElement(issueTimeTicket: () => TimeTicket): CRDTTreeNode {
-    return new CRDTTreeNode(
+    const clone = new CRDTTreeNode(
       CRDTTreeNodeID.of(issueTimeTicket(), 0),
       this.type,
       undefined,
       this.attrs?.deepcopy(),
       this.removedAt,
     );
+    // The split product holds the other half of the same moved node, so
+    // it carries the same merge stamp (as cloneText does).
+    clone.mergedFrom = this.mergedFrom;
+    clone.mergedAt = this.mergedAt;
+    return clone;
   }
 
   /**
@@ -1072,6 +1079,101 @@ export class CRDTTree extends CRDTElement implements GCParent {
   }
 
   /**
+   * `mergedAnchorInterloperGuard` prepares the §9.4 per-node filter for a
+   * style range whose end position was declared inside a parent that a
+   * merge unknown to the styling client removed. The moved anchor child
+   * resolves in the merge target, so the traversal covers nodes sitting
+   * between the merge-source tombstone and the moved children — nodes the
+   * styling client saw outside its range, after the then-live parent. The
+   * predicate skips exactly those interlopers.
+   */
+  private mergedAnchorInterloperGuard(
+    pos: CRDTTreePos,
+    versionVector?: VersionVector,
+  ): { isInterloper: (node: CRDTTreeNode) => boolean } | undefined {
+    if (versionVector === undefined) {
+      return;
+    }
+    const [declaredParent] = pos.toTreeNodePair(this);
+    if (
+      !declaredParent.isRemoved ||
+      !declaredParent.mergedInto ||
+      !declaredParent.removedAt ||
+      ticketKnown(versionVector, declaredParent.removedAt)
+    ) {
+      return;
+    }
+    const target = this.resolveMergeTarget(declaredParent);
+    // Restricted to the shape where the tombstone sits directly under the
+    // merge target; in other shapes the resolved range already excludes
+    // the interlopers.
+    if (target === declaredParent || declaredParent.parent !== target) {
+      return;
+    }
+    // Collect the target's children positioned after the merge-source
+    // tombstone in one pass, so the predicate is O(depth) per node.
+    const afterTombstone = new Set<CRDTTreeNode>();
+    let seenTombstone = false;
+    for (const child of target.allChildren) {
+      if (child === declaredParent) {
+        seenTombstone = true;
+        continue;
+      }
+      if (seenTombstone) {
+        afterTombstone.add(child);
+      }
+    }
+    return {
+      isInterloper: (node: CRDTTreeNode): boolean => {
+        // Judge by the node's highest ancestor directly under the merge
+        // target, so an interloper's descendants are skipped with it.
+        let top = node;
+        while (top.parent && top.parent !== target) {
+          top = top.parent as CRDTTreeNode;
+        }
+        if (top.parent !== target) {
+          return false;
+        }
+        // Fail open on any merge stamp: an earlier merge keeps the
+        // ORIGINAL source in mergedFrom (first-move stamp rule), so
+        // stamp equality cannot prove the node was outside the styled
+        // range. Only stamp-free nodes are positively interlopers.
+        if (top.mergedFrom) {
+          return false;
+        }
+        return afterTombstone.has(top);
+      },
+    };
+  }
+
+  /**
+   * `styleSkipPredicate` builds the per-token skip checks shared by style
+   * and removeStyle: the End-token unknown-split-sibling exclusion and the
+   * §9.4 merged-anchor interloper filter for the range-end position.
+   */
+  private styleSkipPredicate(
+    pos: CRDTTreePos,
+    versionVector?: VersionVector,
+  ): (node: CRDTTreeNode, tokenType: TokenType) => boolean {
+    const anchorGuard = this.mergedAnchorInterloperGuard(pos, versionVector);
+    return (node: CRDTTreeNode, tokenType: TokenType): boolean => {
+      // Skip styling via End token when the node has an unknown
+      // split sibling. The End token is in the range only because
+      // a concurrent split extended the range into the sibling.
+      if (
+        tokenType === TokenType.End &&
+        versionVector !== undefined &&
+        this.hasUnknownSplitSibling(node, versionVector)
+      ) {
+        return true;
+      }
+      // §9.4: the node is in the range only because an unknown merge
+      // pulled the range-end anchor past it.
+      return !!anchorGuard && anchorGuard.isInterloper(node);
+    };
+  }
+
+  /**
    * `advancePastUnknownSplitSiblings` follows the insNextID chain of the
    * given node, advancing past element-type split siblings that the editing
    * client did not know about (not in versionVector).
@@ -1322,6 +1424,8 @@ export class CRDTTree extends CRDTElement implements GCParent {
         ? this.advancePastUnknownSplitSiblings(toLeftRaw, versionVector)
         : toLeftRaw;
 
+    const shouldSkipToken = this.styleSkipPredicate(range[1], versionVector);
+
     const changes: Array<TreeChange> = [];
     const attrs: { [key: string]: any } = attributes
       ? parseObjectValues(attributes)
@@ -1345,14 +1449,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
         }
 
         if (node.canStyle(editedAt, clientLamportAtChange) && attributes) {
-          // Skip styling via End token when the node has an unknown
-          // split sibling. The End token is in the range only because
-          // a concurrent split extended the range into the sibling.
-          if (
-            tokenType === TokenType.End &&
-            versionVector !== undefined &&
-            this.hasUnknownSplitSibling(node, versionVector)
-          ) {
+          if (shouldSkipToken(node, tokenType)) {
             return;
           }
 
@@ -1493,6 +1590,8 @@ export class CRDTTree extends CRDTElement implements GCParent {
 
     addDataSizes(diff, diffTo, diffFrom);
 
+    const shouldSkipToken = this.styleSkipPredicate(range[1], versionVector);
+
     const changes: Array<TreeChange> = [];
     const pairs: Array<GCPair> = [];
     const prevAttributes = new Map<string, string>();
@@ -1515,14 +1614,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
           node.canStyle(editedAt, clientLamportAtChange) &&
           attributesToRemove
         ) {
-          // Skip styling via End token when the node has an unknown
-          // split sibling. The End token is in the range only because
-          // a concurrent split extended the range into the sibling.
-          if (
-            tokenType === TokenType.End &&
-            versionVector !== undefined &&
-            this.hasUnknownSplitSibling(node, versionVector)
-          ) {
+          if (shouldSkipToken(node, tokenType)) {
             return;
           }
           if (!node.attrs) {
@@ -2001,6 +2093,32 @@ export class CRDTTree extends CRDTElement implements GCParent {
 
     // 05. Insert: insert the given nodes at the given position.
     if (contents?.length) {
+      // §9.4: When the insert position was declared inside a parent that a
+      // concurrent merge removed, the content physically lands in the merge
+      // target. Stamp it as merged-from the declared parent so it stays
+      // distinguishable from nodes that were never inside that parent —
+      // style-range resolution and merge-delete propagation key on this.
+      const [declaredFromParent] = range[0].toTreeNodePair(this);
+      const intendedParent =
+        declaredFromParent !== fromParent &&
+        declaredFromParent.isRemoved &&
+        declaredFromParent.mergedInto &&
+        this.resolveMergeTarget(declaredFromParent) === fromParent
+          ? declaredFromParent
+          : undefined;
+      let intendedMergedAt: TimeTicket | undefined;
+      if (intendedParent) {
+        // Take the merge ticket from a sibling the merge moved; the parent's
+        // own removedAt may have been overwritten by a later LWW tombstone.
+        for (const child of fromParent.allChildren) {
+          if (child.mergedFrom?.equals(intendedParent.id) && child.mergedAt) {
+            intendedMergedAt = child.mergedAt;
+            break;
+          }
+        }
+        intendedMergedAt ??= intendedParent.removedAt;
+      }
+
       const aliveContents: Array<CRDTTreeNode> = [];
       let leftInChildren = fromLeft; // tree
       for (const content of contents) {
@@ -2011,6 +2129,11 @@ export class CRDTTree extends CRDTElement implements GCParent {
         } else {
           // 05-1-2. insert after leftSibling
           fromParent.insertAfter(content, leftInChildren);
+        }
+
+        if (intendedParent) {
+          content.mergedFrom = intendedParent.id;
+          content.mergedAt = intendedMergedAt;
         }
 
         leftInChildren = content;

--- a/packages/sdk/test/integration/tree_style_moved_anchor_test.ts
+++ b/packages/sdk/test/integration/tree_style_moved_anchor_test.ts
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, assert } from 'vitest';
+import yorkie, { Tree, SyncMode } from '@yorkie-js/sdk/src/yorkie';
+import {
+  testRPCAddr,
+  toDocKey,
+  withTwoClientsAndDocuments,
+} from '@yorkie-js/sdk/test/integration/integration_helper';
+
+describe('Tree.Style range ending after a merge-moved child', () => {
+  it('does not style a node concurrently inserted at the merged anchor', async ({
+    task,
+  }) => {
+    await withTwoClientsAndDocuments<{ tree: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+
+      // d1 inserts an empty <p> after the second paragraph, then styles a
+      // range ending after `c`, a non-leftmost position inside the second
+      // paragraph. The inserted <p> is outside the styled range on d1.
+      d1.update((root) => root.tree.edit(8, 8, { type: 'p', children: [] }));
+      d1.update((root) => root.tree.style(0, 6, { bold: 'x' }));
+      // d2 concurrently removes the range, merging across the paragraphs.
+      d2.update((root) => root.tree.edit(0, 5));
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(d1.getRoot().tree.toXML(), '<r><p></p>cd</r>');
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, task.name);
+  });
+
+  it('does not leave attributes from removeStyle on a concurrently inserted node', async ({
+    task,
+  }) => {
+    await withTwoClientsAndDocuments<{ tree: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+
+      d1.update((root) => root.tree.edit(8, 8, { type: 'p', children: [] }));
+      d1.update((root) => root.tree.removeStyle(0, 6, ['bold']));
+      d2.update((root) => root.tree.edit(0, 5));
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(d1.getRoot().tree.toXML(), '<r><p></p>cd</r>');
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, task.name);
+  });
+
+  it('still styles an own insert that was inside the styled range', async ({
+    task,
+  }) => {
+    await withTwoClientsAndDocuments<{ tree: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+
+      // d1 inserts <b> inside the second paragraph, before `c`, and styles
+      // a range that covers it. The insert resolves into the merge target
+      // on d2, and must stay styled on both replicas.
+      d1.update((root) => root.tree.edit(5, 5, { type: 'b', children: [] }));
+      d1.update((root) => root.tree.style(0, 8, { bold: 'x' }));
+      d2.update((root) => root.tree.edit(0, 5));
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(d1.getRoot().tree.toXML(), '<r><b bold="x"></b>cd</r>');
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, task.name);
+  });
+
+  it('skips descendants of a node inserted at the merged anchor', async ({
+    task,
+  }) => {
+    await withTwoClientsAndDocuments<{ tree: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+
+      // The inserted <p> carries a nested <b>; both are outside the styled
+      // range on d1, so neither may be styled on the merging replica.
+      d1.update((root) => root.tree.edit(8, 8, { type: 'p', children: [] }));
+      d1.update((root) => root.tree.edit(9, 9, { type: 'b', children: [] }));
+      d1.update((root) => root.tree.style(0, 6, { bold: 'x' }));
+      d2.update((root) => root.tree.edit(0, 5));
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(d1.getRoot().tree.toXML(), '<r><p><b></b></p>cd</r>');
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, task.name);
+  });
+
+  it('still styles a sibling before the merge-source tombstone', async ({
+    task,
+  }) => {
+    await withTwoClientsAndDocuments<{ tree: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'b', children: [] },
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+
+      // The leading <b> is inside the styled range on both replicas and
+      // sits before the merge-source tombstone after the merge.
+      d1.update((root) => root.tree.style(0, 8, { bold: 'x' }));
+      d2.update((root) => root.tree.edit(2, 7));
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(d1.getRoot().tree.toXML(), '<r><b bold="x"></b>cd</r>');
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, task.name);
+  });
+
+  it('still styles a child that arrived via an earlier synced merge', async ({
+    task,
+  }) => {
+    await withTwoClientsAndDocuments<{ tree: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 's', children: [{ type: 'i', children: [] }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+
+      // Fully synced merge: <s> into <p> — <i> moves into <p> and keeps
+      // mergedFrom=s forever (stamped only on the first move).
+      d1.update((root) => root.tree.edit(3, 5));
+      await c1.sync();
+      await c2.sync();
+      assert.equal(d1.getRoot().tree.toXML(), '<r><p>ab<i></i></p></r>');
+      assert.equal(d2.getRoot().tree.toXML(), '<r><p>ab<i></i></p></r>');
+
+      // d1 styles a range ending after <i>, a non-leftmost position
+      // inside <p>, covering <i>. d2 concurrently merges <p> into <r>.
+      d1.update((root) => root.tree.style(0, 5, { bold: 'x' }));
+      d2.update((root) => root.tree.edit(0, 1));
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(d1.getRoot().tree.toXML(), '<r>ab<i bold="x"></i></r>');
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, task.name);
+  });
+
+  it('converges when a third client inserts at the merged anchor', async ({
+    task,
+  }) => {
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c3 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    await c1.activate();
+    await c2.activate();
+    await c3.activate();
+
+    const docKey = `${toDocKey(task.name)}-${c1.getKey()}`;
+    const d1 = new yorkie.Document<{ tree: Tree }>(docKey);
+    const d2 = new yorkie.Document<{ tree: Tree }>(docKey);
+    const d3 = new yorkie.Document<{ tree: Tree }>(docKey);
+    await c1.attach(d1, { syncMode: SyncMode.Manual });
+    await c2.attach(d2, { syncMode: SyncMode.Manual });
+    await c3.attach(d3, { syncMode: SyncMode.Manual });
+
+    d1.update((root) => {
+      root.tree = new Tree({
+        type: 'r',
+        children: [
+          { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+          { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+        ],
+      });
+    });
+    await c1.sync();
+    await c2.sync();
+    await c3.sync();
+
+    // d3's insert is unknown to d1's style, so the version-vector check
+    // keeps it unstyled on every replica.
+    d1.update((root) => root.tree.style(0, 6, { bold: 'x' }));
+    d2.update((root) => root.tree.edit(0, 5));
+    d3.update((root) => root.tree.edit(8, 8, { type: 'p', children: [] }));
+
+    for (const client of [c1, c2, c3]) {
+      await client.sync();
+    }
+    await c1.sync();
+    await c2.sync();
+
+    assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    assert.equal(d2.toSortedJSON(), d3.toSortedJSON());
+
+    for (const [client, doc] of [
+      [c1, d1],
+      [c2, d2],
+      [c3, d3],
+    ] as const) {
+      await client.detach(doc);
+      await client.deactivate();
+    }
+  });
+});

--- a/packages/sdk/test/unit/document/crdt/tree_test.ts
+++ b/packages/sdk/test/unit/document/crdt/tree_test.ts
@@ -729,16 +729,22 @@ describe('CRDTTree.Edit', function () {
     const [[declaredParent]] = tree.findNodesAndSplitText(pos, timeT());
 
     // 02. Merge the second paragraph into the first, then apply an insert
-    // that still declares the merged-away paragraph as its parent.
-    tree.editT([3, 5], undefined, 0, timeT(), timeT);
+    // that still declares the merged-away paragraph as its parent. A later
+    // delete LWW-overwrites the tombstone first, so the merge ticket is
+    // only recoverable from the moved sibling.
+    const mergeTicket = timeT();
+    tree.editT([3, 5], undefined, 0, mergeTicket, timeT);
+    declaredParent.remove(timeT());
     const content = new CRDTTreeNode(posT(), 'b');
     tree.edit([pos, pos], [content], 0, timeT(), timeT);
 
     // 03. The content lands in the merge target (the surviving first
     // paragraph) but is stamped as merged-from the declared parent,
-    // like a merge-moved child.
+    // like a merge-moved child. The merge ticket comes from the moved
+    // sibling, not the parent's LWW-overwritable removedAt.
     assert.equal(content.parent, tree.getRoot().allChildren[0]);
     assert.equal(content.mergedFrom?.equals(declaredParent.id), true);
+    assert.deepEqual(content.mergedAt, mergeTicket);
   });
 
   it('Can find the closest TreePos when parentNode or leftSiblingNode does not exist', function () {

--- a/packages/sdk/test/unit/document/crdt/tree_test.ts
+++ b/packages/sdk/test/unit/document/crdt/tree_test.ts
@@ -82,6 +82,28 @@ describe('CRDTTreeNode', function () {
     assert.deepEqual(right!.mergedAt, mergeTicket);
   });
 
+  it('splitElement preserves mergedFrom and mergedAt', function () {
+    const root = new CRDTTreeNode(posT(), 'r', []);
+    const para = new CRDTTreeNode(posT(), 'p', []);
+    root.append(para);
+    para.append(new CRDTTreeNode(posT(), 'text', 'helloworld'));
+
+    // The paragraph was previously moved by a merge.
+    const sourceID = CRDTTreeNodeID.of(timeT(), 0);
+    const mergeTicket = timeT();
+    para.mergedFrom = sourceID;
+    para.mergedAt = mergeTicket;
+
+    para.children[0].splitText(5, 0);
+    const [split] = para.splitElement(1, timeT);
+    assert.isNotNull(split);
+
+    // The split product holds the other half of the same moved node, so
+    // it must carry the same merge stamp (as splitText does).
+    assert.deepEqual(split!.mergedFrom, sourceID);
+    assert.deepEqual(split!.mergedAt, mergeTicket);
+  });
+
   it('deepcopy preserves merge metadata', function () {
     const para = new CRDTTreeNode(posT(), 'p', []);
     const text = new CRDTTreeNode(posT(), 'text', 'hello');
@@ -681,6 +703,42 @@ describe('CRDTTree.Edit', function () {
     );
     assert.equal(rangeLeft.isRemoved, true);
     assert.equal(tree.toIndex(rangeParent, rangeLeft), 6);
+  });
+
+  it('stamps an insert declared inside a merged-away parent', function () {
+    // 01. Create <root><p>ab</p><p>cd</p></root> and capture the leftmost
+    // position inside the second paragraph before the merge.
+    const tree = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
+    tree.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    tree.editT(
+      [1, 1],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
+    tree.editT([4, 4], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    tree.editT(
+      [5, 5],
+      [new CRDTTreeNode(posT(), 'text', 'cd')],
+      0,
+      timeT(),
+      timeT,
+    );
+    const pos = tree.findPos(5);
+    const [[declaredParent]] = tree.findNodesAndSplitText(pos, timeT());
+
+    // 02. Merge the second paragraph into the first, then apply an insert
+    // that still declares the merged-away paragraph as its parent.
+    tree.editT([3, 5], undefined, 0, timeT(), timeT);
+    const content = new CRDTTreeNode(posT(), 'b');
+    tree.edit([pos, pos], [content], 0, timeT(), timeT);
+
+    // 03. The content lands in the merge target (the surviving first
+    // paragraph) but is stamped as merged-from the declared parent,
+    // like a merge-moved child.
+    assert.equal(content.parent, tree.getRoot().allChildren[0]);
+    assert.equal(content.mergedFrom?.equals(declaredParent.id), true);
   });
 
   it('Can find the closest TreePos when parentNode or leftSiblingNode does not exist', function () {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
A concurrent `Tree.Style`/`Tree.RemoveStyle` whose range end is anchored after a merge-moved child styles a node concurrently inserted at the merged anchor on the applying replica only.
From `<r><p>ab</p><p>cd</p></r>`:
- A inserts an empty `<p>` at index 8 and styles `[0,6)`
- B concurrently removes `[0,5)`

After a full sync, the `<p>` ends up `bold="x"` on B only.

The anchor resolves through the moved child, so the boundary redirect from #1309 never fires, and the `canStyle` version-vector check passes because the interloper is the styling client's own insert.

This PR fixes the issue in two steps:
1. It stamps inserts declared inside a merged-away parent with `mergedFrom` = declared parent.
2. During style traversal, it skips nodes under the merge target that appear after the merge-source tombstone and have no merge stamp. Each node is judged by its highest ancestor under the target, so an interloper's descendants are skipped with it.

Nodes carrying any `mergedFrom` fail open because an earlier merge leaves the original source in the stamp (first-move rule), so stamp equality cannot prove the node was outside the range.
`cloneElement` copies `mergedFrom`/`mergedAt` (`splitText` parity) so the judgment is application-order independent.
The skip checks are shared between `style` and `removeStyle` via a single predicate with a precomputed after-tombstone set.

Tests include seven integration cases in `tree_style_moved_anchor_test.ts`:
- the reported case and the `removeStyle` variant, which fail without this fix
- interloper descendants
- an own insert inside the style range
- a sibling before the tombstone
- a third client's unknown insert
- a child brought in by an earlier synced merge that should remain styled

Unit tests also verify the merge stamp and that `splitElement` copies the stamp correctly.

#### Any background context you want to provide?
Found by the property-based Tree test for #1298 right after #1309 landed; this is the follow-up variant #1309 documented. Mirrors yorkie-team/yorkie#1928; the design is in its `docs/design/concurrent-merge-split.md` §9.4 (Fix 22). Two variants remain and reproduce on main without this change (a range start anchored after a moved child; an edit-only divergence); both are next-cycle issues.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1311

### Checklist
- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency when merging document trees with concurrently inserted content.
  * Prevented styles and removed attributes from incorrectly affecting nodes introduced at merged anchors.
  * Preserved merge history when elements are split or inserted into merged-away locations.
  * Ensured valid styles continue to apply to unaffected content and earlier merged content.

* **Tests**
  * Added coverage for concurrent styling, merging, element insertion, and multi-client convergence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->