### PR TITLE
Keep collection able to resolve every entry it tracks

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -10,6 +10,7 @@ New design documents should be based on [TEMPLATE.md](TEMPLATE.md).
 - [ProseMirror Binding](prosemirror.md): Bidirectional sync between ProseMirror and Yorkie Tree CRDT
 - [ProseMirror Native Split/Merge](prosemirror-native-split-merge.md): Use Tree.Edit splitLevel and boundary deletion for splits and merges instead of block replacement
 - [One Node per CRDTTreeNodeID](tree-node-id-identity.md): Rules that keep a Tree position resolvable when two nodes claim one ID, mirroring the server
+- [One Live Element per createdAt](element-identity.md): Why a client can stop syncing for good after an undo, what closes the paths that get it there, and why the root cause needs a wire change
 - [Offline Local Persistence](offline-local-persistence.md): Persist a document and its un-pushed changes to IndexedDB so a reload survives, on top of a server-side stable actor; why rebase-on-restore is rejected
 
 ## Guidelines

--- a/docs/design/element-identity.md
+++ b/docs/design/element-identity.md
@@ -99,7 +99,17 @@ deregister is no longer gated on the source.
 | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | The guard hides a future occurrence instead of surfacing it | The invariant is pinned directly by `test/unit/document/gc_containment_test.ts`, which fails on duplication rather than on the crash it eventually causes |
 | Registering the displaced element changes collection counts | Measured: content is unchanged at every step, and the counts an existing test asserted were the leak rather than a property                               |
-| The unconditional deregister fires where it did not before  | An ordinary set carries a freshly issued `createdAt`, so the lookup misses. It can hit only under duplicate application, which the server prevents        |
+| The unconditional deregister fires where it did not before  | An ordinary set carries a freshly issued `createdAt`, so the lookup normally misses. It hits under duplicate application, which the checkpoint does not rule out (see below); there the deregister is the better of the two, since the gated version left the earlier copy's descendants registered forever |
+
+The checkpoint prevents a change being *stored* twice, not applied twice.
+`pushPack` skips a change whose `clientSeq` the checkpoint already covers, but
+it filters the list it stores — `reqPack.Changes` is left intact, and
+`pullSnapshot` applies that raw list on a document built for a `serverSeq` that
+already includes them. A pack retried after a lost response therefore replays
+its own changes, and `applyChanges` has no version-vector deduplication. That is
+a defect in its own right, filed in the Go repository as
+`20260911-duplicate-change-application-not-idempotent-todo.md`; it is not
+introduced or worsened here.
 
 ### Design Decisions
 

--- a/docs/design/element-identity.md
+++ b/docs/design/element-identity.md
@@ -85,13 +85,41 @@ given, and dropped the displaced element too, so the clone's accounting drifted
 from the document the operation is replayed on. `json/object.ts` already
 registered the value it replaces.
 
-### Clear a reused identity wherever the operation is applied
+### Retire a reused identity wherever the operation is applied — and only that
 
 Whether a `Set` is restoring an element under an already-registered `createdAt`
 is a property of the tree, not of who is applying the operation. The undo is
 generated on one replica and executed on all of them — peers apply it with
 `OpSource.Remote`, and the Go server replays it to build a snapshot — so the
