### PR TITLE
Add boundary deltas to the Counter PBT

### DIFF
--- a/packages/sdk/test/crdt_pbt/counter_test.ts
+++ b/packages/sdk/test/crdt_pbt/counter_test.ts
@@ -21,6 +21,26 @@ const nonZeroDeltaArbitrary = fc.oneof(
   fc.integer({ min: 1, max: 10 }),
 );
 
+const boundaryDeltaArbitrary = fc.constantFrom(
+  2 ** 31 - 1,
+  2 ** 31,
+  2 ** 31 + 1,
+  -(2 ** 31 - 1),
+  -(2 ** 31),
+  -(2 ** 31 + 1),
+  2 ** 53 - 1,
+  2 ** 53,
+  -(2 ** 53 - 1),
+  -(2 ** 53),
+);
+
+// Small deltas stay dominant so that shrunk counterexamples remain readable.
+const deltaArbitrary = fc.oneof(
+  { withCrossShrink: true },
+  { arbitrary: nonZeroDeltaArbitrary, weight: 3 },
+  { arbitrary: boundaryDeltaArbitrary, weight: 1 },
+);
+
 function counterStepArbitrary(clientCount: number): fc.Arbitrary<CounterStep> {
   const clientIndexArbitrary = fc.integer({
     min: 0,
@@ -30,7 +50,7 @@ function counterStepArbitrary(clientCount: number): fc.Arbitrary<CounterStep> {
     fc.record({
       kind: fc.constant<'increase'>('increase'),
       client: clientIndexArbitrary,
-      delta: nonZeroDeltaArbitrary,
+      delta: deltaArbitrary,
     }),
     fc.record({
       kind: fc.constant<'sync'>('sync'),
@@ -57,7 +77,7 @@ function counterTraceArbitrary(
         minLength: clientCount,
         maxLength: clientCount,
       }),
-      deltas: fc.array(nonZeroDeltaArbitrary, {
+      deltas: fc.array(deltaArbitrary, {
         minLength: clientCount,
         maxLength: clientCount,
       }),
@@ -80,11 +100,21 @@ function counterTraceArbitrary(
     });
 }
 
+function expectedCounterJSON(trace: Array<CounterStep>): string {
+  let sum = 0n;
+  for (const step of trace) {
+    if (step.kind === 'increase') {
+      sum += BigInt(step.delta);
+    }
+  }
+  return `{"counter":${BigInt.asIntN(32, sum)}}`;
+}
+
 function assertDocumentsEqual(
   pairs: ClientsAndDocuments<CounterDocument>,
+  expected: string,
 ): void {
-  const expected = pairs[0].document.toSortedJSON();
-  for (const pair of pairs.slice(1)) {
+  for (const pair of pairs) {
     assert.equal(pair.document.toSortedJSON(), expected);
   }
 }
@@ -98,7 +128,7 @@ async function runCounterTrace(
     root.counter = new Counter(0);
   });
   await runFinalSyncForPBT(pairs);
-  assertDocumentsEqual(pairs);
+  assertDocumentsEqual(pairs, '{"counter":0}');
 
   for (const step of trace) {
     const pair = pairs[step.client];
@@ -113,7 +143,7 @@ async function runCounterTrace(
   }
 
   await runFinalSyncForPBT(pairs);
-  assertDocumentsEqual(pairs);
+  assertDocumentsEqual(pairs, expectedCounterJSON(trace));
 }
 
 describe('Counter property-based tests', function () {


### PR DESCRIPTION
<!--  Thanks for sending a pull request! -->

#### What this PR does / why we need it?
The Counter PBT from #1300 bounds deltas to `±10`, so the bug class behind #1307
(an `Int` counter pushed past int32 by one `increase`) was outside its domain.
It passed before and after #1312.

- Adds `boundaryDeltaArbitrary` with `±(2^31 - 1)`, `±2^31`, `±(2^31 + 1)`,
  `±(2^53 - 1)` and `±2^53`, mixed into the existing delta arbitrary at a low
  weight so small deltas stay dominant.
- Compares every replica against an expected value computed from the same
  deltas with `BigInt.asIntN(32, ...)`. The previous check only compared
  replicas to each other, which passes when all of them reach the same wrong
  value.

#### Any background context you want to provide?
The issue proposed a 9:1 weight. With the pinned seed (`0x5eed`) and the
default 20 runs, that ratio does not reproduce the #1307 bug: reverting
`counter.ts` to the parent of #1312 still passes. The bug needs a Long-typed
delta applied on a nonzero base with a matching sign, and at 9:1 the fixed
sample contains only 3 to 6 Long-typed deltas across 20 traces, none in a
qualifying position.

Rather than changing the shared seed in `helper.ts`, which would also pin the
sample for the Tree and Object PBTs that follow, this PR raises the boundary
weight to 3:1. Small deltas remain 75% of the distribution. With
`counter.ts` reverted to the parent of #1312, both tests now fail at the
default settings, for example:

```
Counterexample: [[{"kind":"increase","client":2,"delta":-2147483649},
                  {"kind":"increase","client":1,"delta":1},
                  {"kind":"increase","client":0,"delta":1}]]
AssertionError: expected '{"counter":2147483649}' to equal '{"counter":-2147483647}'
```

`withCrossShrink` is enabled on the delta arbitrary so that a failure that does
not depend on a boundary delta shrinks toward small deltas instead of keeping an unrelated large value in the counterexample.

#### What are the relevant tickets?
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #1325
Part of #1288

### Checklist
- [x] Added relevant tests or not required
- [ ] Addressed and resolved all CodeRabbit review comments
- [x] Didn't break anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded counter testing to cover small changes and important integer boundary values.
  * Improved validation of initial and final counter states, including 32-bit wrapping behavior.
  * Added more reliable expected-value calculations for large numeric changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->