### PR TITLE
Recover style ranges collapsed by a merge at the from anchor

### DIFF
--- a/packages/sdk/src/document/crdt/tree.ts
+++ b/packages/sdk/src/document/crdt/tree.ts
@@ -1101,7 +1101,13 @@ export class CRDTTree extends CRDTElement implements GCParent {
   private mergedAnchorInterloperGuard(
     pos: CRDTTreePos,
     versionVector?: VersionVector,
-  ): { isInterloper: (node: CRDTTreeNode) => boolean } | undefined {
+  ):
+    | {
+        isInterloper: (node: CRDTTreeNode) => boolean;
+        declaredParent: CRDTTreeNode;
+        target: CRDTTreeNode;
+      }
+    | undefined {
     if (versionVector === undefined) {
       return;
     }
@@ -1154,6 +1160,61 @@ export class CRDTTree extends CRDTElement implements GCParent {
         }
         return afterTombstone.has(top);
       },
+      declaredParent,
+      target,
+    };
+  }
+
+  /**
+   * `reversedFromAnchorRecovery` prepares the §9.4 from-side counterpart of
+   * `mergedAnchorInterloperGuard` for a style range whose start position was
+   * declared inside a parent that a merge unknown to the styling client
+   * removed. The resolved range then collapses (start past end) and the
+   * traversal misses nodes the styling client covered. The recovery
+   * re-anchors the traversal start just after the last live sibling before
+   * the merge-source tombstone; the caller must style only nodes the
+   * returned predicate positively identifies as interlopers. Stamped nodes
+   * in the span stay out of reach and fail open unstyled — see the §9.4
+   * known limitations in yorkie's concurrent-merge-split design doc.
+   */
+  private reversedFromAnchorRecovery(
+    pos: CRDTTreePos,
+    fromParent: CRDTTreeNode,
+    fromLeft: CRDTTreeNode,
+    toParent: CRDTTreeNode,
+    toLeft: CRDTTreeNode,
+    versionVector?: VersionVector,
+  ):
+    | {
+        fromParent: CRDTTreeNode;
+        fromLeft: CRDTTreeNode;
+        isInterloper: (node: CRDTTreeNode) => boolean;
+      }
+    | undefined {
+    const guard = this.mergedAnchorInterloperGuard(pos, versionVector);
+    if (!guard) {
+      return;
+    }
+    // Only a range that actually collapsed needs recovery: when both
+    // anchors moved with the merge, the resolved range stays ordered and
+    // still covers what the styling client covered.
+    if (this.toIndex(fromParent, fromLeft) <= this.toIndex(toParent, toLeft)) {
+      return;
+    }
+    const { declaredParent, target } = guard;
+    let anchorLeft: CRDTTreeNode = target;
+    for (const child of target.allChildren) {
+      if (child === declaredParent) {
+        break;
+      }
+      if (!child.isRemoved) {
+        anchorLeft = child;
+      }
+    }
+    return {
+      fromParent: target,
+      fromLeft: anchorLeft,
+      isInterloper: guard.isInterloper,
     };
   }
 
