### PR TITLE
Release v0.7.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and Yorkie JS SDK adheres to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+## [v0.7.18] - 2026-08-31
+
+### Fixed
+
+- Anchor RGATreeList.insert on the last node's position identity by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1332
+- Recover style ranges collapsed by a merge at the from anchor by @Nahee-Park in https://github.com/yorkie-team/yorkie-js-sdk/pull/1329
+- Relink insertion chain when restore recreates a purged fragment by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1328
+- Reject integers outside the int64 range by @lemon0333 in https://github.com/yorkie-team/yorkie-js-sdk/pull/1326
+
 ## [v0.7.17] - 2026-08-18
 
 ### Fixed

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yorkie-js/devtools",
   "displayName": "Yorkie Devtools",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "description": "A browser extension that helps you debug Yorkie.",
   "homepage": "https://yorkie.dev/",
   "scripts": {

--- a/packages/prosemirror/package.json
+++ b/packages/prosemirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/prosemirror",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "description": "ProseMirror binding for Yorkie collaborative editing",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/react",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "description": "A set of hooks and providers for Yorkie JS SDK",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/schema",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "description": "Yorkie Schema for Yorkie Document",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/sdk",
-  "version": "0.7.17",
+  "version": "0.7.18",
   "description": "Yorkie JS SDK",
   "main": "./src/yorkie.ts",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Bump Yorkie JS SDK to v0.7.18.

Bump the five publishable packages (`sdk`, `react`, `schema`, `prosemirror`,
`devtools`) to 0.7.18. The root `package.json` is private at `0.0.0` and internal
deps resolve through `workspace:*`, so neither moves and the lockfile is unchanged.

### CHANGELOG (Fixed)

- Anchor RGATreeList.insert on the last node's position identity (#1332)
- Recover style ranges collapsed by a merge at the from anchor (#1329)
- Relink insertion chain when restore recreates a purged fragment (#1328)
- Reject integers outside the int64 range (#1326)

#1330 (boundary deltas to the Counter PBT) is test-only and excluded.

The first three fixes are paired with the yorkie server release (#1958, #1954,
#1953).

## Test plan

Version-bump + CHANGELOG only; no code change. CI validates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved list insertion stability when changes occur near the end of a list.
  * Preserved style ranges more reliably after content merges.
  * Fixed restoration of previously removed content and its insertion relationships.
  * Added validation to reject integers outside the supported 64-bit range.

* **Release**
  * Updated packages to version 0.7.18 and documented the fixes in the changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->