### PR TITLE
Release v0.7.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and Yorkie JS SDK adheres to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+## [v0.7.17] - 2026-08-18
+
+### Fixed
+
+- Count a removed container's descendants in the GC total by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1322
+
 ## [v0.7.16] - 2026-08-15
 
 ### Fixed

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yorkie-js/devtools",
   "displayName": "Yorkie Devtools",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "A browser extension that helps you debug Yorkie.",
   "homepage": "https://yorkie.dev/",
   "scripts": {

--- a/packages/prosemirror/package.json
+++ b/packages/prosemirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/prosemirror",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "ProseMirror binding for Yorkie collaborative editing",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/react",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "A set of hooks and providers for Yorkie JS SDK",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/schema",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "Yorkie Schema for Yorkie Document",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/sdk",
-  "version": "0.7.16",
+  "version": "0.7.17",
   "description": "Yorkie JS SDK",
   "main": "./src/yorkie.ts",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Bumps the five publishable packages to v0.7.17 and adds the changelog entry.

The root `package.json` is private at `0.0.0` and internal dependencies resolve
through `workspace:*`, so neither moves and the lockfile is unchanged.

## Contents

`v0.7.16..main` is two commits:

- #1322 — Count a removed container's descendants in the GC total. Production
  code under `packages/sdk/src`, so it is in the changelog.
- #1321 — Archive a task record, index docs and scripts, gate doc links. Docs,
  scripts, eslint config and root package scripts only, so it is excluded.

#1322 is the TypeScript half of yorkie-team/yorkie#1934, which ships in the
server's v0.7.17.

## Test plan

- `pnpm exec eslint .` — clean. Note that a plain `pnpm lint` reports 7 errors
  under `packages/devtools/.plasmo/`, which is a gitignored Plasmo build
  artifact that only exists once devtools has been built locally; CI never sees
  it. Worth teaching eslint to ignore that path, separately from this release.
- `pnpm build:packages` — all packages build.
- SDK integration tests were not run locally: they need a server on port 8080,
  which was occupied, and the local `yorkieteam/yorkie:latest` image predates
  this release. CI runs the suite against a fresh server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected garbage-collection totals to include descendants of removed containers.

* **Chores**
  * Updated package versions to `0.7.17`.
  * Added changelog information for the release dated August 18, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->