@@ -1165,6 +1226,7 @@ export class CRDTTree extends CRDTElement implements GCParent {
   private styleSkipPredicate(
     pos: CRDTTreePos,
     versionVector?: VersionVector,
+    recoveredInterloper?: (node: CRDTTreeNode) => boolean,
   ): (node: CRDTTreeNode, tokenType: TokenType) => boolean {
     const anchorGuard = this.mergedAnchorInterloperGuard(pos, versionVector);
     return (node: CRDTTreeNode, tokenType: TokenType): boolean => {
@@ -1176,6 +1238,11 @@ export class CRDTTree extends CRDTElement implements GCParent {
         versionVector !== undefined &&
         this.hasUnknownSplitSibling(node, versionVector)
       ) {
+        return true;
+      }
+      // §9.4 from-side: a recovered traversal may only touch nodes the
+      // collapsed range lost, the positively identified interlopers.
+      if (recoveredInterloper && !recoveredInterloper(node)) {
         return true;
       }
       // §9.4: the node is in the range only because an unknown merge
@@ -1512,7 +1579,22 @@ export class CRDTTree extends CRDTElement implements GCParent {
         ? this.advancePastUnknownSplitSiblings(toLeftRaw, versionVector)
         : toLeftRaw;
 
-    const shouldSkipToken = this.styleSkipPredicate(range[1], versionVector);
+    const recovery = this.reversedFromAnchorRecovery(
+      range[0],
+      fromParent,
+      fromLeft,
+      toParent,
+      toLeft,
+      versionVector,
+    );
+    const [traverseFromParent, traverseFromLeft] = recovery
+      ? [recovery.fromParent, recovery.fromLeft]
+      : [fromParent, fromLeft];
+    const shouldSkipToken = this.styleSkipPredicate(
+      range[1],
+      versionVector,
+      recovery?.isInterloper,
+    );
 
     const changes: Array<TreeChange> = [];
     const attrs: { [key: string]: any } = attributes
@@ -1523,8 +1605,8 @@ export class CRDTTree extends CRDTElement implements GCParent {
     const newAttrKeys: Array<string> = [];
     let capturedPrev = false;
     this.traverseInPosRange(
-      fromParent,
-      fromLeft,
+      traverseFromParent,
+      traverseFromLeft,
       toParent,
       toLeft,
       ([node, tokenType]) => {
@@ -1678,15 +1760,30 @@ export class CRDTTree extends CRDTElement implements GCParent {
 
     addDataSizes(diff, diffTo, diffFrom);
 
-    const shouldSkipToken = this.styleSkipPredicate(range[1], versionVector);
+    const recovery = this.reversedFromAnchorRecovery(
+      range[0],
+      fromParent,
+      fromLeft,
+      toParent,
+      toLeft,
+      versionVector,
+    );
+    const [traverseFromParent, traverseFromLeft] = recovery
+      ? [recovery.fromParent, recovery.fromLeft]
+      : [fromParent, fromLeft];
+    const shouldSkipToken = this.styleSkipPredicate(
+      range[1],
+      versionVector,
+      recovery?.isInterloper,
+    );
 
     const changes: Array<TreeChange> = [];
     const pairs: Array<GCPair> = [];
     const prevAttributes = new Map<string, string>();
     let capturedPrev = false;
     this.traverseInPosRange(
-      fromParent,
-      fromLeft,
+      traverseFromParent,
+      traverseFromLeft,
       toParent,
       toLeft,
       ([node, tokenType]) => {

--- a/packages/sdk/test/integration/tree_style_moved_anchor_test.ts
+++ b/packages/sdk/test/integration/tree_style_moved_anchor_test.ts
@@ -274,3 +274,162 @@ describe('Tree.Style range ending after a merge-moved child', () => {
     }
   });
 });
+
+describe('Tree.Style range starting after a merge-moved child', () => {
+  it('styles the writer insert when a merge reverses the range', async ({
+    task,
+  }) => {
+    await withTwoClientsAndDocuments<{ tree: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+
+      // d1 inserts an empty <p> after the second paragraph, then styles a
+      // range starting after `c` and ending inside its own insert. On d2
+      // the concurrent merge moves `cd` behind the insert, so the resolved
+      // range collapses and would miss the insert entirely.
+      d1.update((root) => root.tree.edit(8, 8, { type: 'p', children: [] }));
+      d1.update((root) => root.tree.style(6, 9, { bold: 'x' }));
+      d2.update((root) => root.tree.edit(0, 5));
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(d1.getRoot().tree.toXML(), '<r><p bold="x"></p>cd</r>');
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, task.name);
+  });
+
+  it('applies removeStyle to the writer insert on both replicas', async ({
+    task,
+  }) => {
+    await withTwoClientsAndDocuments<{ tree: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+
+      // Same shape as above with removeStyle: the removal tombstone must
+      // materialize on both replicas, not only on the writer.
+      d1.update((root) => root.tree.edit(8, 8, { type: 'p', children: [] }));
+      d1.update((root) => root.tree.removeStyle(6, 9, ['bold']));
+      d2.update((root) => root.tree.edit(0, 5));
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, task.name);
+  });
+
+  it('keeps a range that stays ordered away from the insert', async ({
+    task,
+  }) => {
+    await withTwoClientsAndDocuments<{ tree: Tree }>(async (c1, d1, c2, d2) => {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+          ],
+        });
+      });
+      await c1.sync();
+      await c2.sync();
+
+      // Both anchors sit inside the merged paragraph, so the resolved
+      // range moves with the merge and stays ordered. The recovery must
+      // not widen it onto the insert.
+      d1.update((root) => root.tree.edit(8, 8, { type: 'p', children: [] }));
+      d1.update((root) => root.tree.style(6, 7, { bold: 'x' }));
+      d2.update((root) => root.tree.edit(0, 5));
+
+      await c1.sync();
+      await c2.sync();
+      await c1.sync();
+
+      assert.equal(d1.getRoot().tree.toXML(), '<r><p></p>cd</r>');
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    }, task.name);
+  });
+
+  it('keeps a reversed range away from an insert unknown to the styler', async ({
+    task,
+  }) => {
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c3 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    await c1.activate();
+    await c2.activate();
+    await c3.activate();
+
+    const docKey = `${toDocKey(task.name)}-${c1.getKey()}`;
+    const d1 = new yorkie.Document<{ tree: Tree }>(docKey);
+    const d2 = new yorkie.Document<{ tree: Tree }>(docKey);
+    const d3 = new yorkie.Document<{ tree: Tree }>(docKey);
+    await c1.attach(d1, { syncMode: SyncMode.Manual });
+    await c2.attach(d2, { syncMode: SyncMode.Manual });
+    await c3.attach(d3, { syncMode: SyncMode.Manual });
+
+    d1.update((root) => {
+      root.tree = new Tree({
+        type: 'r',
+        children: [
+          { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+          { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+        ],
+      });
+    });
+    await c1.sync();
+    await c2.sync();
+    await c3.sync();
+
+    // d3's insert is unknown to d1's style, so the version-vector check
+    // keeps it unstyled even when the recovered traversal passes it.
+    d1.update((root) => root.tree.edit(8, 8, { type: 'p', children: [] }));
+    d1.update((root) => root.tree.style(6, 9, { bold: 'x' }));
+    d2.update((root) => root.tree.edit(0, 5));
+    d3.update((root) => root.tree.edit(8, 8, { type: 'b', children: [] }));
+
+    for (const client of [c1, c2, c3]) {
+      await client.sync();
+    }
+    await c1.sync();
+    await c2.sync();
+
+    assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+    assert.equal(d2.toSortedJSON(), d3.toSortedJSON());
+    assert.include(
+      d1.toSortedJSON(),
+      '{"type":"p","children":[],"attributes":{"bold":"x"}}',
+    );
+    assert.include(d1.toSortedJSON(), '{"type":"b","children":[]}');
+
+    for (const [client, doc] of [
+      [c1, d1],
+      [c2, d2],
+      [c3, d3],
+    ] as const) {
+      await client.detach(doc);
+      await client.deactivate();
+    }
+  });
+});

--- a/packages/sdk/test/integration/tree_style_moved_anchor_test.ts
+++ b/packages/sdk/test/integration/tree_style_moved_anchor_test.ts
@@ -236,41 +236,43 @@ describe('Tree.Style range ending after a merge-moved child', () => {
     await c2.attach(d2, { syncMode: SyncMode.Manual });
     await c3.attach(d3, { syncMode: SyncMode.Manual });
 
-    d1.update((root) => {
-      root.tree = new Tree({
-        type: 'r',
-        children: [
-          { type: 'p', children: [{ type: 'text', value: 'ab' }] },
-          { type: 'p', children: [{ type: 'text', value: 'cd' }] },
-        ],
+    try {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+          ],
+        });
       });
-    });
-    await c1.sync();
-    await c2.sync();
-    await c3.sync();
+      await c1.sync();
+      await c2.sync();
+      await c3.sync();
 
-    // d3's insert is unknown to d1's style, so the version-vector check
-    // keeps it unstyled on every replica.
-    d1.update((root) => root.tree.style(0, 6, { bold: 'x' }));
-    d2.update((root) => root.tree.edit(0, 5));
-    d3.update((root) => root.tree.edit(8, 8, { type: 'p', children: [] }));
+      // d3's insert is unknown to d1's style, so the version-vector check
+      // keeps it unstyled on every replica.
+      d1.update((root) => root.tree.style(0, 6, { bold: 'x' }));
+      d2.update((root) => root.tree.edit(0, 5));
+      d3.update((root) => root.tree.edit(8, 8, { type: 'p', children: [] }));
 
-    for (const client of [c1, c2, c3]) {
-      await client.sync();
-    }
-    await c1.sync();
-    await c2.sync();
+      for (const client of [c1, c2, c3]) {
+        await client.sync();
+      }
+      await c1.sync();
+      await c2.sync();
 
-    assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-    assert.equal(d2.toSortedJSON(), d3.toSortedJSON());
-
-    for (const [client, doc] of [
-      [c1, d1],
-      [c2, d2],
-      [c3, d3],
-    ] as const) {
-      await client.detach(doc);
-      await client.deactivate();
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+      assert.equal(d2.toSortedJSON(), d3.toSortedJSON());
+    } finally {
+      for (const [client, doc] of [
+        [c1, d1],
+        [c2, d2],
+        [c3, d3],
+      ] as const) {
+        await client.detach(doc);
+        await client.deactivate();
+      }
     }
   });
 });
