### PR TITLE
Relink insertion chain when restore recreates a purged fragment

### DIFF
--- a/packages/sdk/src/document/crdt/rga_tree_split.ts
+++ b/packages/sdk/src/document/crdt/rga_tree_split.ts
@@ -817,6 +817,23 @@ export class RGATreeSplit<T extends RGATreeSplitValue> implements GCParent {
             chainAnchor,
           );
           this.insertAfter(prev, newNode);
+          // `insertAfter` only maintains the physical prev/next chain. Relink
+          // the separate insertion chain (`insPrev`/`insNext`) too, the same
+          // way `splitNode` does, so a recreated interior fragment is not
+          // skipped by the surviving same-insertion neighbours. Otherwise a
+          // later edit whose boundary lands on this fragment resolves through
+          // a stale insertion pointer in `findFloorNodePreferToLeft` and
+          // miscomputes its offset (yorkie-team/yorkie-js-sdk#1327).
+          if (cursor > 0) {
+            const insPrev = this.findPieceCovering(span.createdAt, cursor - 1);
+            if (insPrev) {
+              newNode.setInsPrev(insPrev);
+            }
+          }
+          const insNext = this.findPieceCovering(span.createdAt, gapEnd);
+          if (insNext) {
+            newNode.setInsNext(insNext);
+          }
           recreated.push(newNode);
           chainAnchor = newNode;
           cursor = gapEnd;

--- a/packages/sdk/test/unit/document/text_restore_relink_test.ts
+++ b/packages/sdk/test/unit/document/text_restore_relink_test.ts
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, assert } from 'vitest';
+import { maxVectorOf } from '@yorkie-js/sdk/test/helper/helper';
+import { Document } from '@yorkie-js/sdk/src/document/document';
+import { Text } from '@yorkie-js/sdk/src/yorkie';
+
+const ACTOR = '000000000000000000000001';
+
+/**
+ * Regression for yorkie-team/yorkie-js-sdk#1327.
+ *
+ * `restore()`'s gap-recreate branch inserts a recreated node with
+ * `insertAfter`, which only maintains the physical prev/next chain — it does
+ * NOT relink the separate insertion chain (`insPrev`/`insNext`). So after a
+ * purged interior fragment is recreated on undo, the surviving neighbours of
+ * the same insertion still point their insertion pointers past the recreated
+ * node (their pre-recreate links).
+ *
+ * A LATER edit whose boundary lands on that recreated node resolves its
+ * absolute offset via `findFloorNodePreferToLeft`, which walks `insPrev`.
+ * Because the recreated node was skipped in the insertion chain, the walk
+ * lands on the wrong node and `findNodeWithSplit` miscomputes the relative
+ * offset — dropping the edit silently or, as here, throwing because the
+ * offset exceeds the resolved node's length.
+ */
+describe('Text restore relink (issue #1327)', () => {
+  it('keeps a later boundary edit correct after a purged interior fragment is recreated', () => {
+    const doc = new Document<{ t: Text }>('text-restore-relink-1327');
+    doc.setActor(ACTOR);
+    doc.update((r) => {
+      r.t = new Text();
+    });
+
+    // Single insertion "0123456789": one node, id (t1:0).
+    doc.update((r) => r.t.edit(0, 0, '0123456789'));
+    assert.equal(doc.getRoot().t.toString(), '0123456789');
+
+    // Delete the interior "45" (indices [4,6)). The node splits into
+    // (t1:0)"0123" - {t1:4 "45"} - (t1:6)"6789"; the middle is tombstoned.
+    doc.update((r) => r.t.edit(4, 6, ''));
+    assert.equal(doc.getRoot().t.toString(), '01236789');
+
+    // Purge the tombstone so undo cannot un-tombstone in place and must
+    // recreate the "45" fragment through restore()'s gap branch.
+    const purged = doc.garbageCollect(maxVectorOf([ACTOR]));
+    assert.isAbove(purged, 0, 'the deleted "45" fragment should be purged');
+    assert.equal(doc.getGarbageLen(), 0, 'nothing should remain pending GC');
+
+    // Undo recreates (t1:4)"45" via insertAfter — physical chain is repaired
+    // ("0123456789") but the insertion chain around it stays stale.
+    doc.history.undo();
+    assert.equal(
+      doc.getRoot().t.toString(),
+      '0123456789',
+      'restore itself must rebuild the visible text',
+    );
+
+    // The bug bites here: an edit whose boundary (index 6) sits exactly at the
+    // recreated node's right edge resolves through the stale insertion chain.
+    doc.update((r) => r.t.edit(6, 6, 'X'));
+    assert.equal(
+      doc.getRoot().t.toString(),
+      '012345X6789',
+      'an edit at the recreated boundary must land at the right offset',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #1327.

`RGATreeSplit.restore()`'s gap-recreate branch recreated a purged interior
fragment with `insertAfter`, which maintains only the physical `prev`/`next`
chain — not the separate insertion chain (`insPrev`/`insNext`). Sibling
methods (`splitNode`, `deepcopy`, `purge`) keep both chains in sync, but the
restore gap branch did not.

As a result the recreated node was skipped by its surviving same-insertion
neighbours. A **later** edit whose boundary landed on that node resolved its
absolute offset via `findFloorNodePreferToLeft`, which walks `insPrev`. The
walk hit a stale pointer and `findNodeWithSplit` miscomputed the relative
offset — silently dropping the edit or throwing `offset should be less than
or equal to length`.

### Reproduction

1. `edit(0, 0, "0123456789")` — one node `(t1:0)`
2. `edit(4, 6, "")` — splits into `(t1:0)"0123"`, `{t1:4 "45"}` (tombstone),
   `(t1:6)"6789"`
3. GC purges the tombstone
4. `undo()` — recreates `(t1:4)"45"` via the gap branch; visible text is
   correct but the insertion chain around it is stale
5. `edit(6, 6, "X")` — boundary at the recreated node resolves through the
   stale chain and throws

### Fix

After `insertAfter` in the gap branch, relink the insertion chain the same
way `splitNode` does, locating the same-insertion neighbours with
`findPieceCovering` (left neighbour covering `cursor-1`, right neighbour
covering `gapEnd`). Guarded for `cursor === 0` and missing neighbours.

The identical fix is applied to the Go server in
yorkie-team/yorkie (CRDT logic is mirrored across both SDKs).

## Test plan

- Added `text_restore_relink_test.ts`, which reproduces #1327 and fails
  without the fix (`offset should be less than or equal to length`), passes
  with it.
- `pnpm sdk build` ✓, ESLint (zero warnings) ✓
- Full unit suite ✓ (343 passed)
- Full suite incl. integration against a live server ✓ (2915 passed;
  `webhook_test.ts` excluded — local environment cannot reach the webhook
  receiver, unrelated to this change)

### Follow-up (non-blocking)

A multi-agent review flagged optional test-hardening for a later PR:
multi-gap-within-one-insertion, `cursor === 0` leftmost fragment, and a
redo-cycle case. The shipped code is correct without them; the added test
pins the exact regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text restoration after deleted interior content is recreated.
  * Boundary edits now apply at the correct position following undo and garbage collection.

* **Tests**
  * Added regression coverage for restoring deleted text fragments and editing adjacent content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->