### PR TITLE
Reject duplicate attach of the same key on one client

### DIFF
--- a/packages/sdk/src/client/client.ts
+++ b/packages/sdk/src/client/client.ts
@@ -385,6 +385,10 @@ export class Client {
   private metadata: Record<string, string>;
   private status: ClientStatus;
   private attachmentMap: Map<string, Attachment<Attachable>>;
+  // `attachingDocs` holds keys with an in-flight attach. attachmentMap is
+  // only populated after the attach round-trip resolves, so this set is
+  // needed to reject a concurrent duplicate attach of the same key.
+  private attachingDocs: Set<string>;
 
   private apiKey: string;
   private authTokenInjector?: (reason?: string) => Promise<string>;
@@ -414,6 +418,7 @@ export class Client {
     this.metadata = opts.metadata || {};
     this.status = ClientStatus.Deactivated;
     this.attachmentMap = new Map();
+    this.attachingDocs = new Set();
 
     // TODO(hackerwins): Consider to group the options as a single object.
     this.apiKey = opts.apiKey || '';
@@ -679,6 +684,20 @@ export class Client {
         `${doc.getKey()} is not detached`,
       );
     }
+    // Reject a duplicate attach of the same key on this client. Without this
+    // guard the request reaches the server, which reports the already-attached
+    // key as a misleading `ErrClientNotFound`; the SDK then deactivates the
+    // whole client. `attachmentMap` covers the resolved case and
+    // `attachingDocs` covers a concurrent in-flight attach.
+    if (
+      this.attachmentMap.has(doc.getKey()) ||
+      this.attachingDocs.has(doc.getKey())
+    ) {
+      throw new YorkieError(
+        Code.ErrAlreadyAttached,
+        `${doc.getKey()} is already attached`,
+      );
+    }
 
     doc.setActor(this.id!);
     // Resolve the effective presence-disabled state at attach time. The
@@ -712,6 +731,10 @@ export class Client {
       : syncMode === SyncMode.Polling
         ? DefaultDocumentPollIntervalMs
         : 0;
+    // Mark the attach in flight synchronously so a concurrent duplicate
+    // attach of the same key is rejected by the guard above before it is
+    // enqueued. Cleared in the task's `finally`.
+    this.attachingDocs.add(doc.getKey());
     return this.enqueueTask(async () => {
       try {
         const res = await this.rpcClient.attachDocument(
@@ -788,6 +811,8 @@ export class Client {
         logger.error(`[AD] c:"${this.getKey()}" err :`, err);
         await this.handleConnectError(err);
         throw err;
+      } finally {
+        this.attachingDocs.delete(doc.getKey());
       }
     });
   }

--- a/packages/sdk/src/util/error.ts
+++ b/packages/sdk/src/util/error.ts
@@ -39,6 +39,10 @@ export enum Code {
   // ErrNotDetached is returned when the resource is not detached.
   ErrNotDetached = 'ErrNotDetached',
 
+  // ErrAlreadyAttached is returned when a document with the same key is
+  // already attached (or being attached) to this client.
+  ErrAlreadyAttached = 'ErrAlreadyAttached',
+
   // ErrSessionNotFound is returned when the server no longer recognises a
   // channel session_id (e.g. reclaimed after TTL). Callers should treat this
   // as "session expired" and retry as a first-call (empty session_id).

--- a/packages/sdk/test/integration/duplicate_attach_test.ts
+++ b/packages/sdk/test/integration/duplicate_attach_test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, assert } from 'vitest';
+import yorkie from '@yorkie-js/sdk/src/yorkie';
+import { Code, YorkieError } from '@yorkie-js/sdk/src/util/error';
+
+/**
+ * `attachExpectingAlreadyAttached` mirrors how a caller awaits an attach
+ * inside try/catch (as the react hook does) and asserts the duplicate is
+ * rejected with the document-scoped `ErrAlreadyAttached` code.
+ */
+async function attachExpectingAlreadyAttached(
+  fn: () => Promise<unknown>,
+): Promise<void> {
+  try {
+    await fn();
+    assert.fail('expected duplicate attach to throw ErrAlreadyAttached');
+  } catch (err) {
+    assert.instanceOf(err, YorkieError);
+    assert.equal((err as YorkieError).code, Code.ErrAlreadyAttached);
+  }
+}
+import {
+  toDocKey,
+  testRPCAddr,
+} from '@yorkie-js/sdk/test/integration/integration_helper';
+
+// A duplicate attach of the same key on one client must be rejected locally
+// with a document-scoped error, and must NOT deactivate the client. Reaching
+// the server produces a misleading `ErrClientNotFound`, which the SDK would
+// otherwise escalate to full client deactivation. This reproduces the fast
+// navigation race where a component re-attaches a key whose previous attach
+// is still in flight (or already resolved as an orphan).
+describe.sequential('Duplicate attach guard', function () {
+  it('rejects re-attaching an already attached key without killing the client', async function ({
+    task,
+  }) {
+    const client = new yorkie.Client({ rpcAddr: testRPCAddr });
+    await client.activate();
+    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
+
+    const doc1 = new yorkie.Document<{ n?: number }>(docKey);
+    await client.attach(doc1);
+
+    const doc2 = new yorkie.Document<{ n?: number }>(docKey);
+    await attachExpectingAlreadyAttached(() => client.attach(doc2));
+
+    assert.isTrue(client.isActive(), 'client must stay active');
+    assert.isTrue(client.has(docKey), 'original attachment is intact');
+
+    await client.detach(doc1);
+    await client.deactivate();
+  });
+
+  it('rejects a concurrent attach of the same key while the first is in flight', async function ({
+    task,
+  }) {
+    const client = new yorkie.Client({ rpcAddr: testRPCAddr });
+    await client.activate();
+    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
+
+    // Fire the first attach without awaiting; the attachment is not yet in
+    // attachmentMap, so the guard must also track the in-flight attach.
+    const doc1 = new yorkie.Document<{ n?: number }>(docKey);
+    const attach1 = client.attach(doc1);
+
+    const doc2 = new yorkie.Document<{ n?: number }>(docKey);
+    await attachExpectingAlreadyAttached(() => client.attach(doc2));
+
+    // The first attach still completes successfully.
+    await attach1;
+    assert.isTrue(client.isActive(), 'client must stay active');
+    assert.isTrue(client.has(docKey), 'first attach succeeded');
+
+    await client.detach(doc1);
+    await client.deactivate();
+  });
+});


### PR DESCRIPTION
## What

Guard `client.attach` so a second attach of a document key that is already
attached — or has an attach still in flight — on the same client is rejected
locally with a new document-scoped `ErrAlreadyAttached`, before the request
reaches the server.

## Why

Rapidly re-attaching a key whose previous attach is still in flight (or already
resolved as an orphan) sends a second `AttachDocument` for the same key on one
client. The server can't transition the already-attached key to `Attaching`, so
its `FindOneAndUpdate` matches nothing and returns a **misleading**
`ErrClientNotFound` (`server/backend/database/mongo/client.go`). `handleConnectError`
treats `ErrClientNotFound` as fatal and calls `deactivateInternal()`, killing the
**entire** client — which for a signed-in session is a singleton — until a full
page reload.

This surfaced as a fast-navigation race in `@yorkie-js/react`'s document lifecycle:
the cleanup detaches only `if (client.has(docKey))`, but `attachmentMap` (what
`has` reads) is populated only after the attach round-trip resolves. A fast unmount
skips the detach, the attach later lands as an orphan, and the next mount's attach
collides on the same key.

`attachmentMap` covers the resolved-duplicate case; a new `attachingDocs` set
covers the concurrent in-flight case, since `attachmentMap` is only set after the
round trip. The guard throws synchronously, consistent with the existing
`isActive`/`getStatus` precondition checks, so callers awaiting `attach` inside
try/catch (including the react hook) observe it as a non-fatal rejection and the
client stays active.

## Test plan

- New `packages/sdk/test/integration/duplicate_attach_test.ts`:
  - sequential duplicate attach → `ErrAlreadyAttached`, client stays active
  - concurrent in-flight duplicate attach → `ErrAlreadyAttached`, first attach
    still succeeds, client stays active
- Verified against a real server:
  - full SDK suite (excl. webhook): 2939 passed, 0 failed
  - `client_test.ts`: 18/18
  - `@yorkie-js/react` package: 94/94
  - `pnpm lint` and `pnpm sdk build` clean
- End-to-end with the unchanged react-hook lifecycle: before this change the
  fast-nav sequence ends with `active=false` (dead session); after it the client
  stays `active=true` throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate document attachments from being submitted when the document is already attached or an attachment is in progress.
  * Added a clear `ErrAlreadyAttached` error for duplicate attachment attempts.
  * Preserved the existing attachment and client activity after a duplicate attempt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->