-deregister is no longer gated on the source.
+retirement is no longer gated on the source.
+
+What it retires is one entry. `deregisterElement` was the wrong instrument: it
+walks the tombstone's descendants, and the tombstone's descendant set can be a
+strict superset of the restored copy's, because a peer may have added a member
+into the container after the undoing replica took the copy its reverse carries.
+Those extra members lose their `elementPairMapByCreatedAt` entries with nothing
+to put them back, and the next change addressed at one of them throws `fail to
+find` inside `applyChangePack` — the same permanent desync as [#1340], reached
+on a replica that never performed an undo.
+
+`unregisterRemovedElementPair` drops the one `gcElementSetByCreatedAt` member
+that collection would have resolved onto live data, releases the charge the
+orphaned subtree holds, and leaves the identity index alone.
+
+### Delete index entries by identity, not by key
+
+The general statement of the same defect. `deregisterElement` deleted
+`elementPairMapByCreatedAt[createdAt]` outright, and an undone array assignment
+restores descendants under their original `createdAt`s — only the top level is
+re-ticketed — so collecting the tombstone deleted entries that answer for live
+elements. The deletes now fire only when the slot still holds the element being
+retired.
+
+`sizeInGC` records which element a charge is held for, so a size can no longer
+be taken out of `docSize.live` that live was not holding. `ElementRHT.purge` and
+`RGATreeList.purge` get the matching guard; neither is reachable under this
+ordering today, and they are what keeps the identity work from having to be
+rediscovered when revive lands.
 
 ### Risks and Mitigation
 
@@ -99,7 +127,8 @@ deregister is no longer gated on the source.
 | ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | The guard hides a future occurrence instead of surfacing it | The invariant is pinned directly by `test/unit/document/gc_containment_test.ts`, which fails on duplication rather than on the crash it eventually causes |
 | Registering the displaced element changes collection counts | Measured: content is unchanged at every step, and the counts an existing test asserted were the leak rather than a property                               |
-| The unconditional deregister fires where it did not before  | An ordinary set carries a freshly issued `createdAt`, so the lookup normally misses. It hits under duplicate application, which the checkpoint does not rule out (see below); there the deregister is the better of the two, since the gated version left the earlier copy's descendants registered forever |
+| The ungated retirement fires where it did not before | An ordinary set carries a freshly issued `createdAt`, so the worklist lookup misses. It hits under duplicate application, which the checkpoint does not rule out (see below) — and there retiring one entry is the safe direction, unlike the subtree deregister this replaced |
+| An identity guard silently skips a delete that should have happened | The element that owns the slot clears it when its own turn comes, so nothing is stranded that was reachable. What is deliberately retained is the abandoned tombstone's registration — memory, not `docSize`, and it is what keeps the change log replayable |
 
 The checkpoint prevents a change being *stored* twice, not applied twice.
 `pushPack` skips a change whose `clientSeq` the checkpoint already covers, but
@@ -117,7 +146,9 @@ introduced or worsened here.
 | -------------------------------------------- | ---------------------------------------------------------------------------------------------- |
 | Skip rather than drop an unresolvable member | Dropping releases nothing and leaves the charge unreported                                     |
 | Fix the local path as well as the operation  | The clone is what the updater sees and what the size limit is checked against                  |
-| Ship with the Go change, not before it       | Both SDKs gate the same deregister; one-sided, the SDKs disagree about what a peer's undo does |
+| Ship with the Go change, not before it       | Both SDKs gate the same retirement; one-sided, the SDKs disagree about what a peer's undo does |
+| Retire one worklist entry, not the subtree   | The subtree is not the unit that went stale. Deregistering it evicts members the restored copy never carried, and a change addressed at one of them then throws — on the server's replay too, which makes the stored change log unreplayable |
+| Keep the abandoned tombstone registered      | Its registration is what the peer's later change resolves through. Retaining it costs memory and nothing in `docSize`, which `release` settles at retirement time |
 
 ## Alternatives Considered
 

--- a/docs/design/element-identity.md
+++ b/docs/design/element-identity.md
@@ -1,0 +1,127 @@
+---
+created: 2026-09-12
+updated: 2026-09-12
+tags: [crdt, gc, undo-redo, identity]
+---
+
+# One Live Element per createdAt
+
+## Problem
+
+`CRDTRoot` indexes the whole document by creation ticket:
+
+- `elementPairMapByCreatedAt` — how every operation finds its target, and how
+  garbage collection finds an element's parent so it can purge it.
+- `gcElementSetByCreatedAt` — the tombstones waiting to be collected.
+- `sizeInGC` — which side of `docSize` an element's size is charged to.
+
+All three assume one live element per `createdAt`, and nothing enforces it.
+`registerElement` is an unconditional `Map.set`, so a second element under the
+same id silently replaces the first.
+
+Undo produces exactly that. The reverse of an array removal is
+`AddOperation(value.deepcopy())`, and `deepcopy` keeps the `createdAt` of every
+descendant. The removed original is still in the tree as a tombstone until the
+minimum synced version vector passes over it, so executing the reverse puts a
+second live node under each of those ids.
+
+From there, `garbageCollect` eventually meets a member of the gc set it cannot
+resolve, dereferences it unguarded, and throws — inside `applyChangePack`,
+which is where every sync applies the server's change pack. The same pass
+throws again on the next sync, so the client never syncs that document again
+([#1340]). The same state is what surfaced as `'ownKeys' on proxy: trap
+returned duplicate entries`.
+
+Two other paths reach the same unresolvable state without any undo:
+
+- `ArraySetOperation` registered its value with no parent, so the pair resolves
+  and `purge` has nothing to call.
+- `SetOperation` cleared a colliding registration only when the source was
+  `OpSource.UndoRedo`, so every replica except the one that performed the undo
+  kept a gc set member that resolves to the restored — live — element and can
+  therefore never be collected.
+
+### Goals
+
+- A client that meets a document in this state keeps syncing.
+- Close the paths that create it without going through undo.
+- Do not change the wire format, and do not change what undo restores.
+
+### Non-Goals
+
+- **The root cause.** Undo of a removal is still expressed as re-insertion of a
+  copy, so two live elements can still end up under one `createdAt`. Fixing
+  that is [Identity-Preserving Revive](#see-also), which needs a replicated
+  liveness register and a restore mode on the wire — protobuf plus a
+  coordinated release across the Go and JS SDKs.
+- Repairing documents already written with duplicated ids. The guard keeps such
+  a document usable; it does not clean it. Server-side compaction is the
+  supported remediation.
+
+## Design
+
+### Tolerate a member that cannot be resolved
+
+`garbageCollect` and `getGarbageElementSetSize` guard the lookup the way
+`getGCElementPairs` beside them already did, and `garbageCollect` also checks
+that the pair has a parent to purge through.
+
+The member is **skipped, not dropped**. The element is still in the document
+and its size is still charged to `docSize.gc`, which only `deregisterElement`
+releases. Forgetting the member would leave that charge counted against the
+size limit with nothing left reporting it as garbage — `getGarbageLen` would
+say zero while `docSize.gc` said otherwise.
+
+### Register what an array assignment installs, and what it displaces
+
+`ArraySetOperation.execute` now passes the parent, and registers the element
+the assignment displaced. The `TODO` it carried claimed the two could not be
+told apart because they share a `createdAt`; they do not, and that stopped
+being true when array set became insert-then-remove rather than an in-place
+swap.
+
+`json/array.ts` performs the same assignment against the clone the updater is
+given, and dropped the displaced element too, so the clone's accounting drifted
+from the document the operation is replayed on. `json/object.ts` already
+registered the value it replaces.
+
+### Clear a reused identity wherever the operation is applied
+
+Whether a `Set` is restoring an element under an already-registered `createdAt`
+is a property of the tree, not of who is applying the operation. The undo is
+generated on one replica and executed on all of them — peers apply it with
+`OpSource.Remote`, and the Go server replays it to build a snapshot — so the
+deregister is no longer gated on the source.
+
+### Risks and Mitigation
+
+| Risk                                                        | Mitigation                                                                                                                                                |
+| ----------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| The guard hides a future occurrence instead of surfacing it | The invariant is pinned directly by `test/unit/document/gc_containment_test.ts`, which fails on duplication rather than on the crash it eventually causes |
+| Registering the displaced element changes collection counts | Measured: content is unchanged at every step, and the counts an existing test asserted were the leak rather than a property                               |
+| The unconditional deregister fires where it did not before  | An ordinary set carries a freshly issued `createdAt`, so the lookup misses. It can hit only under duplicate application, which the server prevents        |
+
+### Design Decisions
+
+| Decision                                     | Reason                                                                                         |
+| -------------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| Skip rather than drop an unresolvable member | Dropping releases nothing and leaves the charge unreported                                     |
+| Fix the local path as well as the operation  | The clone is what the updater sees and what the size limit is checked against                  |
+| Ship with the Go change, not before it       | Both SDKs gate the same deregister; one-sided, the SDKs disagree about what a peer's undo does |
+
+## Alternatives Considered
+
+| Alternative                                                       | Why not                                                                                                                                                                                                                                                                                                                                                         |
+| ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Deep re-identification: give the whole restored subtree fresh ids | Prototyped and measured. It removes the duplication, but a restored element becomes a _new_ element, so every operation stacked against the old one stops applying: reconciling the descendants makes the two ends of one operation name different objects and it throws, and not reconciling them makes the undo a silent no-op. No arrangement satisfies both |
+| Guard `garbageCollect` only, as the issue suggested               | Stops the crash and leaves everything else: the duplicate state, the array-set routes, and the peer-side leak                                                                                                                                                                                                                                                   |
+| Assert the invariant in `registerElement` and throw               | Turns a silent corruption into a crash for documents already in the wild — the opposite of what the guard is for                                                                                                                                                                                                                                                |
+
+## See Also
+
+- [One Node per CRDTTreeNodeID](tree-node-id-identity.md) — the same invariant
+  for tree nodes, and the restore-mode precedent this SDK already carries
+- yorkie#1978 — the Go counterpart, where the same `Set` gate loses the member
+  outright rather than leaking it
+
+[#1340]: https://github.com/yorkie-team/yorkie-js-sdk/issues/1340

--- a/packages/sdk/src/document/crdt/element_rht.ts
+++ b/packages/sdk/src/document/crdt/element_rht.ts
@@ -155,6 +155,19 @@ export class ElementRHT {
       );
     }
 
+    // The slot names a creation time, not an element. Undo of a remove
+    // re-inserts a copy under the original createdAt and `set` re-points this
+    // map at it, so unlinking whatever the key answers with would delete a live
+    // member on a tombstone's behalf. The tombstone is already off both maps by
+    // then, so there is nothing left to unlink.
+    //
+    // A genuinely missing key still throws above: that is a mis-registration
+    // worth reporting, and this guard is only about a slot that has been taken
+    // over.
+    if (node.getValue() !== element) {
+      return;
+    }
+
     const nodeByKey = this.nodeMapByKey.get(node.getStrKey());
     if (node === nodeByKey) {
       this.nodeMapByKey.delete(nodeByKey.getStrKey());

--- a/packages/sdk/src/document/crdt/rga_tree_list.ts
+++ b/packages/sdk/src/document/crdt/rga_tree_list.ts
@@ -554,6 +554,13 @@ export class RGATreeList implements GCParent {
       );
     }
 
+    // Same guard as `ElementRHT.purge`: releasing the position node of an entry
+    // that now holds a different element would unlink a live one on a
+    // tombstone's behalf. A genuinely missing entry still throws above.
+    if (entry.elem !== element) {
+      return;
+    }
+
     const node = entry.positionNode;
     this.elementMapByCreatedAt.delete(element.getCreatedAt().toIDString());
     this.release(node);

--- a/packages/sdk/src/document/crdt/root.ts
+++ b/packages/sdk/src/document/crdt/root.ts
@@ -49,6 +49,15 @@ interface CRDTElementPair {
 }
 
 /**
+ * `GCCharge` is what `docSize.gc` is holding on behalf of one element, and
+ * which element that is. See `Root.sizeInGC` for why the identity matters.
+ */
+interface GCCharge {
+  element: CRDTElement;
+  size: DataSize;
+}
+
+/**
  * `RootStats` is a structure that represents the statistics of the root object.
  */
 export interface RootStats {
@@ -98,14 +107,28 @@ export class CRDTRoot {
   /**
    * `sizeInGC` maps the creation time of every registered element whose size
    * counts toward `docSize.gc` rather than `docSize.live`, to the exact amount
-   * charged. Each element's size belongs to exactly one of the two, and an
-   * element reaches gc by more routes than it has removals: it can be removed
-   * itself, or be a descendant of a removed container. Recording the amount
-   * rather than a flag keeps the two sides symmetric even though `getDataSize`
-   * is not stable over an element's lifetime -- it grows by a ticket the moment
-   * `removedAt` is set, which can happen after the size has already moved.
+   * charged and to the element it is charged for. Each element's size belongs
+   * to exactly one of the two, and an element reaches gc by more routes than it
+   * has removals: it can be removed itself, or be a descendant of a removed
+   * container. Recording the amount rather than a flag keeps the two sides
+   * symmetric even though `getDataSize` is not stable over an element's
+   * lifetime -- it grows by a ticket the moment `removedAt` is set, which can
+   * happen after the size has already moved.
+   *
+   * The identity is load-bearing. A createdAt is meant to name one element, but
+   * it does not for the whole of a document's life: undo restores a `deepcopy`
+   * of a removed element, and the copy keeps the original's createdAt while the
+   * original is still a tombstone. Charging or releasing by key alone then
+   * bills whichever of the two occupies the slot, and a size can be taken out
+   * of `docSize.live` that live was never holding -- which is how docSize goes
+   * negative.
+   *
+   * A zero size is not the same as no record. It says this element has been
+   * released: charged to neither side, because its subtree was orphaned by a
+   * restore and nothing will ever collect it. Anything that later charges it
+   * again has to know live is not the side to take it from.
    */
-  private sizeInGC: Map<string, DataSize>;
+  private sizeInGC: Map<string, GCCharge>;
 
   /**
    * `gcPairMap` is a hash table that maps the IDString of GCChild to the
@@ -252,16 +275,35 @@ export class CRDTRoot {
       // already-removed container never passed through a removal, so it still
       // sits in live; subtracting it from gc would push gc below zero and
       // leave its cost in live forever.
+      // A charge recorded against some other element that shares this
+      // createdAt says nothing about this one, which is still in live.
       const charged = this.sizeInGC.get(createdAt);
-      if (charged) {
-        subDataSize(this.docSize.gc, charged);
+      if (charged && charged.element === elem) {
+        subDataSize(this.docSize.gc, charged.size);
         this.sizeInGC.delete(createdAt);
       } else {
         subDataSize(this.docSize.live, elem.getDataSize());
       }
 
-      this.elementPairMapByCreatedAt.delete(createdAt);
-      this.gcElementSetByCreatedAt.delete(createdAt);
+      // NOTE(hackerwins): Drop the index entries by identity, not by key. A
+      // createdAt is meant to name one element, but undo breaks that: it
+      // restores a `deepcopy` of a removed container, and the copy keeps every
+      // descendant's createdAt while the original is still a tombstone. Only
+      // the top level of an undone array set gets a fresh ticket, so the
+      // descendants below it are answered by the live copy while the tombstone
+      // is still the one being collected here. Deleting by key would evict the
+      // live element's entry, and every later operation addressed at it throws
+      // `fail to find` -- inside `applyChangePack`, which is the permanent
+      // desync this release exists to stop.
+      //
+      // The tombstone loses nothing by it: it is already unlinked from the
+      // tree, and whatever now owns the slot will clear it when its own turn
+      // comes. `gcElementSetByCreatedAt` carries no element of its own, so the
+      // pair map is what decides the identity for both.
+      if (this.elementPairMapByCreatedAt.get(createdAt)?.element === elem) {
+        this.elementPairMapByCreatedAt.delete(createdAt);
+        this.gcElementSetByCreatedAt.delete(createdAt);
+      }
       count++;
     };
 
@@ -314,29 +356,124 @@ export class CRDTRoot {
 
   /**
    * `moveSizeToGC` moves the size of the given element from live to gc, and
-   * reports whether it moved a size live was holding. A size already in gc --
-   * because the element was removed before, or because a container above it
-   * was -- only has its charge topped up: getDataSize grows by a ticket when
-   * removedAt is set, which can happen after the move.
+   * reports whether it moved a size live was holding. A size already charged to
+   * gc for this same element -- because it was removed before, because a
+   * container above it was, or because a restore released it -- only has its
+   * charge topped up: getDataSize grows by a ticket when removedAt is set,
+   * which can happen after the move.
+   *
+   * A charge recorded against a different element that shares this createdAt is
+   * not this element's: this one is still in live and moves in full. The record
+   * it displaces is a released one (zero), so nothing charged is lost.
    */
   private moveSizeToGC(element: CRDTElement): boolean {
     const createdAt = element.getCreatedAt().toIDString();
     const size = element.getDataSize();
 
     const charged = this.sizeInGC.get(createdAt);
-    if (charged) {
+    if (charged && charged.element === element) {
       addDataSizes(this.docSize.gc, {
-        data: size.data - charged.data,
-        meta: size.meta - charged.meta,
+        data: size.data - charged.size.data,
+        meta: size.meta - charged.size.meta,
       });
-      this.sizeInGC.set(createdAt, size);
+      this.sizeInGC.set(createdAt, { element, size });
       return false;
     }
 
     addDataSizes(this.docSize.gc, size);
     subDataSize(this.docSize.live, size);
-    this.sizeInGC.set(createdAt, size);
+    this.sizeInGC.set(createdAt, { element, size });
     return true;
+  }
+
+  /**
+   * `unregisterRemovedElementPair` drops the collection entry registered under
+   * the given createdAt, if there is one, and releases the charge it holds. It
+   * reports whether an entry was dropped.
+   *
+   * It is the narrow counterpart of `registerRemovedElement`, for the one
+   * caller that has to retire a tombstone without collecting it: a `Set` that
+   * restores an element under a createdAt a tombstone already answers to.
+   * `ElementRHT.set` has by then re-pointed `nodeMapByCreatedAt` at the
+   * restored copy, so the entry the removal left behind now resolves, through
+   * that index, to live data -- and collection would purge it.
+   *
+   * Deliberately narrow. The obvious alternative, deregistering the tombstone
+   * and its descendants outright, reaches past the entry that is stale: the
+   * tombstone's descendant set can be a strict superset of the restored copy's
+   * -- a peer may have added a child into the container after the undoing
+   * replica took its copy -- and deregistering evicts those descendants from
+   * `elementPairMapByCreatedAt` with nothing to put them back. A later change
+   * addressed at one of them then throws inside `applyChangePack` on every
+   * replica, and permanently on the server, which replays the same change log
+   * to rebuild the document and its snapshots.
+   *
+   * What it still does reach is the accounting, and it has to. The subtree is
+   * orphaned by the restore, so dropping the entry is dropping the only thing
+   * that would ever have collected it. Its cost is released from wherever it
+   * sits -- `docSize.gc` for anything a removal moved there, `docSize.live` for
+   * a member a peer added into the container after it was already removed.
+   */
+  public unregisterRemovedElementPair(createdAt: TimeTicket): boolean {
+    const key = createdAt.toIDString();
+    if (!this.gcElementSetByCreatedAt.has(key)) {
+      return false;
+    }
+
+    const element = this.elementPairMapByCreatedAt.get(key)?.element;
+    if (!element) {
+      // The worklist carries no element of its own; with nothing to resolve it
+      // through there is no charge to release and no identity to compare.
+      // Dropping the entry is still right -- it can never be collected.
+      this.gcElementSetByCreatedAt.delete(key);
+      return true;
+    }
+
+    this.release(element);
+    if (element instanceof CRDTContainer) {
+      element.getDescendants((elem) => {
+        this.release(elem);
+        return false;
+      });
+    }
+
+    this.gcElementSetByCreatedAt.delete(key);
+    return true;
+  }
+
+  /**
+   * `release` forgets the cost of an element that has become unreachable
+   * without being collected, and any collection entry naming it. It leaves
+   * `elementPairMapByCreatedAt` alone: the slot may since have been taken over
+   * by a live element restored under this same createdAt, and that element's
+   * registration has to stand.
+   */
+  private release(element: CRDTElement): void {
+    const createdAt = element.getCreatedAt().toIDString();
+
+    // Subtract from whichever side is actually holding it, by the amount
+    // actually charged -- the same split `deregisterElement` makes. A member
+    // added into an already-removed container never passed through a removal,
+    // so it still sits in live.
+    const charged = this.sizeInGC.get(createdAt);
+    if (charged && charged.element === element) {
+      subDataSize(this.docSize.gc, charged.size);
+    } else {
+      subDataSize(this.docSize.live, element.getDataSize());
+    }
+
+    // Record the release rather than forgetting it. This element stays
+    // addressable -- that is the whole point of not deregistering it -- so a
+    // peer that has not seen the restore can still remove something inside this
+    // subtree, and `moveSizeToGC` would then take its size out of live for a
+    // second time and drive docSize negative. A zero charge says live is not
+    // holding it, and the identity says which element that is about, so a copy
+    // restored under the same createdAt is still charged normally.
+    this.sizeInGC.set(createdAt, { element, size: { data: 0, meta: 0 } });
+
+    if (this.elementPairMapByCreatedAt.get(createdAt)?.element === element) {
+      this.gcElementSetByCreatedAt.delete(createdAt);
+    }
   }
 
   /**

--- a/packages/sdk/src/document/crdt/root.ts
+++ b/packages/sdk/src/document/crdt/root.ts
@@ -418,8 +418,8 @@ export class CRDTRoot {
 
     for (const createdAt of this.gcElementSetByCreatedAt) {
       seen.add(createdAt);
-      const pair = this.elementPairMapByCreatedAt.get(createdAt)!;
-      if (pair.element instanceof CRDTContainer) {
+      const pair = this.elementPairMapByCreatedAt.get(createdAt);
+      if (pair?.element instanceof CRDTContainer) {
         pair.element.getDescendants((el) => {
           seen.add(el.getCreatedAt().toIDString());
           return false;
@@ -464,11 +464,27 @@ export class CRDTRoot {
     let count = 0;
 
     for (const createdAt of this.gcElementSetByCreatedAt) {
-      const pair = this.elementPairMapByCreatedAt.get(createdAt)!;
+      // NOTE(hackerwins): Neither lookup is guaranteed to hit. A document
+      // written by an SDK that registered an element without its parent, or
+      // that left two elements under one createdAt, holds a member of this set
+      // that cannot be reached for purging. Dereferencing either one throws
+      // inside `applyChangePack`, and because that is where every sync applies
+      // the server's change pack, the same pass throws again on the next sync:
+      // the client stops syncing the document for good (#1340).
+      //
+      // Skip it rather than drop it. The element is still in the document and
+      // its size is still charged to `docSize.gc`, which only
+      // `deregisterElement` releases; forgetting the member would leave that
+      // charge counted against the size limit with nothing left reporting it
+      // as garbage. `getGCElementPairs` already guards the same lookup.
+      const pair = this.elementPairMapByCreatedAt.get(createdAt);
+      if (!pair || !pair.parent) {
+        continue;
+      }
       const removedAt = pair.element.getRemovedAt();
 
       if (removedAt && minSyncedVersionVector?.afterOrEqual(removedAt)) {
-        pair.parent!.purge(pair.element);
+        pair.parent.purge(pair.element);
         count += this.deregisterElement(pair.element);
       }
     }

--- a/packages/sdk/src/document/json/array.ts
+++ b/packages/sdk/src/document/json/array.ts
@@ -727,8 +727,18 @@ export class ArrayProxy {
       ),
     );
 
-    target.set(createdAt, element, ticket);
+    const removed = target.set(createdAt, element, ticket);
     context.registerElement(element, target);
+
+    // NOTE(hackerwins): The displaced element has to be registered here too,
+    // not only in `ArraySetOperation.execute`. This path runs against the
+    // clone the updater is given, so leaving it out makes the clone's
+    // accounting drift from the document the operation is replayed on.
+    // `json/object.ts`'s `setInternal` registers the value it replaces the
+    // same way.
+    if (removed) {
+      context.registerRemovedElement(removed);
+    }
 
     return element;
   }

--- a/packages/sdk/src/document/operation/array_set_operation.ts
+++ b/packages/sdk/src/document/operation/array_set_operation.ts
@@ -77,11 +77,29 @@ export class ArraySetOperation extends Operation {
 
     const value = this.value.deepcopy();
     parentObject.insertAfter(this.createdAt, value, this.getExecutedAt());
-    parentObject.delete(this.createdAt, this.getExecutedAt());
+    const removed = parentObject.delete(this.createdAt, this.getExecutedAt());
 
-    // TODO(junseo): GC logic is not implemented here
-    // because there is no way to distinguish between old and new element with same `createdAt`.
-    root.registerElement(value);
+    // NOTE(hackerwins): The parent has to be passed. `garbageCollect` reaches
+    // an element through the pair registered here and calls `purge` on its
+    // parent, so a value registered without one cannot be collected -- it
+    // throws there instead, inside `applyChangePack`, and that client stops
+    // syncing for good. No undo is involved: setting an array element, then
+    // removing it, then collecting is enough.
+    root.registerElement(value, parentObject);
+
+    // NOTE(hackerwins): The element this assignment displaced has to be
+    // registered for collection. Discarding it left it charged to
+    // `docSize.live` with nothing able to reach it, so an ordinary
+    // `arr[i] = x` in a loop grew the document without bound and collection
+    // reported nothing to do.
+    //
+    // The old TODO here said the two could not be told apart because they
+    // share a createdAt. They do not: `this.createdAt` names the element being
+    // displaced and `value` carries its own identity. That stopped being true
+    // when `set` became insert-then-remove rather than an in-place swap.
+    if (removed) {
+      root.registerRemovedElement(removed);
+    }
 
     return {
       opInfos: [

--- a/packages/sdk/src/document/operation/set_operation.ts
+++ b/packages/sdk/src/document/operation/set_operation.ts
@@ -102,11 +102,23 @@ export class SetOperation extends Operation {
     // the ones about to be registered, so passing it would charge the wrong
     // size against gc and leave the stale element's own descendants registered
     // forever.
-    if (source === OpSource.UndoRedo) {
-      const registered = root.findByCreatedAt(value.getCreatedAt());
-      if (registered) {
-        root.deregisterElement(registered);
-      }
+    //
+    // NOTE(hackerwins): This is not conditional on the source. The undo is
+    // generated on one replica and executed on all of them -- peers apply it
+    // with `OpSource.Remote`, and the Go server replays it to build a snapshot
+    // -- and every one of them has the same stale entry to clear. Gating it on
+    // `OpSource.UndoRedo` left the removal's member in
+    // `gcElementSetByCreatedAt` on every replica but the one that undid, where
+    // it resolves to the restored element, whose `removedAt` is undefined, so
+    // collection skips it forever: garbage that is reported and never taken.
+    // The Go SDK gates the same call and loses the member outright there; see
+    // yorkie#1978.
+    //
+    // An ordinary set carries a freshly issued createdAt, so the lookup
+    // normally misses and costs one map read.
+    const registered = root.findByCreatedAt(value.getCreatedAt());
+    if (registered) {
+      root.deregisterElement(registered);
     }
     root.registerElement(value, obj);
     if (removed) {

--- a/packages/sdk/src/document/operation/set_operation.ts
+++ b/packages/sdk/src/document/operation/set_operation.ts
@@ -97,29 +97,35 @@ export class SetOperation extends Operation {
     // during undo/redo, it's essential to handle previously tombstoned elements.
     // In non-GC languages, there may be a need to execute both deregister and purge.
     //
-    // NOTE(hackerwins): It has to be the registered element that is
-    // deregistered, not the incoming copy: the copy's size and descendants are
-    // the ones about to be registered, so passing it would charge the wrong
-    // size against gc and leave the stale element's own descendants registered
-    // forever.
+    // NOTE(hackerwins): A set can restore an element under a createdAt that a
+    // tombstone already answers to -- undoing a remove re-inserts the removed
+    // element under its original identity, and `obj.set` above has just handed
+    // that identity to the restored copy in the object's `nodeMapByCreatedAt`.
     //
-    // NOTE(hackerwins): This is not conditional on the source. The undo is
-    // generated on one replica and executed on all of them -- peers apply it
-    // with `OpSource.Remote`, and the Go server replays it to build a snapshot
-    // -- and every one of them has the same stale entry to clear. Gating it on
-    // `OpSource.UndoRedo` left the removal's member in
-    // `gcElementSetByCreatedAt` on every replica but the one that undid, where
-    // it resolves to the restored element, whose `removedAt` is undefined, so
-    // collection skips it forever: garbage that is reported and never taken.
-    // The Go SDK gates the same call and loses the member outright there; see
-    // yorkie#1978.
+    // The entry that has to follow is the one in `gcElementSetByCreatedAt`.
+    // Collection resolves it through the index that was just re-pointed, so
+    // leaving it makes the next pass reach live data.
+    //
+    // Retiring that entry is the whole job, so retire only that entry. The
+    // tombstone's other registrations are deliberately left alone: its
+    // descendant set can be a strict superset of the restored copy's, since a
+    // peer may have added a child into the container after the undoing replica
+    // took its copy, and tearing the subtree out of
+    // `elementPairMapByCreatedAt` would take those extra descendants with it,
+    // with nothing to put them back -- so a later change addressed at one of
+    // them throws inside `applyChangePack`. See
+    // `CRDTRoot.unregisterRemovedElementPair`.
+    //
+    // This is a condition on the state of the tree, not on who is applying:
+    // peers apply the undo with `OpSource.Remote`, and the Go server replays
+    // it to build a snapshot, and every one of them has the same stale entry.
+    // Gating it on `OpSource.UndoRedo` spared only the replica that performed
+    // the undo; the Go SDK gates the same call and loses the member outright
+    // there, which is the data loss yorkie#1978 fixes alongside this.
     //
     // An ordinary set carries a freshly issued createdAt, so the lookup
     // normally misses and costs one map read.
-    const registered = root.findByCreatedAt(value.getCreatedAt());
-    if (registered) {
-      root.deregisterElement(registered);
-    }
+    root.unregisterRemovedElementPair(value.getCreatedAt());
     root.registerElement(value, obj);
     if (removed) {
       root.registerRemovedElement(removed);

--- a/packages/sdk/test/integration/gc_containment_test.ts
+++ b/packages/sdk/test/integration/gc_containment_test.ts
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, assert } from 'vitest';
+import yorkie, { SyncMode } from '@yorkie-js/sdk/src/yorkie';
+import { Document } from '@yorkie-js/sdk/src/document/document';
+import { YorkieError } from '@yorkie-js/sdk/src/util/error';
+import {
+  testRPCAddr,
+  toDocKey,
+} from '@yorkie-js/sdk/test/integration/integration_helper';
+
+type TestDoc = {
+  items: Array<{ id: string; box: { w: number; h: number }; body: any }>;
+};
+
+/**
+ * `undoTolerantly` runs an undo that may have nothing left to apply. A reverse
+ * operation names the element it was recorded against, and a peer may have
+ * removed it in the meantime; that is reported as a `YorkieError` and leaves
+ * the document untouched. What must not happen is the document being left
+ * unable to sync, which is what the rest of this test checks.
+ */
+function undoTolerantly(run: () => void): void {
+  try {
+    run();
+  } catch (e) {
+    assert.instanceOf(e, YorkieError, `undo failed with ${e}`);
+  }
+}
+
+describe('Garbage collection containment', function () {
+  it('keeps syncing while two peers reorder, edit and undo one element', async function ({
+    task,
+  }) {
+    const docKey = toDocKey(`${task.name}-${new Date().getTime()}`);
+    const d1 = new yorkie.Document<TestDoc>(docKey);
+    const d2 = new yorkie.Document<TestDoc>(docKey);
+
+    const c1 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    const c2 = new yorkie.Client({ rpcAddr: testRPCAddr });
+    await c1.activate();
+    await c2.activate();
+    await c1.attach(d1, { syncMode: SyncMode.Manual });
+    await c2.attach(d2, { syncMode: SyncMode.Manual });
+
+    try {
+      // Every sync applies a change pack, which is where a document that
+      // cannot resolve a member of its collection worklist dies: it throws
+      // inside `applyChangePack` and goes on throwing on every later sync,
+      // so the client never syncs that document again (#1340).
+      const sync = async () => {
+        for (let i = 0; i < 4; i++) {
+          await c1.sync(d1);
+          await c2.sync(d2);
+        }
+      };
+
+      d1.update((r) => {
+        r.items = [
+          { id: 'x', box: { w: 10, h: 10 }, body: { text: '' } },
+          { id: 'y', box: { w: 10, h: 10 }, body: { text: '' } },
+        ];
+      });
+      await sync();
+
+      const indexOf = (doc: Document<TestDoc>, id: string) =>
+        doc.getRoot().items.findIndex((item) => item.id === id);
+
+      // One element removed and re-inserted over and over, both peers
+      // rewriting its nested objects and walking their undo stacks.
+      for (let round = 0; round < 8; round++) {
+        d1.update((r) => {
+          const i = indexOf(d1, 'x');
+          if (i < 0) return;
+          const plain = JSON.parse(JSON.stringify(r.items[i]));
+          r.items.splice(i, 1);
+          r.items.splice(0, 0, plain);
+        }, 'reorder');
+
+        d2.update((r) => {
+          const i = indexOf(d2, 'x');
+          if (i < 0) return;
+          r.items[i].body = { text: 'o'.repeat(round + 1) };
+          r.items[i].box = { w: 10, h: 20 + round };
+        }, 'edit');
+
+        await sync();
+
+        if (round % 3 === 0) {
+          undoTolerantly(() => d1.history.undo());
+        }
+        if (round % 4 === 0) {
+          d2.update((r) => {
+            const i = indexOf(d2, 'y');
+            if (i >= 0) r.items.splice(i, 1);
+          }, 'remove y');
+          undoTolerantly(() => d2.history.undo());
+        }
+        if (round % 5 === 0) {
+          undoTolerantly(() => d1.history.redo());
+          undoTolerantly(() => d2.history.redo());
+        }
+
+        // No sync in between, so both peers stack a reverse operation on top
+        // of state the other has not seen.
+        d1.update((r) => {
+          const i = indexOf(d1, 'x');
+          if (i >= 0) r.items[i].body = { text: `d1-${round}` };
+        }, 'edit body');
+        d2.update((r) => {
+          const i = indexOf(d2, 'x');
+          if (i >= 0) {
+            const plain = JSON.parse(JSON.stringify(r.items[i]));
+            r.items.splice(i, 1);
+            r.items.splice(0, 0, plain);
+          }
+        }, 'reorder');
+        undoTolerantly(() => d1.history.undo());
+        undoTolerantly(() => d2.history.undo());
+
+        await sync();
+      }
+
+      // A poisoned client stops applying change packs, so an ordinary edit
+      // followed by a sync is what tells a healthy one from a dead one.
+      d1.update((r) => {
+        const i = indexOf(d1, 'x');
+        if (i >= 0) r.items[i].box = { w: 1, h: 1 };
+      }, 'final edit');
+      await sync();
+
+      assert.deepEqual(
+        JSON.parse(d1.toJSON()),
+        JSON.parse(d2.toJSON()),
+        'the two documents disagree after the final edit',
+      );
+    } finally {
+      await c1.deactivate();
+      await c2.deactivate();
+    }
+  }, 30000);
+});

--- a/packages/sdk/test/unit/document/gc_containment_test.ts
+++ b/packages/sdk/test/unit/document/gc_containment_test.ts
@@ -223,3 +223,142 @@ describe('Garbage collection containment', () => {
     assert.equal(doc.toSortedJSON(), '{"items":[]}');
   });
 });
+
+/**
+ * `broadcast` is `deliver` for more than one receiver. The ack has to happen
+ * once, after every receiver has the pack: it clears the sender's local
+ * changes, so acking per receiver would leave the second one with nothing.
+ */
+function broadcast<T>(from: Document<T>, ...tos: Array<Document<T>>): void {
+  const pack = from.createChangePack();
+  const changes = pack.getChanges();
+  for (const to of tos) {
+    to.applyChangePack(
+      ChangePack.create(
+        pack.getDocumentKey(),
+        Checkpoint.of(0n, 0),
+        false,
+        changes,
+        InitialVersionVector,
+      ),
+    );
+  }
+  const lastSeq = changes.length
+    ? changes[changes.length - 1].getID().getClientSeq()
+    : 0;
+  from.applyChangePack(
+    ChangePack.create(
+      pack.getDocumentKey(),
+      Checkpoint.of(0n, lastSeq),
+      false,
+      [],
+      InitialVersionVector,
+    ),
+  );
+}
+
+describe('Restoring a container', function () {
+  /**
+   * The reverse of a remove is a set of `value.deepcopy()`, taken when the
+   * removal was recorded. A peer that added a member into the container after
+   * that copy was taken has a tombstone whose descendant set is a strict
+   * superset of the copy's. Retiring the tombstone by deregistering it and its
+   * descendants evicts those extra members from `elementPairMapByCreatedAt`,
+   * and nothing puts them back -- so the next change addressed at one of them
+   * throws `fail to find` inside `applyChangePack`, which is the permanent
+   * desync this release exists to stop.
+   *
+   * It is not confined to the replica it happens on: the Go server rebuilds
+   * documents and snapshots by replaying the stored change log, so a change
+   * that cannot apply makes the document unloadable for everyone.
+   *
+   * This does not assert convergence. The restored container still diverges --
+   * the copy never held the peer's member, so the edit lands on an orphaned
+   * subtree and is invisible. That is the identity-preserving revive work this
+   * release defers. What must hold is narrower: the change log stays
+   * replayable.
+   */
+  it('keeps a member a peer added into it addressable', function () {
+    const d1 = new Document<any>('restore-foreign');
+    const d2 = new Document<any>('restore-foreign');
+    const d3 = new Document<any>('restore-foreign');
+
+    d1.update((r) => {
+      r.obj = { k: 1 };
+    });
+    broadcast(d1, d2, d3);
+
+    // d2 adds a member inside obj. d1 never sees it, so the copy its undo
+    // carries will not contain it.
+    d2.update((r) => {
+      r.obj.n = { y: 1 };
+    });
+    broadcast(d2, d3);
+
+    d1.update((r) => {
+      delete r.obj;
+    }, 'remove obj');
+    d1.history.undo();
+    deliver(d1, d3);
+
+    // d2, which has not seen the removal, edits the member it added.
+    d2.update((r) => {
+      r.obj.n.x = 5;
+    });
+    const pack = d2.createChangePack();
+
+    let thrown: unknown;
+    try {
+      d3.applyChangePack(
+        ChangePack.create(
+          pack.getDocumentKey(),
+          Checkpoint.of(0n, 0),
+          false,
+          pack.getChanges(),
+          InitialVersionVector,
+        ),
+      );
+    } catch (e) {
+      thrown = e;
+    }
+    assert.isUndefined(
+      thrown,
+      `the peer's change no longer applies, so the change log is unreplayable: ${thrown}`,
+    );
+  });
+
+  /**
+   * Each cycle leaves another tombstone answering to the same createdAt.
+   * Collection that resolves an entry through a createdAt-keyed index rather
+   * than through the element it was registered for will, on a later pass,
+   * unlink a live member on a dead one's behalf or fail to find the node at
+   * all -- and a throw inside `garbageCollect` inside `applyChangePack` is
+   * exactly #1340.
+   */
+  it('survives being restored and removed repeatedly', function () {
+    const doc = new Document<any>('restore-repeat');
+    doc.update((r) => {
+      r.o = { k: 1 };
+    });
+
+    for (let i = 0; i < 3; i++) {
+      doc.update((r) => {
+        delete r.o;
+      }, 'remove o');
+      doc.history.undo();
+    }
+    doc.update((r) => {
+      delete r.o;
+    }, 'remove o');
+
+    let thrown: unknown;
+    try {
+      doc.garbageCollect(maxVectorOf([doc.getChangeID().getActorID()]));
+    } catch (e) {
+      thrown = e;
+    }
+    assert.isUndefined(thrown, `collection threw: ${thrown}`);
+    assert.equal(doc.toSortedJSON(), '{}');
+    assert.equal(doc.getGarbageLen(), 0);
+  });
+});

