### PR TITLE
Release v0.7.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and Yorkie JS SDK adheres to [Semantic Versioning](https://semver.org/spec/v2.0.
 
 ## [Unreleased]
 
+## [v0.7.20] - 2026-09-09
+
+### Added
+
+- Add offline local persistence (serialize, store, resume, multi-tab) by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1338
+
+### Fixed
+
+- Reject duplicate attach of the same key on one client by @hackerwins in https://github.com/yorkie-team/yorkie-js-sdk/pull/1337
+
 ## [v0.7.19] - 2026-09-03
 
 ### Fixed

--- a/packages/devtools/package.json
+++ b/packages/devtools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yorkie-js/devtools",
   "displayName": "Yorkie Devtools",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "A browser extension that helps you debug Yorkie.",
   "homepage": "https://yorkie.dev/",
   "scripts": {

--- a/packages/prosemirror/package.json
+++ b/packages/prosemirror/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/prosemirror",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "ProseMirror binding for Yorkie collaborative editing",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/react",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "A set of hooks and providers for Yorkie JS SDK",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/schema/package.json
+++ b/packages/schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/schema",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "Yorkie Schema for Yorkie Document",
   "main": "./src/index.ts",
   "publishConfig": {

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yorkie-js/sdk",
-  "version": "0.7.19",
+  "version": "0.7.20",
   "description": "Yorkie JS SDK",
   "main": "./src/yorkie.ts",
   "publishConfig": {


### PR DESCRIPTION
## What this does

Bumps the five publishable packages to 0.7.20 and adds the CHANGELOG entry.

- `packages/{sdk,react,schema,prosemirror,devtools}/package.json`

The root `package.json` stays private at `0.0.0` and inter-package deps are
`workspace:*`, so no lockfile change.

## Changelog

### Added
- Add offline local persistence (serialize, store, resume, multi-tab) (#1338)

### Fixed
- Reject duplicate attach of the same key on one client (#1337)

## Note

#1338 needs a server carrying yorkie-team/yorkie#1969 and #1970, which ship in
yorkie v0.7.20. Merge and release after the server.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added offline local persistence support.
  - Duplicate attachment of the same key on a single client is now rejected.

- **Chores**
  - Released version 0.7.20 across the available packages.
  - Added the v0.7.20 changelog entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->