### PR TITLE
Keep a tree position resolvable when two nodes claim one ID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -121,9 +121,10 @@ dist/
 bundle/
 
 # Docs files (generated API docs)
-docs/
-!docs/design/
-!docs/tasks/
+# `docs/` alone also matched the hand-written docs/ at the repo root, and the
+# negations below it could not re-include them: git does not descend into an
+# excluded directory. Scope the pattern to where typedoc writes instead.
+packages/**/docs/
 
 # ghpages
 ghpages/

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -8,6 +8,7 @@ New design documents should be based on [TEMPLATE.md](TEMPLATE.md).
 - [Polling Sync Mode](polling-sync-mode.md): Stream-less `SyncMode.Polling` for Channel and Document, opt-in alternative to watch streams
 - [ProseMirror Binding](prosemirror.md): Bidirectional sync between ProseMirror and Yorkie Tree CRDT
 - [ProseMirror Native Split/Merge](prosemirror-native-split-merge.md): Use Tree.Edit splitLevel and boundary deletion for splits and merges instead of block replacement
+- [One Node per CRDTTreeNodeID](tree-node-id-identity.md): Rules that keep a Tree position resolvable when two nodes claim one ID, mirroring the server
 
 ## Guidelines
 

--- a/docs/design/tree-node-id-identity.md
+++ b/docs/design/tree-node-id-identity.md
@@ -86,7 +86,7 @@ which took the copy path no longer restores its text.
 |------|------------|
 | A dropped content node is silent, so a user's undo appears to do nothing | Only fires for content that reuses another change's identity, which is the buggy path. The repair is to stop copying — see Open Problems |
 | `splitText` now throws where it used to no-op | It only throws for a position that cannot be resolved in this replica, which previously produced a wrong edit position instead |
-| Two nodes in the same state (both live or both tombstoned) still resolve by registration order | Not reachable through the public edit path today; documented rather than fixed, since a tie-break would have to be identical on every replica |
+| Two nodes in the same state (both live or both tombstoned) still resolve by registration order | **Reachable**: deleting the live one of a duplicated pair leaves two tombstones, and nothing re-registers a node when it is tombstoned, so a live replica and one rebuilt from a snapshot can disagree again. Out of scope here — see Open Problems |
 
 ## Open Problems
 
@@ -100,3 +100,25 @@ which took the copy path no longer restores its text.
   its same-change carve-out and become an invariant rather than a goal.
 - **Documents already carrying duplicates keep them.** They load and resolve
   consistently, but nothing removes the duplicates.
+- **Rule 2 only covers a live/tombstone pair.** Delete the live duplicate and
+  both become tombstones, at which point registration order decides again: the
+  live replica keeps the node it registered last, a rebuilt one takes document
+  order, and a position anchored there resolves to a different node on each.
+  Closing it needs a replica-independent total order (live first, then
+  `removedAt`, then ID) plus re-registration when a node is tombstoned — and it
+  has to land on the server in the same cycle, since a tie-break applied on one
+  side only is worse than none.
+- **The drop decision depends on GC state.** `purge` unregisters the ID, so a
+  replica that has already collected the tombstone accepts a copy that a
+  replica which has not would drop.
+- **`setActor` rewrites the operation's actor, not its content's.** A change
+  built before `attach` carries content whose `createdAt` names a different
+  actor than `executedAt`, so every replica reads it as foreign content. A
+  false drop still needs the ID to be in the tree already, which for fresh
+  content only happens through the delimiter path, but rule 1's carve-out is
+  conditional on this.
+- **An unresolvable position aborts the change.** `splitText` throws and
+  nothing between it and `Document.applyChanges` catches, so one such position
+  fails the whole change rather than the operation. The server behaves the same
+  way with `ErrSplitOutOfRange`; both sides should decide together whether the
+  operation should be skipped instead.

--- a/docs/design/tree-node-id-identity.md
+++ b/docs/design/tree-node-id-identity.md
@@ -90,9 +90,11 @@ which took the copy path no longer restores its text.
 
 ## Open Problems
 
-- **Undo by copy is the source.** Routing every reverse through the restore
-  path — or having the copy issue fresh IDs — removes path 1 entirely. Until
-  then these rules only contain it.
+- **Undo by copy is the source.** Routing every reverse the restore path can
+  express through it removes path 1. Issuing fresh IDs for the copies would
+  stop the collision, but it keeps the copy-based model that duplicates content
+  when undo ranges overlap — a narrower fix for the identity problem alone, not
+  for undo correctness. Until then these rules only contain it.
 - **Simulated split delimiters are the second source.** Carrying the split
   tickets in the operation would remove path 2, and only then can rule 1 drop
   its same-change carve-out and become an invariant rather than a goal.