--- a/packages/sdk/test/unit/document/gc_containment_test.ts
+++ b/packages/sdk/test/unit/document/gc_containment_test.ts
@@ -1,0 +1,225 @@
+/*
+ * Copyright 2026 The Yorkie Authors. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, it, assert } from 'vitest';
+import { Document } from '@yorkie-js/sdk/src/document/document';
+import { CRDTElement } from '@yorkie-js/sdk/src/document/crdt/element';
+import { CRDTRoot } from '@yorkie-js/sdk/src/document/crdt/root';
+import { ChangePack } from '@yorkie-js/sdk/src/document/change/change_pack';
+import { Checkpoint } from '@yorkie-js/sdk/src/document/change/checkpoint';
+import { InitialVersionVector } from '@yorkie-js/sdk/src/document/time/version_vector';
+import { maxVectorOf } from '@yorkie-js/sdk/test/helper/helper';
+
+const A1 = '000000000000000000000001';
+const A2 = '000000000000000000000002';
+
+/**
+ * `deliver` pushes the sender's pending changes into the receiver, then acks
+ * them back to the sender so the next call does not re-send them. The
+ * receiver applies with `OpSource.Remote`, which is also how the server
+ * replays a change log to build a snapshot.
+ */
+function deliver<T>(from: Document<T>, to: Document<T>): void {
+  const pack = from.createChangePack();
+  const changes = pack.getChanges();
+  to.applyChangePack(
+    ChangePack.create(
+      pack.getDocumentKey(),
+      Checkpoint.of(0n, 0),
+      false,
+      changes,
+      InitialVersionVector,
+    ),
+  );
+  const lastSeq = changes.length
+    ? changes[changes.length - 1].getID().getClientSeq()
+    : 0;
+  from.applyChangePack(
+    ChangePack.create(
+      pack.getDocumentKey(),
+      Checkpoint.of(0n, lastSeq),
+      false,
+      [],
+      InitialVersionVector,
+    ),
+  );
+}
+
+/**
+ * `collect` runs garbage collection with every actor at its maximum lamport,
+ * so nothing is held back by an unsynced peer.
+ */
+function collect(doc: Document<any>): number {
+  return doc.garbageCollect(maxVectorOf([doc.getChangeID().getActorID()]));
+}
+
+describe('Garbage collection containment', () => {
+  it('collects an array element replaced by an array set', () => {
+    const doc = new Document<any>('array-set-then-remove');
+    doc.update((r) => {
+      r.arr = [{ a: 1 }];
+    });
+    doc.update((r) => {
+      r.arr[0] = { b: 2 };
+    });
+    doc.update((r) => {
+      r.arr.splice(0, 1);
+    });
+
+    // No undo anywhere. The value an array set installs has to be registered
+    // with its parent, or garbage collection cannot reach it to purge it and
+    // throws on the missing parent instead -- inside `applyChangePack`, which
+    // is what stops the client from syncing again.
+    assert.doesNotThrow(() => collect(doc));
+    assert.equal(doc.getGarbageLen(), 0);
+    assert.equal(doc.toSortedJSON(), '{"arr":[]}');
+  });
+
+  it('collects the element an array assignment displaces', () => {
+    const doc = new Document<any>('array-set-leak');
+    doc.update((r) => {
+      r.arr = [0];
+    });
+
+    const set = (v: number) => {
+      doc.update((r) => {
+        r.arr[0] = v;
+      });
+      collect(doc);
+    };
+
+    // One cycle establishes the steady state: an array holding one number,
+    // with the element it displaced collected.
+    set(1);
+    const steady = JSON.parse(JSON.stringify(doc.getDocSize()));
+    assert.equal(doc.getGarbageLen(), 0);
+
+    for (let i = 2; i <= 10; i++) {
+      set(i);
+    }
+
+    // The displaced elements used to stay charged to live with nothing able
+    // to reach them, so an ordinary assignment loop grew the document without
+    // bound. No undo is involved.
+    assert.equal(doc.toSortedJSON(), '{"arr":[10]}');
+    assert.equal(doc.getGarbageLen(), 0);
+    assert.deepEqual(doc.getDocSize(), steady);
+  });
+
+  it('collects the tombstone an undone object remove leaves on a peer', () => {
+    // `SetOperation` restores the member under its original createdAt, and
+    // the object re-keys onto the restored node. The removal's member in the
+    // gc set then resolves to that live element, whose removedAt is
+    // undefined, so collection can never take it. Deregistering the stale
+    // registration is what clears it, and that has to happen wherever the
+    // operation is applied -- not only on the replica that performed the undo.
+    const d1 = new Document<any>('undone-object-remove');
+    const d2 = new Document<any>('undone-object-remove');
+    d1.setActor(A1);
+    d2.setActor(A2);
+
+    d1.update((r) => {
+      r.obj = { k: 1 };
+      r.keep = 0;
+    });
+    deliver(d1, d2);
+
+    d1.update((r) => {
+      delete r.obj;
+    }, 'remove obj');
+    d1.history.undo();
+    deliver(d1, d2);
+
+    assert.equal(d1.toSortedJSON(), '{"keep":0,"obj":{"k":1}}');
+    assert.equal(d2.toSortedJSON(), '{"keep":0,"obj":{"k":1}}');
+
+    const vector = maxVectorOf([A1, A2]);
+    d1.garbageCollect(vector);
+    d2.garbageCollect(vector);
+
+    assert.equal(d1.toSortedJSON(), '{"keep":0,"obj":{"k":1}}');
+    assert.equal(d2.toSortedJSON(), '{"keep":0,"obj":{"k":1}}');
+    assert.equal(d1.getGarbageLen(), 0);
+    assert.equal(
+      d2.getGarbageLen(),
+      0,
+      'the peer holds a worklist entry that can never be collected',
+    );
+  });
+
+  it('survives a gc set member left behind by an older client', () => {
+    const doc = new Document<any>('legacy-orphan');
+    doc.update((r) => {
+      r.items = [{ a: 1 }];
+    });
+
+    // A document written by an SDK that left two elements under one createdAt
+    // holds a gc set member the pair map cannot resolve. The state is not
+    // reachable through this SDK's public API, so it is staged directly: what
+    // is pinned is that a client meeting such a document keeps syncing
+    // instead of throwing inside `applyChangePack`.
+    const root = doc.getRootCRDT() as CRDTRoot;
+    const stale = new Set<string>(
+      (root as unknown as { gcElementSetByCreatedAt: Set<string> })
+        .gcElementSetByCreatedAt,
+    );
+    stale.add('1:000000000000000000000000:999');
+    (
+      root as unknown as { gcElementSetByCreatedAt: Set<string> }
+    ).gcElementSetByCreatedAt = stale;
+
+    const before = JSON.parse(JSON.stringify(doc.getDocSize()));
+    assert.doesNotThrow(() => root.getGarbageLen());
+    assert.doesNotThrow(() => collect(doc));
+
+    // The member is skipped, not forgotten: its size is still charged to
+    // `docSize.gc`, and only `deregisterElement` releases that, so dropping
+    // it would leave the charge with nothing reporting it as garbage.
+    assert.deepEqual(doc.getDocSize(), before);
+    assert.isAbove(doc.getGarbageLen(), 0);
+    assert.equal(doc.toSortedJSON(), '{"items":[{"a":1}]}');
+  });
+
+  it('survives a gc set member whose element has no parent', () => {
+    const doc = new Document<any>('legacy-parentless');
+    doc.update((r) => {
+      r.items = [{ a: 1 }];
+    });
+    doc.update((r) => {
+      r.items.splice(0, 1);
+    });
+
+    // `ArraySetOperation` used to register its value without a parent, so the
+    // pair resolves but `purge` has nothing to call. Re-register the tombstone
+    // that way to reproduce what such a document carries.
+    const root = doc.getRootCRDT() as CRDTRoot;
+    let tombstone: CRDTElement | undefined;
+    doc.getRootObject().getDescendants((elem) => {
+      if (elem.getRemovedAt()) {
+        tombstone = elem;
+        return true;
+      }
+      return false;
+    });
+    assert.isDefined(tombstone);
+    root.registerElement(tombstone!);
+
+    const before = JSON.parse(JSON.stringify(doc.getDocSize()));
+    assert.doesNotThrow(() => collect(doc));
+    assert.deepEqual(doc.getDocSize(), before);
+    assert.equal(doc.toSortedJSON(), '{"items":[]}');
+  });
+});


