### PR TITLE
Anchor RGATreeList.insert on the last node's position identity

### DIFF
--- a/docs/tasks/active/20260830-array-move-snapshot-order-lessons.md
+++ b/docs/tasks/active/20260830-array-move-snapshot-order-lessons.md
@@ -1,0 +1,52 @@
+# Lessons: anchor RGATreeList.insert on position identity
+
+**Created**: 2026-08-30
+
+## A split accessor leaves its call sites behind
+
+When `getLastCreatedAt()` was introduced to return position identity, the
+point was to stop confusing element identity with position identity. But
+introducing the correct accessor does not migrate the call sites that
+still hold the old one. Both SDKs kept exactly one stale caller each, and
+in both cases it was the append helper.
+
+The lesson is that an identity split is only finished once every reader
+of the old accessor has been audited. A grep for the old accessor at the
+time of the split would have caught both.
+
+## The same defect hides behind different callers in each SDK
+
+Go and this SDK had the identical bug, but it was reachable through
+different paths: in Go, `Add` was used by both `DeepCopy` and snapshot
+restore; here, `deepcopy` was already correct and only `fromArray` used
+`insert`.
+
+So "the Go repro also reproduces here" is not a safe assumption — the Go
+regression test uses `DeepCopy`, which passes on this SDK. The behavior
+has to be reproduced through the path this SDK actually takes, or the
+test proves nothing.
+
+## Build the fixture through the path that is not under test
+
+The obvious way to write this test is to build the array with `insert`
+and then restore it. That would have been wrong: the fixture itself would
+be corrupted by the bug, so the test would fail before reaching the
+assertion it cares about and would not show that reconstruction is what
+breaks.
+
+Building the fixture with `doc.update` — the live path, which already
+anchors on position identity — keeps the pre-snapshot document correct,
+so the failure appears only in the restored copy. That is what makes it a
+reconstruction-only repro.
+
+## Describe the mechanism, not the plausible mechanism
+
+The first draft of the doc comment blamed `getByID` for resolving to the
+dead position node. `insertAfter` does not call `getByID`; it has its own
+inline lookup that consults `nodeMapByCreatedAt` first. Reading the
+function rather than the neighbouring one caught it.
+
+The observed output is the check on the explanation: `[66,26,14,15]`
+means both appends landed after a single anchor ahead of `14`, in
+reverse. An explanation that predicts a different ordering is wrong even
+if it sounds right.

--- a/docs/tasks/active/20260830-array-move-snapshot-order-todo.md
+++ b/docs/tasks/active/20260830-array-move-snapshot-order-todo.md
@@ -1,0 +1,56 @@
+# Anchor RGATreeList.insert on position identity
+
+**Created**: 2026-08-30
+
+Server-side counterpart: yorkie#1958 (issue yorkie#1948). A replica that
+rebuilt an array from a snapshot reversed a run of appended elements when
+the array's last element had been moved into its slot. The server fix
+landed in Go; this SDK carried the identical defect, so fixing only Go
+would have turned a uniform cross-SDK bug into a permanent
+server-vs-client divergence.
+
+## Problem
+
+`RGATreeList.insert` anchored the appended element on the last node's
+ELEMENT identity (`this.last.getCreatedAt()`) instead of its POSITION
+identity (`getLastCreatedAt()`).
+
+The two are the same until the last element is moved. After a move they
+diverge, and `insertAfter` resolves `nodeMapByCreatedAt` first — where
+the element's createdAt still keys its now-dead original position node,
+since dead positions are retained as stable anchors. So each append
+landed after that stale dead slot instead of the tail. Because every
+appended element carries the newest ticket, the RGA forward-skip in
+`findNextBeforeExecutedAt` never advances, so each append landed
+immediately after the same anchor and the appended run came out
+reversed.
+
+`fromArray` (`api/converter.ts`) is the only caller of `insert`, which is
+why this surfaced solely on the snapshot restore path. `CRDTArray.deepcopy`
+already anchored on `clone.getLastCreatedAt()`, so it was never affected —
+the mirror image of Go, where `DeepCopy` went through the buggy `Add` and
+was affected.
+
+Concretely: a document holding `[14,15,26,66]` decoded from its own
+snapshot as `[66,26,14,15]`.
+
+## Tasks
+
+- [x] Add a regression test that round-trips a moved-then-appended array
+      through `objectToBytes`/`bytesToObject`
+      (`test/unit/api/array_move_snapshot_test.ts`)
+- [x] Anchor `RGATreeList.insert` on `getLastCreatedAt()`
+- [x] Record why the anchor must be position identity, in the doc comment
+- [x] Verify red-to-green: the test fails on `main` with
+      `[66,26,14,15]` and passes with the fix
+- [x] `pnpm sdk lint`, `pnpm sdk build`, unit suite (343 passed)
+- [x] Full integration suite against a local server (2578 passed)
+
+## Review
+
+The fix is one line and mirrors yorkie#1958 exactly. The regression test
+builds its fixture through the live document API (`doc.update`), which
+anchors on position identity already, so the only `insert` calls are the
+ones `fromArray` makes during restore. That keeps the test a genuine
+reconstruction-only repro: the pre-snapshot document is correct and only
+the restored copy diverges.