@@ -335,6 +337,10 @@ describe('Tree.Style range starting after a merge-moved child', () => {
       await c2.sync();
       await c1.sync();
 
+      assert.include(
+        d1.toSortedJSON(),
+        '{"type":"p","children":[],"attributes":{}}',
+      );
       assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
     }, task.name);
   });
@@ -389,47 +395,49 @@ describe('Tree.Style range starting after a merge-moved child', () => {
     await c2.attach(d2, { syncMode: SyncMode.Manual });
     await c3.attach(d3, { syncMode: SyncMode.Manual });
 
-    d1.update((root) => {
-      root.tree = new Tree({
-        type: 'r',
-        children: [
-          { type: 'p', children: [{ type: 'text', value: 'ab' }] },
-          { type: 'p', children: [{ type: 'text', value: 'cd' }] },
-        ],
+    try {
+      d1.update((root) => {
+        root.tree = new Tree({
+          type: 'r',
+          children: [
+            { type: 'p', children: [{ type: 'text', value: 'ab' }] },
+            { type: 'p', children: [{ type: 'text', value: 'cd' }] },
+          ],
+        });
       });
-    });
-    await c1.sync();
-    await c2.sync();
-    await c3.sync();
+      await c1.sync();
+      await c2.sync();
+      await c3.sync();
 
-    // d3's insert is unknown to d1's style, so the version-vector check
-    // keeps it unstyled even when the recovered traversal passes it.
-    d1.update((root) => root.tree.edit(8, 8, { type: 'p', children: [] }));
-    d1.update((root) => root.tree.style(6, 9, { bold: 'x' }));
-    d2.update((root) => root.tree.edit(0, 5));
-    d3.update((root) => root.tree.edit(8, 8, { type: 'b', children: [] }));
+      // d3's insert is unknown to d1's style, so the version-vector check
+      // keeps it unstyled even when the recovered traversal passes it.
+      d1.update((root) => root.tree.edit(8, 8, { type: 'p', children: [] }));
+      d1.update((root) => root.tree.style(6, 9, { bold: 'x' }));
+      d2.update((root) => root.tree.edit(0, 5));
+      d3.update((root) => root.tree.edit(8, 8, { type: 'b', children: [] }));
 
-    for (const client of [c1, c2, c3]) {
-      await client.sync();
-    }
-    await c1.sync();
-    await c2.sync();
+      for (const client of [c1, c2, c3]) {
+        await client.sync();
+      }
+      await c1.sync();
+      await c2.sync();
 
-    assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
-    assert.equal(d2.toSortedJSON(), d3.toSortedJSON());
-    assert.include(
-      d1.toSortedJSON(),
-      '{"type":"p","children":[],"attributes":{"bold":"x"}}',
-    );
-    assert.include(d1.toSortedJSON(), '{"type":"b","children":[]}');
-
-    for (const [client, doc] of [
-      [c1, d1],
-      [c2, d2],
-      [c3, d3],
-    ] as const) {
-      await client.detach(doc);
-      await client.deactivate();
+      assert.equal(d1.toSortedJSON(), d2.toSortedJSON());
+      assert.equal(d2.toSortedJSON(), d3.toSortedJSON());
+      assert.include(
+        d1.toSortedJSON(),
+        '{"type":"p","children":[],"attributes":{"bold":"x"}}',
+      );
+      assert.include(d1.toSortedJSON(), '{"type":"b","children":[]}');
+    } finally {
+      for (const [client, doc] of [
+        [c1, d1],
+        [c2, d2],
+        [c3, d3],
+      ] as const) {
+        await client.detach(doc);
+        await client.deactivate();
+      }
     }
   });
 });

--- a/packages/sdk/test/unit/document/crdt/tree_test.ts
+++ b/packages/sdk/test/unit/document/crdt/tree_test.ts
@@ -18,6 +18,7 @@ import { describe, it, assert } from 'vitest';
 import {
   InitialTimeTicket as ITT,
   MaxTimeTicket as MTT,
+  TimeTicket,
 } from '@yorkie-js/sdk/src/document/time/ticket';
 import {
   CRDTTree,
@@ -28,6 +29,7 @@ import {
   TreeChangeType,
   TreeNodeForTest,
 } from '@yorkie-js/sdk/src/document/crdt/tree';
+import { VersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
 import { stringifyObjectValues } from '@yorkie-js/sdk/src/util/object';
 import { idT, posT, timeT } from '@yorkie-js/sdk/test/helper/helper';
 
@@ -745,6 +747,108 @@ describe('CRDTTree.Edit', function () {
     assert.equal(content.parent, tree.getRoot().allChildren[0]);
     assert.equal(content.mergedFrom?.equals(declaredParent.id), true);
     assert.deepEqual(content.mergedAt, mergeTicket);
+  });
+
+  // An actor outside the styler's version vector, for simulating an
+  // unknown concurrent merge in a single-context unit test.
+  const otherActor = '111111111111111111111111';
+
+  it('recovers a style range reversed by an unknown merge at the from anchor', function () {
+    // 01. Create <root><p>ab</p><p>cd</p></root> and insert the styler's
+    // own <p> after the second paragraph.
+    const tree = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
+    tree.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    tree.editT(
+      [1, 1],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
+    tree.editT([4, 4], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    tree.editT(
+      [5, 5],
+      [new CRDTTreeNode(posT(), 'text', 'cd')],
+      0,
+      timeT(),
+      timeT,
+    );
+    const inserted = new CRDTTreeNode(posT(), 'p');
+    tree.editT([8, 8], [inserted], 0, timeT(), timeT);
+
+    // 02. Capture the styler-view range (from after `c`, to inside the
+    // insert) and a version vector that predates the merge.
+    const fromPos = tree.findPos(6);
+    const toPos = tree.findPos(9);
+    const knownTicket = timeT();
+    const stylerVV = new VersionVector(
+      new Map([[knownTicket.getActorID(), knownTicket.getLamport()]]),
+    );
+
+    // 03. Apply a merge from another actor, outside the styler's version
+    // vector: the moved `cd` now resolves after the insert, so the range
+    // collapses. The recovery must still style the insert.
+    const mergeTicket = TimeTicket.of(
+      knownTicket.getLamport() + 1n,
+      0,
+      otherActor,
+    );
+    tree.editT([0, 5], undefined, 0, mergeTicket, timeT);
+    tree.style(
+      [fromPos, toPos],
+      stringifyObjectValues({ bold: 'x' }),
+      timeT(),
+      stylerVV,
+    );
+
+    assert.equal(inserted.attrs?.get('bold'), '"x"');
+  });
+
+  it('keeps an ordered from-anchor range off the writer insert', function () {
+    // Same shape, but both anchors sit inside the merged paragraph: the
+    // resolved range moves with the merge and stays ordered, so the
+    // recovery must not widen it onto the insert.
+    const tree = new CRDTTree(new CRDTTreeNode(posT(), 'root'), timeT());
+    tree.editT([0, 0], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    tree.editT(
+      [1, 1],
+      [new CRDTTreeNode(posT(), 'text', 'ab')],
+      0,
+      timeT(),
+      timeT,
+    );
+    tree.editT([4, 4], [new CRDTTreeNode(posT(), 'p')], 0, timeT(), timeT);
+    tree.editT(
+      [5, 5],
+      [new CRDTTreeNode(posT(), 'text', 'cd')],
+      0,
+      timeT(),
+      timeT,
+    );
+    const inserted = new CRDTTreeNode(posT(), 'p');
+    tree.editT([8, 8], [inserted], 0, timeT(), timeT);
+
+    const fromPos = tree.findPos(6);
+    const toPos = tree.findPos(7);
+    const knownTicket = timeT();
+    const stylerVV = new VersionVector(
+      new Map([[knownTicket.getActorID(), knownTicket.getLamport()]]),
+    );
+
+    const mergeTicket = TimeTicket.of(
+      knownTicket.getLamport() + 1n,
+      0,
+      otherActor,
+    );
+    tree.editT([0, 5], undefined, 0, mergeTicket, timeT);
+    tree.style(
+      [fromPos, toPos],
+      stringifyObjectValues({ bold: 'x' }),
+      timeT(),
+      stylerVV,
+    );
+
+    assert.equal(inserted.attrs?.get('bold'), undefined);
   });
 
   it('Can find the closest TreePos when parentNode or leftSiblingNode does not exist', function () {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?

A `Tree.Style`/`Tree.RemoveStyle` whose range starts after a merge-moved child styles nothing on the applying replica. From `<r><p>ab</p><p>cd</p></r>`:

- client A inserts an empty `<p>` at index 8, then calls `removeStyle(6, 9)` (from after `c`, to inside the insert)
- client B concurrently removes `[0,5)`, merging the paragraphs

After a full sync only A carries an empty `attributes: {}` on the insert.

**Root cause:** the merge moves the anchor child behind the insert, so the resolved range inverts (start past end) and the traversal is empty. The per-node filter from #1311 cannot help: it only skips visited nodes, and nothing is visited.

**Fix:** `reversedFromAnchorRecovery`, the from-side counterpart of that filter. When the range start matches the same merged-anchor shape and the resolved range actually collapsed, it re-anchors the traversal start just after the last live sibling before the merge-source tombstone; the shared skip predicate then styles only nodes positively identified as interlopers, and version-vector checks keep unknown inserts unstyled. An ordered range that moved with the merge is left untouched.

For `removeStyle` the removal tombstone now materializes on both replicas: even for a missing key it arbitrates a concurrent `setStyle` with an earlier ticket by LWW, so the converged state is entry/entry rather than empty/empty.

Tests: four integration cases (style and removeStyle reversal, ordered-range control, a third client's unknown insert) and two unit tests pinning the recovery and the no-op at the CRDT layer.

#### Any background context you want to provide?

The from-side variant documented as a known limitation when #1317 landed; found by the Tree PBT for #1298. Mirrors yorkie-team/yorkie#1954 (design update: `docs/design/concurrent-merge-split.md` §9.4, Fix 23). Stamped nodes inside a collapsed span keep the pre-fix behavior; they reproduce on main and are documented there as known limitations.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1324 

### Checklist
- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed styling and style removal for ranges affected by concurrent document merges.
  * Prevented style ranges from incorrectly expanding to include unrelated inserted content.
  * Improved consistency when changes are made across multiple replicas.

* **Tests**
  * Added coverage for merged anchors, unknown concurrent inserts, style removal, and multi-replica convergence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->