### PR DESCRIPTION
Closes #1340.

> **This PR has been through two corrections.** It first carried a deep re-identification
> fix — giving a subtree restored by undo fresh ids all the way down. Prototyped, measured,
> **rejected**: a restored element becomes a *new* element, so every operation stacked
> against the old one stops applying, and neither reconciling the descendants nor leaving
> them alone satisfies both halves.
>
> It then ungated `deregisterElement`. A pre-merge review found, and I reproduced, that this
> evicts members a peer added into the container after the undoing replica took its copy —
> throwing `fail to find` inside `applyChangePack` on a replica that never undid anything,
> which is the very symptom this PR exists to stop. What ships now retires **one worklist
> entry**, and deletes index entries by identity rather than by key. See
> `docs/design/element-identity.md`.

## What this fixes

`CRDTRoot.garbageCollect` dereferenced `elementPairMapByCreatedAt.get(...)!` and
`pair.parent!` without checking, and neither is guaranteed to hit. The throw lands inside
`Document.applyChangePack` — where every sync applies the server's change pack — so the same
pass throws again on the next sync and **the client never syncs that document again**.

Three routes reach a member the collection worklist cannot resolve. Two of them involve no
undo at all:

| | |
|---|---|
| **`ArraySetOperation` registered its value with no parent.** Collection resolves the pair and then calls `purge` on `undefined`. Setting an array element, removing it and collecting is enough — the guard the issue suggested does not cover this, because it throws one line later. | `array_set_operation.ts` |
| **`ArraySetOperation` discarded the element it displaced.** Never registered for collection, so it stayed charged to `docSize.live` with nothing able to reach it: an ordinary `arr[i] = x` in a loop grew the document without bound. `json/array.ts` runs the same assignment against the clone the updater is given and dropped it too. | `array_set_operation.ts`, `json/array.ts` |
| **`SetOperation` cleared a colliding registration only for `OpSource.UndoRedo`.** That is a condition on the state of the tree written as a condition on who is applying. Every replica except the one that performed the undo kept a worklist member that resolves to the restored — live — element, which collection can therefore never take. It now retires that member on every source, through `unregisterRemovedElementPair`, which touches the worklist and the accounting and **not** the identity index. | `set_operation.ts`, `crdt/root.ts` |
| **`deregisterElement` deleted index entries by key.** An undone array assignment restores descendants under their original `createdAt`s — only the top level is re-ticketed — so collecting the tombstone evicted entries that answer for live elements, and the next change addressed at one of them threw. The deletes now fire only when the slot still holds the element being retired, and `sizeInGC` records which element a charge is held for so a size cannot be taken out of `docSize.live` that live was not holding. | `crdt/root.ts` |
| **`ElementRHT.purge` and `RGATreeList.purge` unlinked by key.** Same shape, one layer down. Both now return rather than unlink when the slot has been taken over, and both keep throwing on a genuinely missing key — that is a mis-registration worth reporting. | `crdt/element_rht.ts`, `crdt/rga_tree_list.ts` |

