### PR TITLE
Release v0.7.19

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and Yorkie JS SDK adheres to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+## [v0.7.19] - 2026-09-03
+
+### Fixed
+
+- Replace YSON regex preprocessor with a string-aware scanner by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1335
+
 ## [v0.7.18] - 2026-08-31
 
 ### Fixed

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yorkie-js/devtools",
   "displayName": "Yorkie Devtools",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "A browser extension that helps you debug Yorkie.",
   "homepage": "https://yorkie.dev/",
   "scripts": {

--- a/packages/prosemirror/package.json
+++ b/packages/prosemirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/prosemirror",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "ProseMirror binding for Yorkie collaborative editing",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/react",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "A set of hooks and providers for Yorkie JS SDK",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/schema",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Yorkie Schema for Yorkie Document",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/sdk",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "description": "Yorkie JS SDK",
   "main": "./src/yorkie.ts",
   "publishConfig": {


### PR DESCRIPTION
## Summary

Release `v0.7.19`, matching the yorkie server (yorkie-team/yorkie#1968).

Scope since `v0.7.18`:

### Fixed
- Replace YSON regex preprocessor with a string-aware scanner (#1335)

Bumps the five publishable packages (`sdk`, `react`, `schema`, `prosemirror`,
`devtools`) from `0.7.18` to `0.7.19`. Internal deps resolve via `workspace:*`,
so no lockfile change is needed. `devtools` ships via a separate workflow and
is not published to npm.

## Test plan
- Version-only release PR; CI is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YSON preprocessing to correctly handle strings, reducing parsing issues involving string content.

* **Changelog**
  * Added release notes for version 0.7.19.

* **Maintenance**
  * Updated package versions to 0.7.19 across the released packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->