--- a/docs/design/tree-node-id-identity.md
+++ b/docs/design/tree-node-id-identity.md
@@ -1,0 +1,100 @@
+---
+created: 2026-08-15
+updated: 2026-08-15
+tags: [tree, crdt, undo-redo, snapshot]
+---
+
+# One Node per CRDTTreeNodeID
+
+## Problem
+
+Every Tree position is anchored by a `CRDTTreeNodeID` (`createdAt` + `offset`),
+so an ID must name a single node. This document records the rules that keep
+that true, why they exist, and what they still leave open. They mirror the
+server-side rules in
+[yorkie/docs/design/tree.md](https://github.com/yorkie-team/yorkie/blob/main/docs/design/tree.md);
+a client and the server have to apply them the same way, or the same position
+resolves to different nodes on each side.
+
+### Goals
+
+- Keep a document loadable when two nodes already share one ID.
+- Stop creating new duplicates.
+- Resolve an ID to the same node on a live document and on one rebuilt from a
+  snapshot.
+
+### Non-Goals
+
+- Removing duplicates from documents that already carry them.
+- Fixing the undo path that creates them (see Open Problems).
+
+## Proposal Details
+
+### How two nodes end up under one ID
+
+`nodeMapByID` is an LLRB keyed by `CRDTTreeNodeID` and cannot hold two entries
+for one key: the second `put` overwrites the first, so the winner follows the
+order the nodes were registered — operation order on a live document, document
+order in the `CRDTTree` constructor when it is rebuilt from a snapshot. Two
+nodes under one ID therefore resolve differently on each replica, and the
+offset a position carries can fall outside the node it lands on.
+
+On the server that produced a panic in `splitText` and a document that could
+not be opened (yorkie#1927). In this SDK `String.slice` does not throw: the
+right value comes back empty, the split looks like a no-op, and the edit
+silently lands at the wrong position — the same corruption, quieter.
+
+Two paths produce the duplicates:
+
+1. **Undo by copy.** `TreeEditOperation.toReverseOperation` reverses a deletion
+   by deep-copying the removed nodes, and the copy keeps each node's ID. The
+   identity-preserving restore path (`restoreSpans`) avoids this, but it only
+   covers edits that were merge- and split-free; everything else still copies,
+   and SDKs from 0.7.13 and earlier copy for every deletion.
+2. **Simulated split delimiters.** An element split issues its tickets by
+   simulating the delimiters the client consumed rather than replaying them
+   (see the note in `TreeEditOperation.execute`), so two nodes in one change
+   can be issued the same ID.
+
+### Rules
+
+1. **Content that reuses an identity is dropped.** Content created by an edit
+   carries that edit's lamport and actor, so a content node whose `createdAt`
+   names another change is a copy of a node that already exists.
+   `CRDTTree.dropDuplicateContents` drops it and the rest of the edit applies.
+   Content from the edit's own change is kept even when its ID collides —
+   that is path 2 above, and the node belongs to the document.
+
+2. **A live node keeps the ID over a tombstone.** `CRDTTree.registerNode` keeps
+   the live node when a different node already holds the ID, so a live document
+   and one rebuilt from a snapshot agree. `CRDTTree.purge` removes only the
+   entry the purged node itself holds, so collecting a tombstone does not
+   unregister the live node sharing its ID.
+
+3. **An unresolvable position fails the operation.** `splitText` throws
+   `ErrInvalidArgument` when the offset is past the end of the node, instead of
+   letting `slice` turn it into a silent no-op.
+
+Dropping content rather than failing the change is deliberate: such changes are
+already in the history of existing documents, and a change that cannot be
+replayed is a document that can never be loaded again. The cost is that an undo
+which took the copy path no longer restores its text.
+
+### Risks and Mitigation
+
+| Risk | Mitigation |
+|------|------------|
+| A dropped content node is silent, so a user's undo appears to do nothing | Only fires for content that reuses another change's identity, which is the buggy path. The repair is to stop copying — see Open Problems |
+| `splitText` now throws where it used to no-op | It only throws for a position that cannot be resolved in this replica, which previously produced a wrong edit position instead |
+| Two nodes in the same state (both live or both tombstoned) still resolve by registration order | Not reachable through the public edit path today; documented rather than fixed, since a tie-break would have to be identical on every replica |
+
+## Open Problems
+
+- **Undo by copy is the source.** Routing every reverse through the restore
+  path — or having the copy issue fresh IDs — removes path 1 entirely. Until
+  then these rules only contain it.
+- **Simulated split delimiters are the second source.** Carrying the split
+  tickets in the operation would remove path 2, and only then can rule 1 drop
+  its same-change carve-out and become an invariant rather than a goal.
+- **Documents already carrying duplicates keep them.** They load and resolve
+  consistently, but nothing removes the duplicates.

--- a/docs/tasks/active/20260815-duplicate-tree-node-id-lessons.md
+++ b/docs/tasks/active/20260815-duplicate-tree-node-id-lessons.md
@@ -32,6 +32,19 @@ longer create the state under test, and tests written that way would
 have kept passing while testing nothing. Constructing the corrupted
 state directly keeps them honest for documents that already carry it.
 
+## A port is not a copy: the client keeps an undo stack
+
+The server applies an operation and forgets it. Here every edit also
+produces its reverse, and that reverse was sized from the content the
+operation carried. Dropping content in the tree therefore left the
+reverse spanning tokens that were never inserted, so redoing an undo
+would have deleted whatever sat at that position — turning a silent
+no-op into a destructive one, which is worse than the bug being fixed.
+
+Nothing in the server change hinted at it, because the server has no
+reverse to build. The lesson is to walk what the port's side does *with*
+the result of the ported call, not just to match the call itself.
+
 ## Same-change collisions are legitimate
 
 The first version of the server-side rule treated every colliding ID as

--- a/docs/tasks/active/20260815-duplicate-tree-node-id-lessons.md
+++ b/docs/tasks/active/20260815-duplicate-tree-node-id-lessons.md
@@ -1,0 +1,42 @@
+# Lessons: mirroring the duplicate CRDTTreeNodeID rules
+
+**Created**: 2026-08-15
+
+## The same bug is louder on the server and quieter here
+
+Go panics on an out-of-range slice; `String.slice` clamps. The identical
+corrupted tree crashed the server — which at least produced a stack trace
+and a 503 that someone filed an issue about — while the browser silently
+skipped the split and edited at the wrong position. The failure that
+takes a process down is the one that gets fixed; the one that quietly
+writes the wrong content is the one that spreads.
+
+Worth remembering when porting a guard: the JS side often needs the
+guard *more*, precisely because nothing else will surface it.
+
+## A rule on one side of the wire is a divergence, not a fix
+
+Dropping duplicated content on the server keeps documents loadable, but a
+client that kept the same content now disagrees with the server about
+what the document contains, and about what its own positions mean. The
+server fix was worth shipping first because it stopped a crash, but it
+was not complete until the same rule ran here. Rules that decide which
+node an ID names belong to the CRDT, not to one of its implementations.
+
+## Reproducing the corruption beats simulating it
+
+The tests build the duplicate by attaching a node directly to the index
+tree and registering it, rather than by calling `edit` with a colliding
+ID. Once `dropDuplicateContents` was in place, the edit path could no
+longer create the state under test, and tests written that way would
+have kept passing while testing nothing. Constructing the corrupted
+state directly keeps them honest for documents that already carry it.
+
+## Same-change collisions are legitimate
+
+The first version of the server-side rule treated every colliding ID as
+corruption and broke a test where an element split and an insert in one
+change legitimately claim the same ID — the delimiters a split consumes
+are simulated, not replayed. The discriminator is the content's lamport
+and actor against the edit's own. Ported here without rediscovering it,
+because the server's test suite had already paid for that lesson.

--- a/docs/tasks/active/20260815-duplicate-tree-node-id-todo.md
+++ b/docs/tasks/active/20260815-duplicate-tree-node-id-todo.md
@@ -36,6 +36,12 @@ with nothing logged.
 - [x] `CRDTTree.dropDuplicateContents`: drop content that reuses an ID
       from another change, keep content this change issued
 - [x] `splitText`: throw `ErrInvalidArgument` past the end of the node
+- [x] Build the reverse operation from the content the tree accepted.
+      `TreeEditOperation` sized the reverse range from the content the
+      operation carried, so a dropped copy left the reverse covering
+      tokens that were never inserted — redo would delete whatever sat
+      there. The delimiter simulation still counts the original content,
+      since the server simulates split tickets the same way
 - [x] Write the rules into `docs/design/tree-node-id-identity.md`
 - [x] `pnpm lint`, `pnpm sdk build`, unit suite, integration suite
 

--- a/docs/tasks/active/20260815-duplicate-tree-node-id-todo.md
+++ b/docs/tasks/active/20260815-duplicate-tree-node-id-todo.md
@@ -41,10 +41,11 @@ with nothing logged.
 
 ## Follow-ups
 
-- The origin is still here: reverse every deletion through the restore
-  path, or have the copy issue fresh IDs. Until then these rules only
-  contain it, and an undo that took the copy path no longer restores
-  its text.
+- The origin is still here: reverse every deletion the restore path can
+  express through it. Fresh IDs for the copies would stop the collision
+  but keep the copy-based model, which duplicates content when undo
+  ranges overlap. Until then these rules only contain it, and an undo
+  that took the copy path no longer restores its text.
 - Element splits simulate the delimiters the client consumed instead of
   replaying them, so ordinary editing can still issue two nodes one ID.
   That is why `dropDuplicateContents` has to keep same-change content,

--- a/docs/tasks/active/20260815-duplicate-tree-node-id-todo.md
+++ b/docs/tasks/active/20260815-duplicate-tree-node-id-todo.md
@@ -1,0 +1,53 @@
+# Mirror the duplicate CRDTTreeNodeID rules
+
+**Created**: 2026-08-15
+
+Server-side counterpart: yorkie#1927. A production document became
+unopenable because two `CRDTTreeNodeID`s named the same node: the server
+panicked in `SplitText` while rebuilding the document from a snapshot,
+which reset the HTTP/2 stream and surfaced as `AttachDocument 503`.
+
+The duplicates came from this SDK. `TreeEditOperation.toReverseOperation`
+reverses a deletion by deep-copying the removed nodes, and the copy keeps
+each node's ID, so undoing a deletion re-inserts nodes under the IDs the
+tombstones already hold. The affected client ran `@yorkie-js/react`
+0.7.13, which has no identity-preserving restore path at all —
+`restoreSpans` landed in fa6cc513, after that release.
+
+## Problem
+
+The rules now live on the server, but a rule that only one side applies
+is worse than no rule: the client keeps the copied content, the server
+drops it, and every position anchored at the shared ID means something
+different on each side.
+
+The failure is also quieter here. `String.slice` does not throw on an
+out-of-range offset — it returns an empty right value, `splitText`
+treats the split as a no-op, and the edit lands at the wrong position
+with nothing logged.
+
+## Tasks
+
+- [x] Add regression tests that reproduce the corruption
+      (`test/unit/document/crdt/tree_duplicate_id_test.ts`)
+- [x] `CRDTTree.registerNode`: keep a live node over a tombstone, and
+      route every `nodeMapByID.put` through it
+- [x] `CRDTTree.purge`: remove only the entry the purged node holds
+- [x] `CRDTTree.dropDuplicateContents`: drop content that reuses an ID
+      from another change, keep content this change issued
+- [x] `splitText`: throw `ErrInvalidArgument` past the end of the node
+- [x] Write the rules into `docs/design/tree-node-id-identity.md`
+- [x] `pnpm lint`, `pnpm sdk build`, unit suite, integration suite
+
+## Follow-ups
+
+- The origin is still here: reverse every deletion through the restore
+  path, or have the copy issue fresh IDs. Until then these rules only
+  contain it, and an undo that took the copy path no longer restores
+  its text.
+- Element splits simulate the delimiters the client consumed instead of
+  replaying them, so ordinary editing can still issue two nodes one ID.
+  That is why `dropDuplicateContents` has to keep same-change content,
+  and why "one node per ID" is a goal rather than an invariant.
+- Documents that already carry duplicate IDs keep them. They load, but
+  nothing removes the duplicates.

--- a/docs/tasks/active/README.md
+++ b/docs/tasks/active/README.md
@@ -1,7 +1,7 @@
 ---
-updated: 2026-06-18
+updated: 2026-08-15
 ---
 
 # Active Tasks
 
-(none)
+- [[20260815-duplicate-tree-node-id-todo]] — **Created**: 2026-08-15

--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -986,7 +986,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
     this.pendingGCPairs = [];
 
     this.indexTree.traverseAll((node) => {
-      this.nodeMapByID.put(node.id, node);
+      this.registerNode(node);
     });
 
     // Rebuild runtime merge state from the persisted `mergedFrom`
@@ -1156,10 +1156,87 @@ export class CRDTTree extends CRDTElement implements GCParent {
   }
 
   /**
-   * `registerNode` registers the given node to the tree.
+   * `registerNode` registers the given node to the tree, keeping a live node
+   * over a tombstone when both claim the same ID.
+   *
+   * Documents written by older clients can carry two nodes under one ID (an
+   * undo that re-inserted a deleted piece by copy). A plain `put` lets the
+   * winner depend on the order the nodes were registered — operation order on
+   * a live document, document order on one rebuilt from a snapshot — so after
+   * a reload the same position resolves to a different node and its offset can
+   * fall outside that node. Keeping the live one makes both orders agree for a
+   * live/tombstone pair, which is the shape those documents carry.
+   *
+   * Two nodes in the same state keep the last-registered-wins behavior, and
+   * stay order-dependent: element IDs issued for a split can legitimately
+   * collide with an inserted node's ID (see the delimiter note in
+   * `TreeEditOperation`), and that resolution order is what the rest of the
+   * tree already assumes.
+   *
+   * A node this refuses stays in the index tree while another node answers for
+   * its ID, so it is reachable by traversal but not by lookup. That is the
+   * intended trade for a duplicate: the alternative is unregistering a node
+   * that positions still resolve through.
    */
   public registerNode(node: CRDTTreeNode): void {
+    const entry = this.nodeMapByID.floorEntry(node.id);
+    if (
+      entry &&
+      entry.value !== node &&
+      entry.key.equals(node.id) &&
+      node.isRemoved &&
+      !entry.value.isRemoved
+    ) {
+      return;
+    }
+
     this.nodeMapByID.put(node.id, node);
+  }
+
+  /**
+   * `dropDuplicateContents` returns the contents that would not put a second
+   * node under an ID already in the tree.
+   *
+   * Content created by an edit carries that edit's lamport and actor, so a
+   * content node whose ID names another change is a copy of a node that
+   * already exists — what the copy-reinsert undo path sends when it reverses a
+   * deletion. Inserting it would leave two nodes under one identity, so the
+   * copy is dropped and the rest of the edit applies.
+   *
+   * Content from this edit's own change is kept even when its ID collides: the
+   * delimiters an element split consumes are simulated rather than replayed,
+   * so an ID issued here can legitimately collide, and dropping it would lose
+   * a node the client already inserted.
+   *
+   * Dropping rather than failing is deliberate: such changes are already in
+   * the history of existing documents, and a change that cannot be replayed is
+   * a document that can never be loaded again. A collision anywhere in a
+   * content node's subtree drops that whole subtree, on the grounds that a
+   * copy is copied whole.
+   */
+  private dropDuplicateContents(
+    contents: Array<CRDTTreeNode>,
+    editedAt: TimeTicket,
+  ): Array<CRDTTreeNode> {
+    return contents.filter((content) => {
+      let reused = false;
+      traverseAll(content, (node) => {
+        const createdAt = node.id.getCreatedAt();
+        if (
+          createdAt.getLamport() === editedAt.getLamport() &&
+          createdAt.getActorID() === editedAt.getActorID()
+        ) {
+          return;
+        }
+
+        const entry = this.nodeMapByID.floorEntry(node.id);
+        if (entry && entry.key.equals(node.id)) {
+          reused = true;
+        }
+      });
+
+      return !reused;
+    });
   }
 
   /**
@@ -1631,6 +1708,13 @@ export class CRDTTree extends CRDTElement implements GCParent {
   ] {
     const diff = { data: 0, meta: 0 };
 
+    // 00. identity check: a CRDTTreeNodeID must name a single node, so content
+    // that reuses an ID already in the tree is dropped before anything is
+    // mutated.
+    if (contents) {
+      contents = this.dropDuplicateContents(contents, editedAt);
+    }
+
     // 01. find nodes from the given range and split nodes.
     const [[fromParent, fromLeftRaw], diffFrom] = this.findNodesAndSplitText(
       range[0],
@@ -2025,7 +2109,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
             addDataSizes(diff, node.getDataSize());
           }
 
-          this.nodeMapByID.put(node.id, node);
+          this.registerNode(node);
 
           // Capture this inserted node's identity span (parent-before-child
           // via traverseAll) for identity-preserving insert undo/redo.
@@ -2160,7 +2244,13 @@ export class CRDTTree extends CRDTElement implements GCParent {
    */
   public purge(node: CRDTTreeNode): void {
     node.parent?.removeChild(node);
-    this.nodeMapByID.remove(node.id);
+    // `nodeMapByID` is keyed by ID, so an unconditional remove would also
+    // unregister a different node that shares this one's ID — see
+    // `registerNode`. Only drop the entry this node actually holds.
+    const entry = this.nodeMapByID.floorEntry(node.id);
+    if (entry && entry.value === node && entry.key.equals(node.id)) {
+      this.nodeMapByID.remove(node.id);
+    }
 
     const insPrevID = node.insPrevID;
     const insNextID = node.insNextID;
@@ -2428,7 +2518,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
         succ.id.getOffset() === offset + length
       ) {
         parent.insertAt(node, siblings.indexOf(succ));
-        this.nodeMapByID.put(node.id, node);
+        this.registerNode(node);
         return node;
       }
       if (offset > span.id.getOffset() || offset > 0) {
@@ -2437,7 +2527,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
         );
         if (pred && pred.isText && pred.parent === parent) {
           parent.insertAfter(node, pred);
-          this.nodeMapByID.put(node.id, node);
+          this.registerNode(node);
           return node;
         }
       }
@@ -2448,7 +2538,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
       const left = this.findFloorNode(span.leftSiblingID);
       if (left && left.parent === parent) {
         parent.insertAfter(node, left);
-        this.nodeMapByID.put(node.id, node);
+        this.registerNode(node);
         return node;
       }
     }