And the guard itself, for documents already carrying the state: `garbageCollect` and
`getGarbageElementSetSize` now guard the lookup the way `getGCElementPairs` beside them
already did. The member is **skipped, not dropped** — its size is still charged to
`docSize.gc`, which only `deregisterElement` releases, so forgetting it would leave that
charge counted against the size limit with nothing reporting it as garbage.

## Verification

`test/unit/document/gc_containment_test.ts` (7 cases) and
`test/integration/gc_containment_test.ts` (the reproduction from the issue). The original six
**fail on `main`** — checked by reverting `src/` and re-running:

```
× collects an array element replaced by an array set
× collects the element an array assignment displaces
× collects the tombstone an undone object remove leaves on a peer
× survives a gc set member left behind by an older client
× survives a gc set member whose element has no parent
× keeps syncing while two peers reorder, edit and undo one element
    TypeError: Cannot read properties of undefined (reading 'element')
```

`keeps a member a peer added into it addressable` is new, and fails on the revision of this
branch that ungated `deregisterElement` with `fail to find` — the regression the review
caught. It asserts that the change log stays replayable; it deliberately does not assert
convergence, since the copy the reverse carries never held the peer's member. That is the
revive work this release precedes.

`survives being restored and removed repeatedly` is insurance rather than a pin: it passes
before the fix too, and catches collection resolving a worklist member through a
createdAt-keyed index instead of the element it was registered for — a throw inside
`garbageCollect` inside `applyChangePack` is literally #1340.

