### PR TITLE
Release v0.7.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and Yorkie JS SDK adheres to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+## [v0.7.16] - 2026-08-15
+
+### Fixed
+
+- Keep a tree position resolvable when two nodes claim one ID by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1318
+- Stamp merge-bound inserts and filter style-range interlopers by @Nahee-Park in https://github.com/yorkie-team/yorkie-js-sdk/pull/1317
+- Stop undo and element splits from reusing a node's identity by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1319
+
 ## [v0.7.15] - 2026-08-13
 
 ### Fixed

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yorkie-js/devtools",
   "displayName": "Yorkie Devtools",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "A browser extension that helps you debug Yorkie.",
   "homepage": "https://yorkie.dev/",
   "scripts": {

--- a/packages/prosemirror/package.json
+++ b/packages/prosemirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/prosemirror",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "ProseMirror binding for Yorkie collaborative editing",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/react",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "A set of hooks and providers for Yorkie JS SDK",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/schema",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Yorkie Schema for Yorkie Document",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/sdk",
-  "version": "0.7.15",
+  "version": "0.7.16",
   "description": "Yorkie JS SDK",
   "main": "./src/yorkie.ts",
   "publishConfig": {


### PR DESCRIPTION
## What

Bump the five publishable packages — `sdk`, `react`, `schema`, `prosemirror`,
`devtools` — to `0.7.16`. The root `package.json` is private at `0.0.0` and
internal deps resolve through `workspace:*`, so neither moves.

## CHANGELOG

All three commits since v0.7.15 change production code under `packages/sdk/src`,
so nothing is excluded. Listed in merge order, which is why #1318 precedes
#1317.

- Keep a tree position resolvable when two nodes claim one ID (#1318)
- Stamp merge-bound inserts and filter style-range interlopers (#1317)
- Stop undo and element splits from reusing a node's identity (#1319)

Pairs with yorkie-team/yorkie#1930.

## Test plan

`pnpm build:packages` — all five packages build clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate tree-node IDs.
  * Improved handling of inserts at merge boundaries and style-range interlopers.
  * Preserved element identity more reliably during undo operations and element splits.

* **Chores**
  * Released version 0.7.16 across the packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->