--- a/packages/sdk/src/document/crdt/rga_tree_list.ts
+++ b/packages/sdk/src/document/crdt/rga_tree_list.ts
@@ -482,9 +482,21 @@ export class RGATreeList implements GCParent {
 
   /**
    * `insert` adds the given element after the last node.
+   *
+   * The anchor must be the last node's POSITION identity
+   * (`getLastCreatedAt`), not its element identity (`last.getCreatedAt`).
+   * When the last element was moved here, the two differ: `insertAfter`
+   * resolves `nodeMapByCreatedAt` first, where the element's createdAt still
+   * keys its now-dead original position node (dead positions are retained as
+   * stable anchors). Anchoring on element identity would therefore append
+   * after that stale dead slot instead of the tail, and since each appended
+   * element carries the newest ticket the RGA forward-skip never advances —
+   * so every append lands immediately after the same anchor, reversing the
+   * appended run (yorkie#1948). `fromArray` is the only caller, so this was
+   * seen solely via snapshot restore.
    */
   public insert(value: CRDTElement): void {
-    this.insertAfter(this.last.getCreatedAt(), value);
+    this.insertAfter(this.getLastCreatedAt(), value);
   }
 
   /**

--- a/packages/sdk/test/unit/api/array_move_snapshot_test.ts
+++ b/packages/sdk/test/unit/api/array_move_snapshot_test.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, assert } from 'vitest';
+import { Document } from '@yorkie-js/sdk/src/document/document';
+import { converter } from '@yorkie-js/sdk/src/api/converter';
+import { JSONArray } from '@yorkie-js/sdk/src/yorkie';
+
+describe('Array move snapshot', function () {
+  // Regression for yorkie#1948: when the last element of an array was moved
+  // into its slot, appending more elements and then restoring the array from a
+  // snapshot must preserve order.
+  //
+  // `RGATreeList.insert` anchored on the last node's ELEMENT createdAt instead
+  // of its POSITION createdAt. For a moved last element those differ, and the
+  // element createdAt resolves to the element's now-dead original position
+  // node, so each appended element landed before the previous one — reversing
+  // the appended run. `fromArray` is the only caller of `insert`, so this
+  // surfaced solely as a replica diverging after a snapshot restore.
+  it('preserves order of a moved-then-appended array across a snapshot', function () {
+    const doc = new Document<{ list: JSONArray<number> }>('test-doc');
+
+    doc.update((root) => {
+      root.list = [14, 15] as JSONArray<number>;
+    });
+    assert.equal('{"list":[14,15]}', doc.toJSON());
+
+    // Two moves that leave two dead position nodes and a moved last element,
+    // while restoring the original [14,15] order.
+    doc.update((root) => {
+      const n14 = root.list.getElementByIndex(0)!;
+      const n15 = root.list.getElementByIndex(1)!;
+      root.list.moveAfter(n15.getID(), n14.getID());
+    });
+    assert.equal('{"list":[15,14]}', doc.toJSON());
+
+    doc.update((root) => {
+      const n15 = root.list.getElementByIndex(0)!;
+      const n14 = root.list.getElementByIndex(1)!;
+      root.list.moveAfter(n14.getID(), n15.getID());
+    });
+    assert.equal('{"list":[14,15]}', doc.toJSON());
+
+    // Append after the moved last element.
+    doc.update((root) => {
+      root.list.push(26);
+      root.list.push(66);
+    });
+    assert.equal('{"list":[14,15,26,66]}', doc.toJSON());
+
+    // The snapshot restore path rebuilds the list through `insert`.
+    const bytes = converter.objectToBytes(doc.getRootObject());
+    const restored = converter.bytesToObject(bytes);
+    assert.equal(
+      restored.toSortedJSON(),
+      doc.toSortedJSON(),
+      'snapshot restore of a moved-then-appended array must preserve order',
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Client-side counterpart of yorkie-team/yorkie#1958 (issue yorkie-team/yorkie#1948).

`RGATreeList.insert` anchored the appended element on the last node's **element** identity (`this.last.getCreatedAt()`) instead of its **position** identity (`getLastCreatedAt()`). The two agree until the last element is moved.

After a move they diverge, and `insertAfter` resolves `nodeMapByCreatedAt` first — where the element's `createdAt` still keys its now-dead original position node, since dead positions are retained as stable anchors. So each append landed after that stale dead slot instead of the tail. Because every appended element carries the newest ticket, the RGA forward-skip in `findNextBeforeExecutedAt` never advances, so each append landed immediately after the same anchor and the appended run came out reversed.

`fromArray` is the only caller of `insert`, so this surfaced solely on the snapshot restore path. A document holding `[14,15,26,66]` decoded from its own snapshot as `[66,26,14,15]`. `CRDTArray.deepcopy` already anchored on `clone.getLastCreatedAt()` and was never affected — the mirror image of Go, where `DeepCopy` went through the buggy `Add`.

### Why this belongs with the server fix

yorkie#1958 fixes the same defect in Go. Landing only the server side would convert a uniform cross-SDK bug into a permanent server-vs-client divergence, since Go is also the server: a fixed server would rebuild the array as `[14,15,26,66]` while a JS client decoding the same snapshot still produced `[66,26,14,15]`.

## Test plan

New regression test `packages/sdk/test/unit/api/array_move_snapshot_test.ts` round-trips a moved-then-appended array through `objectToBytes`/`bytesToObject`.

The fixture is built with `doc.update` — the live path, which already anchors on position identity — so the only `insert` calls are the ones `fromArray` makes during restore. That keeps it a reconstruction-only repro: the pre-snapshot document is correct and only the restored copy diverges.

- Red/green: fails on `main` with `expected '{"list":[66,26,14,15]}' to equal '{"list":[14,15,26,66]}'`, passes with the fix
- `pnpm sdk lint` — clean
- `pnpm sdk build` — clean
- Unit suite — 33 files, 343 passed
- Full integration suite against a local `yorkieteam/yorkie:latest` server — 32 files, 2578 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LVE3CWRptSLvWWsvMFjr14


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed array ordering when restoring a snapshot after moving the last element and appending new items.
  * Appended elements now remain in their original order after snapshot round-trips.

* **Tests**
  * Added regression coverage for moved-and-appended arrays to verify order preservation.

* **Documentation**
  * Documented the issue, resolution, and lessons learned from the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->