@@ -2459,7 +2549,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
       if (right && right.parent === parent) {
         const rightIdx = siblings.indexOf(right);
         parent.insertAt(node, rightIdx);
-        this.nodeMapByID.put(node.id, node);
+        this.registerNode(node);
         return node;
       }
     }
@@ -2473,7 +2563,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
       }
     }
     parent.insertAt(node, insertIdx);
-    this.nodeMapByID.put(node.id, node);
+    this.registerNode(node);
     return node;
   }
 

--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -1214,7 +1214,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
    * content node's subtree drops that whole subtree, on the grounds that a
    * copy is copied whole.
    */
-  private dropDuplicateContents(
+  public dropDuplicateContents(
     contents: Array<CRDTTreeNode>,
     editedAt: TimeTicket,
   ): Array<CRDTTreeNode> {

--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -1716,15 +1716,9 @@ export class CRDTTree extends CRDTElement implements GCParent {
     Set<string>,
     Array<TreeRestoreSpan>,
     Array<TreeRestoreSpan>,
+    number,
   ] {
     const diff = { data: 0, meta: 0 };
-
-    // 00. identity check: a CRDTTreeNodeID must name a single node, so content
-    // that reuses an ID already in the tree is dropped before anything is
-    // mutated.
-    if (contents) {
-      contents = this.dropDuplicateContents(contents, editedAt);
-    }
 
     // 01. find nodes from the given range and split nodes.
     const [[fromParent, fromLeftRaw], diffFrom] = this.findNodesAndSplitText(
@@ -2095,6 +2089,20 @@ export class CRDTTree extends CRDTElement implements GCParent {
     }
 
     // 05. Insert: insert the given nodes at the given position.
+    //
+    // The identity check runs here rather than on entry: resolving the range
+    // above splits text nodes, and a split can create the very ID a content
+    // node carries. Checking before that would let the copy through and leave
+    // two nodes under one ID. `insertedContentSize` is measured now, while the
+    // content is still detached — inserting under a removed parent tombstones
+    // it and shrinks what its size reads back as.
+    if (contents) {
+      contents = this.dropDuplicateContents(contents, editedAt);
+    }
+    const insertedContentSize = contents
+      ? contents.reduce((sum, node) => sum + node.paddedSize(), 0)
+      : 0;
+
     if (contents?.length) {
       const aliveContents: Array<CRDTTreeNode> = [];
       let leftInChildren = fromLeft; // tree
@@ -2191,6 +2199,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
       // parent-before-child — the order `restore()` needs to recreate a purged
       // subtree top-down (a child's recreate resolves its parent by identity).
       spansComplete ? insertedSpans.reverse() : [],
+      insertedContentSize,
     ];
   }
 
@@ -2214,6 +2223,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
     Set<string>,
     Array<TreeRestoreSpan>,
     Array<TreeRestoreSpan>,
+    number,
   ] {
     const fromPos = this.findPos(range[0]);
     const toPos = this.findPos(range[1]);

--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -985,9 +985,20 @@ export class CRDTTree extends CRDTElement implements GCParent {
     this.nodeMapByID = new LLRBTree(CRDTTreeNodeID.createComparator());
     this.pendingGCPairs = [];
 
+    // Registering every node is the cost of loading a document, so it runs
+    // without the duplicate check: a plain put per node, then one comparison
+    // to see whether any ID was claimed twice. Only a tree that carries
+    // duplicates pays for resolving them.
+    let nodeCount = 0;
     this.indexTree.traverseAll((node) => {
-      this.registerNode(node);
+      this.nodeMapByID.put(node.id, node);
+      nodeCount++;
     });
+    if (this.nodeMapByID.size() !== nodeCount) {
+      this.indexTree.traverseAll((node) => {
+        this.registerNode(node);
+      });
+    }
 
     // Rebuild runtime merge state from the persisted `mergedFrom`
     // field. Only `mergedFrom` and `mergedAt` are written to the

--- a/packages/sdk/src/document/operation/tree_edit_operation.ts
+++ b/packages/sdk/src/document/operation/tree_edit_operation.ts
@@ -105,6 +105,7 @@ export class TreeEditOperation extends Operation {
   private toIdx?: number;
   private lastFromIdx?: number;
   private lastToIdx?: number;
+  private insertedContentSize?: number;
   /**
    * `redoSplitLevel` is set on boundary-deletion undo ops that were generated
    * to reverse a split. When this op executes (as undo), `toReverseOperation`
@@ -329,6 +330,9 @@ export class TreeEditOperation extends Operation {
     const insertedContents = contents
       ? tree.dropDuplicateContents(contents, editedAt)
       : undefined;
+    this.insertedContentSize = insertedContents
+      ? insertedContents.reduce((sum, node) => sum + node.paddedSize(), 0)
+      : 0;
 
     const [
       changes,
@@ -512,10 +516,10 @@ export class TreeEditOperation extends Operation {
       return splitUndoOp;
     }
 
-    // Compute inserted content size (total tree index tokens). This counts
-    // what the tree accepted, not what the operation carried: content whose ID
-    // was already in the tree is dropped, and a reverse range covering it
-    // would delete a neighbour on redo.
+    // Inserted content size in tree index tokens, counting what the tree
+    // accepted rather than what this operation carried: content whose ID was
+    // already in the tree is dropped, and a reverse range covering it would
+    // delete a neighbour on redo.
     const insertedContentSize = insertedContents
       ? insertedContents.reduce((sum, node) => sum + node.paddedSize(), 0)
       : 0;
@@ -741,8 +745,16 @@ export class TreeEditOperation extends Operation {
   /**
    * `getContentSize` returns the total visible size of this operation's
    * content (for reconciliation).
+   *
+   * Once the operation has run, this is the size the tree accepted: content
+   * whose ID was already in the tree is dropped, and the undo stack shifts its
+   * stored indices by this size, so counting the dropped copy would move every
+   * index in the stack past content that was never inserted.
    */
   public getContentSize(): number {
+    if (this.insertedContentSize !== undefined) {
+      return this.insertedContentSize;
+    }
     if (!this.contents) return 0;
     return this.contents.reduce((sum, node) => sum + node.paddedSize(), 0);
   }

--- a/packages/sdk/src/document/operation/tree_edit_operation.ts
+++ b/packages/sdk/src/document/operation/tree_edit_operation.ts
@@ -320,6 +320,16 @@ export class TreeEditOperation extends Operation {
       }
     }
 
+    // Content that reuses an ID already in the tree is dropped, so the reverse
+    // operation has to be built from what was inserted rather than from what
+    // this operation carried: a range covering content the tree refused would
+    // delete a neighbour on redo. The delimiter simulation below stays on the
+    // original count, since the server simulates it the same way.
+    const contents = this.contents?.map((content) => content.deepcopy());
+    const insertedContents = contents
+      ? tree.dropDuplicateContents(contents, editedAt)
+      : undefined;
+
     const [
       changes,
       pairs,
@@ -332,7 +342,7 @@ export class TreeEditOperation extends Operation {
       insertedSpans,
     ] = tree.edit(
       [this.fromPos, this.toPos],
-      this.contents?.map((content) => content.deepcopy()),
+      insertedContents,
       this.splitLevel,
       editedAt,
       /**
@@ -383,6 +393,7 @@ export class TreeEditOperation extends Operation {
         mergeLevel,
         removedSpans,
         insertedSpans,
+        insertedContents,
       );
     } else if (isPureSplit) {
       reverseOp = this.toSplitReverseOperation(tree, preEditFromIdx);
@@ -433,6 +444,7 @@ export class TreeEditOperation extends Operation {
     mergeLevel?: number,
     removedSpans?: Array<TreeRestoreSpan>,
     insertedSpans?: Array<TreeRestoreSpan>,
+    insertedContents?: Array<CRDTTreeNode>,
   ): Operation | undefined {
     // Identity-preserving reverse: reverse an edit by reviving the nodes it
     // removed (restoreSpans) AND re-removing the nodes it inserted
@@ -500,9 +512,12 @@ export class TreeEditOperation extends Operation {
       return splitUndoOp;
     }
 
-    // Compute inserted content size (total tree index tokens)
-    const insertedContentSize = this.contents
-      ? this.contents.reduce((sum, node) => sum + node.paddedSize(), 0)
+    // Compute inserted content size (total tree index tokens). This counts
+    // what the tree accepted, not what the operation carried: content whose ID
+    // was already in the tree is dropped, and a reverse range covering it
+    // would delete a neighbour on redo.
+    const insertedContentSize = insertedContents
+      ? insertedContents.reduce((sum, node) => sum + node.paddedSize(), 0)
       : 0;
 
     // Guard: if the positions exceed the post-edit tree size,

--- a/packages/sdk/src/document/operation/tree_edit_operation.ts
+++ b/packages/sdk/src/document/operation/tree_edit_operation.ts
@@ -397,7 +397,6 @@ export class TreeEditOperation extends Operation {
         mergeLevel,
         removedSpans,
         insertedSpans,
-        insertedContents,
       );
     } else if (isPureSplit) {
       reverseOp = this.toSplitReverseOperation(tree, preEditFromIdx);
@@ -448,7 +447,6 @@ export class TreeEditOperation extends Operation {
     mergeLevel?: number,
     removedSpans?: Array<TreeRestoreSpan>,
     insertedSpans?: Array<TreeRestoreSpan>,
-    insertedContents?: Array<CRDTTreeNode>,
   ): Operation | undefined {
     // Identity-preserving reverse: reverse an edit by reviving the nodes it
     // removed (restoreSpans) AND re-removing the nodes it inserted
@@ -516,13 +514,14 @@ export class TreeEditOperation extends Operation {
       return splitUndoOp;
     }
 
-    // Inserted content size in tree index tokens, counting what the tree
-    // accepted rather than what this operation carried: content whose ID was
-    // already in the tree is dropped, and a reverse range covering it would
-    // delete a neighbour on redo.
-    const insertedContentSize = insertedContents
-      ? insertedContents.reduce((sum, node) => sum + node.paddedSize(), 0)
-      : 0;
+    // Inserted content size in tree index tokens, measured before the edit:
+    // these nodes are now in the tree, and one inserted under a concurrently
+    // removed parent is tombstoned on the way in, which shrinks the size read
+    // back here. The guard below relies on that pre-edit size to recognize an
+    // edit that had no effect. What it counts is the content the tree
+    // accepted, not the content this operation carried — a reverse range
+    // covering a dropped copy would delete a neighbour on redo.
+    const insertedContentSize = this.insertedContentSize ?? 0;
 
     // Guard: if the positions exceed the post-edit tree size,
     // the edit was a no-op (e.g., concurrent parent deletion where inserted

--- a/packages/sdk/src/document/operation/tree_edit_operation.ts
+++ b/packages/sdk/src/document/operation/tree_edit_operation.ts
@@ -321,19 +321,12 @@ export class TreeEditOperation extends Operation {
       }
     }
 
-    // Content that reuses an ID already in the tree is dropped, so the reverse
-    // operation has to be built from what was inserted rather than from what
-    // this operation carried: a range covering content the tree refused would
-    // delete a neighbour on redo. The delimiter simulation below stays on the
-    // original count, since the server simulates it the same way.
-    const contents = this.contents?.map((content) => content.deepcopy());
-    const insertedContents = contents
-      ? tree.dropDuplicateContents(contents, editedAt)
-      : undefined;
-    this.insertedContentSize = insertedContents
-      ? insertedContents.reduce((sum, node) => sum + node.paddedSize(), 0)
-      : 0;
-
+    // The tree drops content that reuses an ID it already holds, and reports
+    // the size of what it accepted. The reverse operation and the undo stack
+    // both read that size rather than the content this operation carried: a
+    // range covering content the tree refused would delete a neighbour on
+    // redo. The delimiter simulation below stays on the original count, since
+    // the server simulates it the same way.
     const [
       changes,
       pairs,
@@ -344,9 +337,10 @@ export class TreeEditOperation extends Operation {
       preTombstoned,
       removedSpans,
       insertedSpans,
+      insertedContentSize,
     ] = tree.edit(
       [this.fromPos, this.toPos],
-      insertedContents,
+      this.contents?.map((content) => content.deepcopy()),
       this.splitLevel,
       editedAt,
       /**
@@ -381,6 +375,7 @@ export class TreeEditOperation extends Operation {
       0,
     );
     this.lastToIdx = preEditFromIdx + removedSize;
+    this.insertedContentSize = insertedContentSize;
 
     // Create reverse op for undo
     let reverseOp: Operation | undefined;

--- a/packages/sdk/src/util/index_tree.ts
+++ b/packages/sdk/src/util/index_tree.ts
@@ -291,6 +291,16 @@ export abstract class IndexTreeNode<T extends IndexTreeNode<T>> {
       return [undefined, diff];
     }
 
+    // A position that anchors past the end of this node cannot be resolved
+    // here. `slice` would quietly hand back an empty right value and the split
+    // would look like a no-op, leaving the edit at the wrong position.
+    if (offset < 0 || offset > this.visibleSize) {
+      throw new YorkieError(
+        Code.ErrInvalidArgument,
+        `split at ${offset} of ${this.visibleSize}: offset out of range`,
+      );
+    }
+
     const leftValue = this.value.slice(0, offset);
     const rightValue = this.value.slice(offset);
 

--- a/packages/sdk/test/integration/channel_test.ts
+++ b/packages/sdk/test/integration/channel_test.ts
@@ -78,8 +78,12 @@ describe('Channel', function () {
 
   it('should get presence count', async function ({ task }) {
     await withTwoClientsAndChannels(async (c1, ch1, c2, ch2) => {
-      // Wait a bit for presence to stabilize
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      // Wait for both channels to see each other, rather than assuming a
+      // fixed delay is enough for the presence round trip.
+      await waitFor(
+        () => ch1.getSessionCount() >= 2 && ch2.getSessionCount() >= 2,
+        { message: 'presence did not stabilize within timeout' },
+      );
 
       // Get presence count
       const count1 = ch1.getSessionCount();
@@ -137,8 +141,13 @@ describe('Channel', function () {
       // Broadcast to 'notification' topic
       ch1.broadcast('notification', 'message2');
 
-      // Wait a bit for all events to be processed
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      // Wait for the second broadcast to arrive. A fixed delay races the
+      // round trip: the collector holds one event when the broadcast takes
+      // longer than the delay, and the assertion below reads it as a lost
+      // event rather than a slow one.
+      await waitFor(() => allBroadcastCollector.getLength() >= 2, {
+        message: 'the second broadcast did not arrive within timeout',
+      });
 
       // Chat collector should only have chat messages
       assert.equal(chatCollector.getLength(), 1);

--- a/packages/sdk/test/unit/document/crdt/tree_duplicate_id_test.ts
+++ b/packages/sdk/test/unit/document/crdt/tree_duplicate_id_test.ts
@@ -29,6 +29,8 @@ import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
 import { InitialActorID } from '@yorkie-js/sdk/src/document/time/actor_id';
 import { converter } from '@yorkie-js/sdk/src/api/converter';
 import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
+import { TreeEditOperation } from '@yorkie-js/sdk/src/document/operation/tree_edit_operation';
+import { OpSource } from '@yorkie-js/sdk/src/document/operation/operation';
 
 /**
  * A CRDTTreeNodeID (createdAt + offset) is the identity every position anchors
@@ -287,6 +289,48 @@ describe('CRDTTree with a duplicated node id', function () {
       'the live node keeps the id after its tombstone is collected',
     );
     assert.equal(tree.toXML(), /*html*/ `<r><p>0123456789</p></r>`);
+  });
+
+  it('does not let a dropped copy widen the reverse operation', function () {
+    const [root, tree, textID] = buildDigitTree();
+
+    tree.editT([6, 7], undefined, 0, timeT(), timeT);
+    assert.equal(tree.toXML(), /*html*/ `<r><p>012346789</p></r>`);
+
+    // The undo of that deletion, as the copy-reinsert path builds it: one
+    // content node carrying the id of the piece just tombstoned.
+    const undoAt = TimeTicket.of(timeT().getLamport() + 1n, 1, InitialActorID);
+    const pos = tree.findPos(6);
+    const op = TreeEditOperation.create(
+      tree.getCreatedAt(),
+      pos,
+      pos,
+      [
+        new CRDTTreeNode(
+          CRDTTreeNodeID.of(textID.getCreatedAt(), 5),
+          'text',
+          '5',
+        ),
+      ],
+      0,
+      undoAt,
+    );
+
+    const { reverseOp } = op.execute(root, OpSource.Local);
+    assert.equal(
+      tree.toXML(),
+      /*html*/ `<r><p>012346789</p></r>`,
+      'the copy is not inserted',
+    );
+
+    // Redoing must not delete a neighbour that this edit never inserted.
+    if (reverseOp) {
+      const redo = reverseOp as TreeEditOperation;
+      assert.isTrue(
+        redo.getFromPos().equals(redo.getToPos()),
+        'the reverse of an edit that inserted nothing spans nothing',
+      );
+    }
   });
 
   it('refuses to split a text node past its end', function () {

--- a/packages/sdk/test/unit/document/crdt/tree_duplicate_id_test.ts
+++ b/packages/sdk/test/unit/document/crdt/tree_duplicate_id_test.ts
@@ -323,6 +323,14 @@ describe('CRDTTree with a duplicated node id', function () {
       'the copy is not inserted',
     );
 
+    // The undo stack shifts its stored indices by this size when a remote
+    // edit arrives, so it has to match what the tree accepted.
+    assert.equal(
+      op.getContentSize(),
+      0,
+      'an edit whose content was dropped inserted nothing',
+    );
+
     // Redoing must not delete a neighbour that this edit never inserted.
     if (reverseOp) {
       const redo = reverseOp as TreeEditOperation;

--- a/packages/sdk/test/unit/document/crdt/tree_duplicate_id_test.ts
+++ b/packages/sdk/test/unit/document/crdt/tree_duplicate_id_test.ts
@@ -1,0 +1,304 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, assert } from 'vitest';
+import { posT, timeT } from '@yorkie-js/sdk/test/helper/helper';
+import {
+  CRDTTree,
+  CRDTTreeNode,
+  CRDTTreeNodeID,
+  CRDTTreePos,
+} from '@yorkie-js/sdk/src/document/crdt/tree';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
+import { CRDTObject } from '@yorkie-js/sdk/src/document/crdt/object';
+import { ElementRHT } from '@yorkie-js/sdk/src/document/crdt/element_rht';
+import { TimeTicket } from '@yorkie-js/sdk/src/document/time/ticket';
+import { InitialActorID } from '@yorkie-js/sdk/src/document/time/actor_id';
+import { converter } from '@yorkie-js/sdk/src/api/converter';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
+
+/**
+ * A CRDTTreeNodeID (createdAt + offset) is the identity every position anchors
+ * to, so it must name a single node. An undo that reverses a deletion by
+ * re-inserting a copy of the removed nodes keeps their IDs, which leaves two
+ * nodes under one ID; `nodeMapByID.put` then picks a winner by insertion
+ * order, and that order differs between a live document and one rebuilt from
+ * a snapshot. These mirror the server-side rules in yorkie#1927.
+ */
+
+/**
+ * `buildDigitTree` builds <r><p>0123456789</p></r> under the key "t" of a root
+ * object, and returns the tree with the id of its text node.
+ */
+function buildDigitTree(): [CRDTRoot, CRDTTree, CRDTTreeNodeID] {
+  const root = new CRDTRoot(new CRDTObject(timeT(), ElementRHT.create()));
+  const tree = new CRDTTree(new CRDTTreeNode(posT(), 'r'), timeT());
+  tree.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+
+  const textID = posT();
+  tree.editT(
+    [1, 1],
+    [new CRDTTreeNode(textID, 'text', '0123456789')],
+    0,
+    timeT(),
+    timeT,
+  );
+  assert.equal(tree.toXML(), /*html*/ `<r><p>0123456789</p></r>`);
+
+  root.getObject().set('t', tree, timeT());
+  root.registerElement(tree, root.getObject());
+
+  return [root, tree, textID];
+}
+
+/**
+ * `duplicatedIDs` returns the ids that name more than one node in the tree.
+ */
+function duplicatedIDs(tree: CRDTTree): Array<string> {
+  const counts = new Map<string, number>();
+  tree.getIndexTree().traverseAll((node) => {
+    const key = node.id.toIDString();
+    counts.set(key, (counts.get(key) ?? 0) + 1);
+  });
+
+  const dupes: Array<string> = [];
+  for (const [id, count] of counts) {
+    if (count > 1) {
+      dupes.push(`${id} x${count}`);
+    }
+  }
+  return dupes;
+}
+
+/**
+ * `corruptWithDuplicatedNodeID` reproduces the state an older SDK left in
+ * stored documents: the character at text offset 5 is deleted, and a copy of
+ * it is attached under the tombstone's ORIGINAL id. It bypasses `edit` so the
+ * test keeps exercising an already-corrupted document even once the edit path
+ * refuses to create duplicates.
+ */
+function corruptWithDuplicatedNodeID(
+  tree: CRDTTree,
+  textID: CRDTTreeNodeID,
+): void {
+  tree.editT([6, 7], undefined, 0, timeT(), timeT);
+  assert.equal(tree.toXML(), /*html*/ `<r><p>012346789</p></r>`);
+
+  const p = tree.getRoot().allChildren[0];
+  const tombstone = tree.findFloorNode(
+    CRDTTreeNodeID.of(textID.getCreatedAt(), 5),
+  )!;
+  assert.isTrue(tombstone.isRemoved);
+
+  // The copy lands before the tombstone, where an insert at the same index
+  // puts it, and wins nodeMapByID because it is registered last.
+  const dupe = new CRDTTreeNode(
+    CRDTTreeNodeID.of(textID.getCreatedAt(), 5),
+    'text',
+    '5',
+  );
+  p.insertAt(dupe, p.allChildren.indexOf(tombstone));
+  tree.registerNode(dupe);
+  assert.equal(tree.toXML(), /*html*/ `<r><p>0123456789</p></r>`);
+}
+
+/**
+ * `rebuildFromSnapshot` round-trips the root object through the snapshot
+ * encoding, as a client does when it loads a document.
+ */
+function rebuildFromSnapshot(root: CRDTRoot): CRDTTree {
+  const bytes = converter.objectToBytes(root.getObject());
+  const obj = converter.bytesToObject(bytes);
+  return obj.get('t') as CRDTTree;
+}
+
+describe('CRDTTree with a duplicated node id', function () {
+  it('drops content that reuses an id from an earlier change', function () {
+    const [, tree, textID] = buildDigitTree();
+
+    tree.editT([6, 7], undefined, 0, timeT(), timeT);
+    assert.equal(tree.toXML(), /*html*/ `<r><p>012346789</p></r>`);
+
+    // The undo arrives as a later change, so it carries a later lamport than
+    // the id its content reuses.
+    const undoAt = TimeTicket.of(timeT().getLamport() + 1n, 1, InitialActorID);
+    tree.editT(
+      [6, 6],
+      [
+        new CRDTTreeNode(
+          CRDTTreeNodeID.of(textID.getCreatedAt(), 5),
+          'text',
+          '5',
+        ),
+      ],
+      0,
+      undoAt,
+      () => undoAt,
+    );
+
+    assert.deepEqual(duplicatedIDs(tree), [], 'an id names at most one node');
+    assert.equal(
+      tree.toXML(),
+      /*html*/ `<r><p>012346789</p></r>`,
+      'the copy is not inserted',
+    );
+  });
+
+  it('drops content that reuses an id from another actor', function () {
+    const [, tree, textID] = buildDigitTree();
+
+    tree.editT([6, 7], undefined, 0, timeT(), timeT);
+
+    const undoAt = TimeTicket.of(
+      timeT().getLamport(),
+      1,
+      '0123456789abcdef01234567',
+    );
+    tree.editT(
+      [6, 6],
+      [
+        new CRDTTreeNode(
+          CRDTTreeNodeID.of(textID.getCreatedAt(), 5),
+          'text',
+          '5',
+        ),
+      ],
+      0,
+      undoAt,
+      () => undoAt,
+    );
+
+    assert.deepEqual(duplicatedIDs(tree), [], 'an id names at most one node');
+    assert.equal(tree.toXML(), /*html*/ `<r><p>012346789</p></r>`);
+  });
+
+  it('keeps colliding content issued by this change', function () {
+    const [, tree] = buildDigitTree();
+
+    // The delimiters an element split consumes are simulated rather than
+    // replayed, so an id issued by this edit can collide with one already in
+    // the tree. That content belongs to the document.
+    const existingID = tree.getRoot().allChildren[0].id;
+    const editedAt = TimeTicket.of(
+      existingID.getCreatedAt().getLamport(),
+      existingID.getCreatedAt().getDelimiter() + 1,
+      existingID.getCreatedAt().getActorID(),
+    );
+    tree.editT(
+      [12, 12],
+      [new CRDTTreeNode(CRDTTreeNodeID.of(existingID.getCreatedAt(), 0), 'p')],
+      0,
+      editedAt,
+      () => editedAt,
+    );
+
+    assert.equal(
+      tree.toXML(),
+      /*html*/ `<r><p>0123456789</p><p></p></r>`,
+      'content issued by this change is inserted even when its id collides',
+    );
+  });
+
+  it('resolves a duplicated id to the same node after a snapshot rebuild', function () {
+    const [root, tree, textID] = buildDigitTree();
+
+    corruptWithDuplicatedNodeID(tree, textID);
+    const rebuilt = rebuildFromSnapshot(root);
+    assert.equal(rebuilt.toXML(), tree.toXML());
+
+    const id = CRDTTreeNodeID.of(textID.getCreatedAt(), 5);
+    const live = tree.findFloorNode(id)!;
+    const cold = rebuilt.findFloorNode(id)!;
+    assert.equal(
+      cold.isRemoved,
+      live.isRemoved,
+      `live resolves to a ${live.isRemoved ? 'tombstone' : 'live node'}, ` +
+        `rebuilt to a ${cold.isRemoved ? 'tombstone' : 'live node'}`,
+    );
+  });
+
+  it('applies an edit anchored at a duplicated id after a rebuild', function () {
+    const [root, tree, textID] = buildDigitTree();
+
+    corruptWithDuplicatedNodeID(tree, textID);
+
+    // Keep editing before the duplicated id: this splits the run owning
+    // offsets 0..5, so the piece at offset 0 no longer spans up to offset 5.
+    tree.editT(
+      [4, 4],
+      [new CRDTTreeNode(posT(), 'text', 'x')],
+      0,
+      timeT(),
+      timeT,
+    );
+    assert.equal(tree.toXML(), /*html*/ `<r><p>012x3456789</p></r>`);
+
+    const rebuilt = rebuildFromSnapshot(root);
+    const parentID = rebuilt.getRoot().allChildren[0].id;
+    const editedAt = timeT();
+    assert.doesNotThrow(() => {
+      rebuilt.edit(
+        [
+          CRDTTreePos.of(parentID, CRDTTreeNodeID.of(textID.getCreatedAt(), 5)),
+          CRDTTreePos.of(parentID, CRDTTreeNodeID.of(textID.getCreatedAt(), 6)),
+        ],
+        undefined,
+        0,
+        editedAt,
+        () => editedAt,
+      );
+    });
+  });
+
+  it('keeps the live node resolvable when its tombstone is purged', function () {
+    const [, tree, textID] = buildDigitTree();
+
+    corruptWithDuplicatedNodeID(tree, textID);
+
+    const id = CRDTTreeNodeID.of(textID.getCreatedAt(), 5);
+    const live = tree.findFloorNode(id)!;
+    assert.isFalse(live.isRemoved);
+
+    let tombstone: CRDTTreeNode | undefined;
+    tree.getIndexTree().traverseAll((node) => {
+      if (node.id.equals(id) && node.isRemoved) {
+        tombstone = node;
+      }
+    });
+    assert.isDefined(tombstone);
+    tree.purge(tombstone!);
+
+    assert.equal(
+      tree.findFloorNode(id),
+      live,
+      'the live node keeps the id after its tombstone is collected',
+    );
+    assert.equal(tree.toXML(), /*html*/ `<r><p>0123456789</p></r>`);
+  });
+
+  it('refuses to split a text node past its end', function () {
+    const node = new CRDTTreeNode(posT(), 'text', 'hello');
+
+    try {
+      node.splitText(node.visibleSize + 1, 0);
+      assert.fail('splitText must refuse an out-of-range offset');
+    } catch (error) {
+      assert.instanceOf(error, YorkieError);
+      assert.equal((error as YorkieError).code, Code.ErrInvalidArgument);
+    }
+    assert.equal(node.value, 'hello', 'a refused split leaves the node alone');
+  });
+});

--- a/packages/sdk/test/unit/document/crdt/tree_duplicate_id_test.ts
+++ b/packages/sdk/test/unit/document/crdt/tree_duplicate_id_test.ts
@@ -159,6 +159,30 @@ describe('CRDTTree with a duplicated node id', function () {
     );
   });
 
+  it('drops content whose id this edit is about to create by splitting', function () {
+    const [, tree, textID] = buildDigitTree();
+
+    // Nothing has split the text node yet, so no node carries (textID, 5).
+    // Resolving the insert position splits it there, which creates that id
+    // moments before the copy is inserted under it.
+    const undoAt = TimeTicket.of(timeT().getLamport() + 1n, 1, InitialActorID);
+    tree.editT(
+      [6, 6],
+      [
+        new CRDTTreeNode(
+          CRDTTreeNodeID.of(textID.getCreatedAt(), 5),
+          'text',
+          '5',
+        ),
+      ],
+      0,
+      undoAt,
+      () => undoAt,
+    );
+
+    assert.deepEqual(duplicatedIDs(tree), [], 'an id names at most one node');
+  });
+
   it('drops content that reuses an id from another actor', function () {
     const [, tree, textID] = buildDigitTree();
 


### PR DESCRIPTION
## Summary

Mirrors the server-side rules from [yorkie#1927](https://github.com/yorkie-team/yorkie/pull/1927). The rules decide which node a `CRDTTreeNodeID` names, so they belong to the CRDT rather than to one implementation of it: a client and the server that apply them differently disagree about what a position means.

**The duplicates come from here.** `TreeEditOperation.toReverseOperation` reverses a deletion by deep-copying the removed nodes, and the copy keeps each node's ID, so undoing a deletion re-inserts nodes under the IDs the tombstones already hold. Two nodes then share one identity. The identity-preserving restore path (`restoreSpans`, added in fa6cc513) avoids this, but it only covers edits that were merge- and split-free; everything else still copies, and SDKs from 0.7.13 and earlier — including the client in the production incident — have no restore path at all.

`nodeMapByID.put` overwrites silently, so which node an ID resolves to follows the order the nodes were registered: operation order on a live document, document order in the `CRDTTree` constructor when it is rebuilt from a snapshot. The two disagree, and a position anchored at such an ID lands on a node that does not span its offset.

**The failure is quieter here than on the server.** Go panics on the out-of-range slice — which is how the incident got noticed at all. `String.slice` clamps: `splitText` gets an empty right value, treats the split as a no-op, and the edit lands at the wrong position with nothing logged.

## Changes

- **`CRDTTree.registerNode`** keeps the live node when a different node already holds the ID, so a live document and one rebuilt from a snapshot agree. Every `nodeMapByID.put` now goes through it.
- **`CRDTTree.purge`** removes only the entry the purged node itself holds. Removing by ID would unregister a live node sharing the ID and put the document back where it started.
- **`CRDTTree.dropDuplicateContents`** drops content whose ID names another change — a copy of a node that already exists. Content from the edit's own change is kept even when its ID collides: the delimiters an element split consumes are simulated rather than replayed, so those IDs can legitimately collide, and dropping one would lose a node the client already inserted.
- **`splitText`** throws `ErrInvalidArgument` past the end of the node instead of letting `slice` absorb it.

Dropping content rather than throwing is deliberate: such changes are already in the history of existing documents, and a change that cannot be replayed is a document that can never be loaded again. The cost is that an undo which took the copy path no longer restores its text.

A second commit scopes the generated-docs ignore. `docs/` also matched the hand-written `docs/` at the repo root, and the `!docs/design/` negations under it could not re-include anything — git does not descend into an excluded directory — so new design and task notes were silently ignored while the ones already tracked kept working.

Also fixes a pre-existing flake this branch's verification kept tripping over. Two assertions in `channel_test.ts` slept a fixed 100ms and then read a count a network round trip was supposed to have filled; when the round trip took longer, the count was short and the assertion reported it as a lost event. It failed once in nine runs here, including on its own with nothing else on the server. Both now wait on the condition with a timeout, like every other assertion in that file.

## Test plan

- `pnpm sdk test` (unit): 324 pass.
- Integration against a local server (`CI=true`, so vitest uses the 5s timeout it uses in CI rather than the local `Infinity`): 31 files, 2571 passed, 9 skipped, 0 failed — same counts as `main` on the same server. Run three times; one early run had a `channel_test` subscription flake that did not reproduce in the other two, nor when that file runs alone.
- `pnpm sdk build`, `eslint` on the changed files: clean.
- New tests in `test/unit/document/crdt/tree_duplicate_id_test.ts`, each written to fail before its fix:
  - drops content reusing an ID from an earlier change, and from another actor
  - keeps colliding content issued by the same change
  - resolves a duplicated ID to the same node after a snapshot rebuild
  - applies an edit anchored at a duplicated ID after a rebuild
  - keeps the live node resolvable when its tombstone is purged
  - refuses to split a text node past its end

The corrupted state in the rebuild and purge tests is built by attaching a node directly to the index tree rather than through `edit`, so the tests keep exercising documents that already carry duplicates once `edit` refuses to create them.

## Review follow-ups

Two defects found while porting, each fixed with a test that fails without it:

- The reverse operation's range was sized from the content the operation carried, so a dropped copy left it covering tokens the tree never inserted — redo would delete a neighbour. It now uses what the tree accepted, measured before the edit (a node inserted under a concurrently removed parent is tombstoned on the way in, which shrinks the size read back from it).
- The undo stack shifts its stored indices by the operation's content size when a remote edit arrives, which had the same problem.

Review also corrected a claim in the design note: rule 2 covers a live/tombstone pair only. Deleting the live duplicate leaves two tombstones and registration order decides again, which a plain delete reaches. That is recorded as an open problem — closing it needs a replica-independent total order plus re-registration on tombstoning, landed on the server in the same cycle.

## Follow-ups

- The origin is still here: reverse every deletion the restore path can express through it. Fresh IDs for the copies would stop the collision but keep the copy-based model, which duplicates content when undo ranges overlap.
- Element splits simulate the delimiters the client consumed instead of replaying them, so ordinary editing can still issue two nodes one ID. That is why `dropDuplicateContents` has to keep same-change content, and why "one node per ID" is a goal rather than an invariant.
- Documents that already carry duplicate IDs keep them. They load, but nothing removes the duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