Unit 412 passed / 1 skipped / 1 todo. The **full integration suite — 35 files, 2587 tests —
passed against a server built from yorkie#1978**, which is the pairing that actually ships.
`pnpm lint` and `pnpm verify:doc-links` clean; `pnpm sdk run build` clean.

## Ships with yorkie#1978

The `SetOperation` gate exists in both SDKs, and
`docs/tasks/active/20260816-remote-redo-replica-divergence-todo.md` in the Go repo records
it with an explicit instruction not to fix one side alone — Go's behaviour is faithful
parity with this SDK rather than a regression. The symptom differs: here the peer leaks a
worklist entry it can never take; there the peer and the server **delete the restored
member**, and it disappears from every snapshot built afterwards. **yorkie#1978** is the
companion and this should not merge without it.

## Not addressed

**The root cause.** Undo of a removal is still expressed as re-insertion of a `deepcopy`,
so two live elements can still end up under one `createdAt`; this keeps a client alive and
the change log replayable when that happens rather than preventing it. The restored
container still diverges from a peer that added a member into it concurrently — that
member's edit applies, but onto an orphaned subtree where nobody sees it. Fixing it properly means reviving the
original element instead of inserting a copy, which needs a replicated liveness register
and a restore mode on the wire — protobuf plus a coordinated release across both SDKs, on
the pattern the Text and Tree restore-mode work already followed. The design document in
this PR records the invariant and why the alternative was rejected on measurement.

Documents already carrying duplicated ids are not repaired, only kept usable.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Ty1RHZcasxfCMaDmuxLvyn
